### PR TITLE
Enforce tenant isolation across CRM workflows

### DIFF
--- a/core/security.py
+++ b/core/security.py
@@ -199,6 +199,18 @@ async def get_current_manager_tenant_scope(
     return auth.tenant_scope()
 
 
+async def require_system_manager_tenant_scope(
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
+) -> TenantScope:
+    """Keep global platform surfaces unavailable to white-label tenants."""
+    if not tenant_scope.is_system:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="System tenant access required",
+        )
+    return tenant_scope
+
+
 # Alias for backward compatibility if needed, but we should refactor usages.
 get_current_username = get_current_user
 

--- a/docs/tenant-scope-rollout.md
+++ b/docs/tenant-scope-rollout.md
@@ -146,18 +146,47 @@ each existing staff identity. It does not overwrite an existing membership.
 After deployment, Manager authorization and staff lists use membership
 role/status and tenant ownership rather than the role copied into a token.
 
+## Application isolation in this release
+
+The Manager application now resolves Order and Lead ownership before exposing
+or mutating their root or child records. The boundary covers:
+
+- Lead lists, updates, qualification and loss workflows;
+- Order lists, details, dashboard, calendar, inbox, export, update and delete;
+- proposals, payments, work stages, documents and service attachments;
+- customer equipment, components, service history and Order/equipment links;
+- tenant membership-backed installer lists, searches and assignments;
+- staff-bot task/media/nameplate/defect-act entrypoints;
+- tenant-local notification recipients and staff-task outbox events.
+
+Foreign opaque IDs fail closed and do not reveal or mutate records. Negative
+integration tests exercise separate tenants, while the system tenant alone may
+temporarily read fully legacy null provenance during backfill. Dashboard Order
+and customer projections use the same boundary. The global bank-receipt and
+outgoing-email Manager module has no tenant provenance yet, so non-system
+tenants receive `403` instead of shared financial or mail data. Global
+document-template administration and the backing Google Drive folder are also
+system-only until templates receive an explicit tenant policy. Tenant users
+may query selectable templates only with an owned Order or Customer context;
+foreign opaque IDs fail with `404` and unrelated customer IDs are not returned.
+
 ## What this release does not claim
 
-This release isolates direct Customer reads/writes and customer-owned branches,
-contracts, documents, reconciliation and requisites recognition. Manager
-authentication and staff administration are membership-scoped, including
-negative cross-tenant tests. Only the system tenant can see or claim legacy
-nullable Customer rows during rollout.
+This is still the expand phase, not the database contract phase. Lead and Order
+ownership columns remain nullable until the controlled production backfills
+report zero legacy, partial, unknown and cross-tenant rows. Tenant-aware unique
+indexes and mandatory foreign-key constraints still require the contract
+migration.
 
-It does not yet make the complete CRM safe for an external tenant. Order and
-Lead read/update projections, equipment/service history, installer registry,
-notifications and several child resources still need tenant-scoped query
-boundaries and negative integration tests. Idempotency/reuse lookups
-temporarily include legacy null rows only for the system tenant; their unique
-indexes remain global until the contract migration. A second tenant with real
-traffic or an external customer must not be enabled yet.
+Shared catalog, document-template and finance/mail ownership policy must be
+decided before those platform resources can be delegated to external tenants.
+Document-template administration and finance/mail remain system-only in the
+meantime. Public storefront selection still needs a trusted proxy or signed
+server context, and multi-membership Manager users still need an explicit
+server-validated tenant selector.
+
+A second tenant with real external traffic must not be enabled until the
+backfill reports are clean, the contract migration and isolation suite pass,
+and an internal second-storefront canary has completed. Idempotency/reuse
+lookups temporarily include fully legacy rows only for the system tenant; their
+global indexes remain unchanged until contract.

--- a/manager_frontend/src/views/CustomerProfileView.vue
+++ b/manager_frontend/src/views/CustomerProfileView.vue
@@ -958,7 +958,11 @@ const createEquipmentHistory = async () => {
 
 const loadContractTemplates = async () => {
   try {
-    const res = await ManagerDocsService.getDocTemplates('contract');
+    const res = await ManagerDocsService.getDocTemplates(
+      'contract',
+      undefined,
+      customerId.value,
+    );
     contractTemplates.value = res.items;
   } catch (e) {
     console.warn('Failed to load contract templates', e);

--- a/routers/internal_bot.py
+++ b/routers/internal_bot.py
@@ -145,6 +145,7 @@ async def get_internal_bot_catalog_product(
 async def list_internal_bot_my_tasks(
     payload: BotTaskListRequest,
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_system_tenant_scope),
 ) -> BotTaskListResponse:
     try:
         tasks = await BotTaskReadService.list_for_staff(
@@ -154,6 +155,7 @@ async def list_internal_bot_my_tasks(
             date_from=payload.date_from,
             date_to=payload.date_to,
             statuses=payload.statuses,
+            tenant_scope=tenant_scope,
         )
     except BotTaskAccessDeniedError as exc:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
@@ -171,6 +173,7 @@ async def update_internal_bot_task_status(
     payload: BotTaskStatusUpdateRequest,
     stage_id: int = Path(ge=1),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_system_tenant_scope),
 ) -> BotTaskStatusUpdateResponse:
     try:
         result = await BotTaskMutationService.update_stage_status(
@@ -178,6 +181,7 @@ async def update_internal_bot_task_status(
             telegram_id=payload.telegram_id,
             stage_id=stage_id,
             status=OrderStageStatus(payload.status),
+            tenant_scope=tenant_scope,
         )
     except BotTaskMutationAccessDeniedError as exc:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
@@ -199,6 +203,7 @@ async def save_internal_bot_task_report(
     payload: BotTaskReportSaveRequest,
     stage_id: int = Path(ge=1),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_system_tenant_scope),
 ) -> BotTaskReportSaveResponse:
     try:
         result = await BotTaskMutationService.save_stage_report(
@@ -206,6 +211,7 @@ async def save_internal_bot_task_report(
             telegram_id=payload.telegram_id,
             stage_id=stage_id,
             report=payload.report,
+            tenant_scope=tenant_scope,
         )
     except BotTaskMutationAccessDeniedError as exc:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc

--- a/routers/manager_calendar.py
+++ b/routers/manager_calendar.py
@@ -5,7 +5,8 @@ from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from core.database import get_session
-from core.security import get_current_username
+from core.security import get_current_manager_tenant_scope, get_current_username
+from models.tenancy import TenantScope
 from routers.manager_operation_ids import GET_MANAGER_CALENDAR_EVENTS
 from schemas import CalendarEventResponse
 from services.order_service import OrderService
@@ -19,8 +20,14 @@ async def get_manager_calendar_events(
     end: datetime = Query(..., description="End date (ISO format)"),
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     """
     Get calendar events (assessments and installations) within a date range.
     """
-    return await OrderService.get_calendar_events(session, start, end)
+    return await OrderService.get_calendar_events(
+        session,
+        start,
+        end,
+        tenant_scope=tenant_scope,
+    )

--- a/routers/manager_dashboard.py
+++ b/routers/manager_dashboard.py
@@ -2,7 +2,8 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from core.database import get_session
-from core.security import get_current_username
+from core.security import get_current_manager_tenant_scope, get_current_username
+from models.tenancy import TenantScope
 from schemas import DashboardStatsResponse
 from services.stats_service import StatsService
 
@@ -14,8 +15,11 @@ router = APIRouter(
 @router.get("/stats", response_model=DashboardStatsResponse, operation_id="get_dashboard_stats")
 async def get_dashboard_stats(
     session: AsyncSession = Depends(get_session),
-    _: str = Depends(get_current_username)
+    _: str = Depends(get_current_username),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     service = StatsService()
-    return await service.get_dashboard_stats(session)
-
+    return await service.get_dashboard_stats(
+        session,
+        tenant_scope=tenant_scope,
+    )

--- a/routers/manager_docs.py
+++ b/routers/manager_docs.py
@@ -1,15 +1,27 @@
 import logging
 from datetime import datetime
 
-from fastapi import APIRouter, Depends, UploadFile, File, Form, Query
+from fastapi import APIRouter, Depends, HTTPException, UploadFile, File, Form, Query
 from fastapi.responses import StreamingResponse
 from starlette.concurrency import run_in_threadpool
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from core.database import get_session
 from core.manager_api_errors import manager_http_error
-from core.manager_error_codes import BAD_REQUEST, DOCUMENT_HAS_DEPENDENTS, DOCUMENT_NOT_FOUND, ORDER_DOCUMENTS_LOCKED
-from core.security import get_current_username
+from core.manager_error_codes import (
+    BAD_REQUEST,
+    CUSTOMER_NOT_FOUND,
+    DOCUMENT_HAS_DEPENDENTS,
+    DOCUMENT_NOT_FOUND,
+    ORDER_DOCUMENTS_LOCKED,
+    ORDER_NOT_FOUND,
+)
+from core.security import (
+    get_current_manager_tenant_scope,
+    get_current_username,
+    require_system_manager_tenant_scope,
+)
+from models.tenancy import TenantScope
 from routers.manager_operation_ids import (
     GET_MANAGER_ORDER_DOCUMENTS,
     ATTACH_MANAGER_DOC_FILE,
@@ -39,6 +51,7 @@ from services.document_service import DocumentHasDependentsError, DocumentServic
 from services.document_template_service import DocumentTemplateService
 from services.google_oauth_credentials import GoogleCredentialsError, GoogleDriveListError
 from services.google_service import get_google_service
+from services.tenant_entity_access_service import TenantEntityAccessService
 
 
 logger = logging.getLogger(__name__)
@@ -84,8 +97,19 @@ async def get_manager_order_documents(
     order_id: int,
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
-    docs = await DocumentService.list_order_documents(session, order_id)
+    docs = await DocumentService.list_order_documents(
+        session,
+        order_id,
+        tenant_scope=tenant_scope,
+    )
+    if docs is None:
+        raise manager_http_error(
+            status_code=404,
+            endpoint=GET_MANAGER_ORDER_DOCUMENTS,
+            error_code=ORDER_NOT_FOUND,
+        )
     basis_lookup = await DocumentService.build_document_basis_lookup(session, list(docs))
     return {
         "items": [
@@ -118,9 +142,15 @@ async def upload_manager_order_document(
     file: UploadFile = File(...),
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     try:
-        doc = await DocumentService.upload_document(session, order_id, file)
+        doc = await DocumentService.upload_document(
+            session,
+            order_id,
+            file,
+            tenant_scope=tenant_scope,
+        )
     except OrderDocumentsLockedError as exc:
         raise _order_documents_locked_error(UPLOAD_MANAGER_ORDER_DOCUMENT, exc) from exc
     return ManagerOrderDocumentItem(
@@ -153,6 +183,7 @@ async def register_manager_external_contract(
     file: UploadFile | None = File(None),
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     try:
         doc = await DocumentService.register_external_contract(
@@ -162,6 +193,7 @@ async def register_manager_external_contract(
             contract_date=contract_date,
             external_url=external_url,
             file=file,
+            tenant_scope=tenant_scope,
         )
     except OrderDocumentsLockedError as exc:
         raise _order_documents_locked_error(REGISTER_MANAGER_EXTERNAL_CONTRACT, exc) from exc
@@ -199,9 +231,15 @@ async def attach_manager_doc_file(
     file: UploadFile = File(...),
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     try:
-        doc = await DocumentService.attach_file_to_document(session, doc_id, file)
+        doc = await DocumentService.attach_file_to_document(
+            session,
+            doc_id,
+            file,
+            tenant_scope=tenant_scope,
+        )
     except OrderDocumentsLockedError as exc:
         raise _order_documents_locked_error(ATTACH_MANAGER_DOC_FILE, exc) from exc
     except ValueError as exc:
@@ -242,9 +280,14 @@ async def get_manager_doc_download(
     doc_id: int,
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     try:
-        pdf_content, filename_encoded = await DocumentService.get_download_stream(session, doc_id)
+        pdf_content, filename_encoded = await DocumentService.get_download_stream(
+            session,
+            doc_id,
+            tenant_scope=tenant_scope,
+        )
     except ValueError as exc:
         raise manager_http_error(
             status_code=400,
@@ -278,9 +321,14 @@ async def delete_manager_doc(
     doc_id: int,
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     try:
-        order_id = await DocumentService.delete_document(session, doc_id)
+        order_id = await DocumentService.delete_document(
+            session,
+            doc_id,
+            tenant_scope=tenant_scope,
+        )
     except OrderDocumentsLockedError as exc:
         raise _order_documents_locked_error(DELETE_MANAGER_DOC, exc) from exc
     except DocumentHasDependentsError as exc:
@@ -308,7 +356,7 @@ async def delete_manager_doc(
 )
 async def list_manager_document_templates(
     doc_type: str | None = Query(None),
-    _: str = Depends(get_current_username),
+    _: TenantScope = Depends(require_system_manager_tenant_scope),
     session: AsyncSession = Depends(get_session),
 ):
     items = await DocumentTemplateService.list_template_items(session, doc_type, include_legacy=False)
@@ -323,7 +371,7 @@ async def list_manager_document_templates(
 async def list_manager_document_template_files(
     folder_id: str = Query(DEFAULT_DOCUMENT_TEMPLATE_FOLDER_ID),
     limit: int = Query(100, ge=1, le=200),
-    _: str = Depends(get_current_username),
+    _: TenantScope = Depends(require_system_manager_tenant_scope),
 ):
     try:
         files = await run_in_threadpool(
@@ -352,7 +400,7 @@ async def list_manager_document_template_files(
 )
 async def create_manager_document_template(
     payload: DocumentTemplatePayload,
-    _: str = Depends(get_current_username),
+    _: TenantScope = Depends(require_system_manager_tenant_scope),
     session: AsyncSession = Depends(get_session),
 ):
     try:
@@ -370,7 +418,7 @@ async def create_manager_document_template(
 async def patch_manager_document_template(
     template_id: int,
     payload: DocumentTemplateUpdatePayload,
-    _: str = Depends(get_current_username),
+    _: TenantScope = Depends(require_system_manager_tenant_scope),
     session: AsyncSession = Depends(get_session),
 ):
     try:
@@ -387,7 +435,7 @@ async def patch_manager_document_template(
 )
 async def delete_manager_document_template(
     template_id: int,
-    _: str = Depends(get_current_username),
+    _: TenantScope = Depends(require_system_manager_tenant_scope),
     session: AsyncSession = Depends(get_session),
 ):
     try:
@@ -408,8 +456,53 @@ async def get_doc_templates(
     customer_id: int | None = Query(None),
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
+    selected_customer_id = customer_id
+    if not tenant_scope.is_system and order_id is None and customer_id is None:
+        raise HTTPException(
+            status_code=403,
+            detail="Order or customer context required",
+        )
+    if order_id is not None:
+        order = await TenantEntityAccessService.get_order(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+        )
+        if order is None:
+            raise manager_http_error(
+                status_code=404,
+                endpoint=GET_DOC_TEMPLATES,
+                error_code=ORDER_NOT_FOUND,
+            )
+        selected_customer_id = order.customer_id
+    if customer_id is not None:
+        customer = await TenantEntityAccessService.get_customer(
+            session,
+            customer_id,
+            tenant_scope=tenant_scope,
+        )
+        if customer is None:
+            raise manager_http_error(
+                status_code=404,
+                endpoint=GET_DOC_TEMPLATES,
+                error_code=CUSTOMER_NOT_FOUND,
+            )
     items = await DocumentService.get_available_templates(session, doc_type, order_id=order_id, customer_id=customer_id)
+    if not tenant_scope.is_system:
+        items = [
+            {
+                **item,
+                "customer_ids": [
+                    value
+                    for value in item.get("customer_ids") or []
+                    if selected_customer_id is not None
+                    and int(value) == int(selected_customer_id)
+                ],
+            }
+            for item in items
+        ]
     return {
         "items": [
             DocumentTemplateItem(

--- a/routers/manager_equipment.py
+++ b/routers/manager_equipment.py
@@ -55,6 +55,7 @@ async def list_manager_equipment(
     attention: Optional[str] = Query(None),
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     try:
         data = await EquipmentService.list_equipment(
@@ -66,6 +67,7 @@ async def list_manager_equipment(
             include_archived=include_archived,
             q=q,
             attention=attention,
+            tenant_scope=tenant_scope,
         )
     except ValueError as exc:
         raise manager_http_error(
@@ -93,11 +95,13 @@ async def create_manager_equipment(
     payload: ManagerEquipmentCreatePayload,
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     try:
         data = await EquipmentService.create_equipment(
             session=session,
             payload=payload.model_dump(exclude_unset=True),
+            tenant_scope=tenant_scope,
         )
     except ValueError as exc:
         raise manager_http_error(
@@ -126,12 +130,14 @@ async def create_manager_equipment_from_order(
     payload: ManagerEquipmentFromOrderPayload,
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     try:
         return await EquipmentService.create_equipment_from_order(
             session=session,
             order_id=order_id,
             payload=payload.model_dump(exclude_unset=True),
+            tenant_scope=tenant_scope,
         )
     except ValueError as exc:
         raise manager_http_error(
@@ -182,11 +188,13 @@ async def get_manager_equipment(
     history_limit: int = Query(10, ge=0, le=100),
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     data = await EquipmentService.get_equipment_detail(
         session=session,
         equipment_id=equipment_id,
         history_limit=history_limit,
+        tenant_scope=tenant_scope,
     )
     if data is None:
         raise manager_http_error(
@@ -203,12 +211,14 @@ async def patch_manager_equipment(
     payload: ManagerEquipmentUpdatePayload,
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     try:
         data = await EquipmentService.update_equipment(
             session=session,
             equipment_id=equipment_id,
             payload=payload.model_dump(exclude_unset=True),
+            tenant_scope=tenant_scope,
         )
     except ValueError as exc:
         raise manager_http_error(
@@ -237,12 +247,14 @@ async def create_manager_equipment_component(
     payload: ManagerEquipmentComponentCreatePayload,
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     try:
         data = await EquipmentService.create_component(
             session=session,
             equipment_id=equipment_id,
             payload=payload.model_dump(exclude_unset=True),
+            tenant_scope=tenant_scope,
         )
     except ValueError as exc:
         raise manager_http_error(
@@ -271,6 +283,7 @@ async def patch_manager_equipment_component(
     payload: ManagerEquipmentComponentUpdatePayload,
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     try:
         data = await EquipmentService.update_component(
@@ -278,6 +291,7 @@ async def patch_manager_equipment_component(
             equipment_id=equipment_id,
             component_id=component_id,
             payload=payload.model_dump(exclude_unset=True),
+            tenant_scope=tenant_scope,
         )
     except ValueError as exc:
         raise manager_http_error(
@@ -306,12 +320,14 @@ async def list_manager_equipment_history(
     limit: int = Query(20, ge=1, le=100),
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     data = await EquipmentService.list_history(
         session=session,
         equipment_id=equipment_id,
         page=page,
         limit=limit,
+        tenant_scope=tenant_scope,
     )
     if data is None:
         raise manager_http_error(
@@ -333,12 +349,14 @@ async def create_manager_equipment_history(
     payload: ManagerEquipmentServiceHistoryCreatePayload,
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     try:
         data = await EquipmentService.add_history(
             session=session,
             equipment_id=equipment_id,
             payload=payload.model_dump(exclude_unset=True),
+            tenant_scope=tenant_scope,
         )
     except ValueError as exc:
         raise manager_http_error(
@@ -367,12 +385,14 @@ async def create_manager_equipment_history_from_repair_order(
     payload: ManagerEquipmentHistoryFromRepairOrderPayload,
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     try:
         data = await EquipmentService.add_history_from_repair_order(
             session=session,
             equipment_id=equipment_id,
             payload=payload.model_dump(exclude_unset=True),
+            tenant_scope=tenant_scope,
         )
     except ValueError as exc:
         raise manager_http_error(

--- a/routers/manager_equipment_links.py
+++ b/routers/manager_equipment_links.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, Response, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from core.database import get_session
-from core.security import get_current_username
+from core.security import get_current_manager_tenant_scope, get_current_username
 from routers.manager_operation_ids import (
     CREATE_MANAGER_ORDER_EQUIPMENT_LINK,
     DELETE_MANAGER_ORDER_EQUIPMENT_LINK,
@@ -14,6 +14,7 @@ from schemas import (
     ManagerOrderEquipmentLinkListResponse,
 )
 from services.equipment_link_service import EquipmentLinkService
+from services.tenant_scope_service import TenantScope
 
 
 router = APIRouter(prefix="/api/manager/orders/{order_id}/equipment-links", tags=["manager-equipment-links"])
@@ -24,8 +25,13 @@ async def list_manager_order_equipment_links(
     order_id: int,
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
-    data = await EquipmentLinkService.list_for_order(session, order_id=order_id)
+    data = await EquipmentLinkService.list_for_order(
+        session,
+        order_id=order_id,
+        tenant_scope=tenant_scope,
+    )
     if data is None:
         raise HTTPException(status_code=404, detail="Order not found")
     return data
@@ -42,6 +48,7 @@ async def create_manager_order_equipment_link(
     payload: ManagerOrderEquipmentLinkCreatePayload,
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     try:
         data = await EquipmentLinkService.link_existing(
@@ -49,6 +56,7 @@ async def create_manager_order_equipment_link(
             order_id=order_id,
             equipment_id=payload.equipment_id,
             role=payload.role,
+            tenant_scope=tenant_scope,
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -63,7 +71,13 @@ async def delete_manager_order_equipment_link(
     link_id: int,
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
-    if not await EquipmentLinkService.unlink(session, order_id=order_id, link_id=link_id):
+    if not await EquipmentLinkService.unlink(
+        session,
+        order_id=order_id,
+        link_id=link_id,
+        tenant_scope=tenant_scope,
+    ):
         raise HTTPException(status_code=404, detail="Equipment link not found")
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/routers/manager_installers.py
+++ b/routers/manager_installers.py
@@ -33,6 +33,7 @@ async def list_installers(
     search: Optional[str] = Query(None),
     session: AsyncSession = Depends(get_session),
     _user: str = Depends(get_current_username),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     """
     Paginated list of installers.
@@ -42,6 +43,7 @@ async def list_installers(
         page=page,
         limit=limit,
         search=search,
+        tenant_scope=tenant_scope,
     )
 
 
@@ -78,6 +80,7 @@ async def search_installers(
     limit: int = Query(50, ge=1, le=100),
     session: AsyncSession = Depends(get_session),
     _user: str = Depends(get_current_username),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     """
     Search active installers by name (for autocomplete).
@@ -86,6 +89,7 @@ async def search_installers(
         session=session,
         q=q,
         limit=limit,
+        tenant_scope=tenant_scope,
     )
 
 

--- a/routers/manager_leads_inbox.py
+++ b/routers/manager_leads_inbox.py
@@ -8,7 +8,8 @@ from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from core.database import get_session
-from core.security import get_current_username
+from core.security import get_current_manager_tenant_scope, get_current_username
+from models.tenancy import TenantScope
 from routers.manager_operation_ids import GET_MANAGER_LEADS_COUNTER, GET_MANAGER_LEADS_INBOX
 from schemas import LeadsCounterResponse, LeadsInboxListResponse
 from services.order_service import OrderService
@@ -20,11 +21,15 @@ router = APIRouter(prefix="/api/manager/leads", tags=["manager-leads-inbox"])
 async def get_leads_counter(
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ) -> LeadsCounterResponse:
     """Fast counter for the Dashboard / Sidebar badge.
     Counts only orders with status 'new_lead'.
     """
-    count, has_new = await OrderService.get_new_lead_counter(session)
+    count, has_new = await OrderService.get_new_lead_counter(
+        session,
+        tenant_scope=tenant_scope,
+    )
     return LeadsCounterResponse(count=count, has_new=has_new)
 
 
@@ -35,10 +40,17 @@ async def get_leads_inbox(
     limit: int = Query(50, ge=1, le=100),
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ) -> LeadsInboxListResponse:
     """Unified inbox feed.
 
     scope=active  → new_lead + assessment, sorted by is_new DESC then created_at DESC.
     scope=archive → canceled.
     """
-    return await OrderService.get_leads_inbox(session, scope=scope, page=page, limit=limit)
+    return await OrderService.get_leads_inbox(
+        session,
+        tenant_scope=tenant_scope,
+        scope=scope,
+        page=page,
+        limit=limit,
+    )

--- a/routers/manager_leads_read.py
+++ b/routers/manager_leads_read.py
@@ -4,7 +4,8 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from core.database import get_session
-from core.security import get_current_username
+from core.security import get_current_manager_tenant_scope, get_current_username
+from models.tenancy import TenantScope
 from routers.manager_operation_ids import GET_MANAGER_LEADS
 from schemas import LeadListResponse
 from services.lead_service import LeadService
@@ -25,12 +26,14 @@ async def get_manager_leads(
     sort: str = Query("created_at_desc"),
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     try:
         return await LeadService.list_leads(
             session=session,
             page=page,
             limit=limit,
+            tenant_scope=tenant_scope,
             status=status,
             source=source,
             search=search,

--- a/routers/manager_leads_write.py
+++ b/routers/manager_leads_write.py
@@ -55,9 +55,15 @@ async def patch_manager_lead(
     payload: LeadUpdatePayload,
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     try:
-        lead = await LeadService.update_lead(session=session, lead_id=lead_id, payload=payload)
+        lead = await LeadService.update_lead(
+            session=session,
+            lead_id=lead_id,
+            payload=payload,
+            tenant_scope=tenant_scope,
+        )
     except ValueError as exc:
         raise manager_http_error(
             status_code=400,
@@ -113,9 +119,15 @@ async def mark_manager_lead_lost(
     payload: LeadLossPayload,
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     try:
-        result = await LeadService.mark_lead_lost(session=session, lead_id=lead_id, payload=payload)
+        result = await LeadService.mark_lead_lost(
+            session=session,
+            lead_id=lead_id,
+            payload=payload,
+            tenant_scope=tenant_scope,
+        )
     except ValueError as exc:
         raise manager_http_error(
             status_code=400,

--- a/routers/manager_mail.py
+++ b/routers/manager_mail.py
@@ -7,7 +7,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from core.database import get_session
 from core.manager_api_errors import manager_http_error
 from core.manager_error_codes import BAD_REQUEST
-from core.security import get_current_username
+from core.security import (
+    get_current_manager_tenant_scope,
+    require_system_manager_tenant_scope,
+)
+from models.tenancy import TenantScope
 from routers.manager_operation_ids import (
     ATTACH_MANAGER_BANK_RECEIPT,
     ATTACH_MANAGER_BANK_RECEIPT_GROUP,
@@ -65,7 +69,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter(
     prefix="/api/manager/mail",
     tags=["manager/mail"],
-    dependencies=[Depends(get_current_username)],
+    dependencies=[Depends(require_system_manager_tenant_scope)],
 )
 
 
@@ -125,6 +129,7 @@ def _email_lead_import_job_response(snapshot: EmailLeadImportJobSnapshot) -> Ema
 async def import_manager_bank_receipts(
     limit: int = Query(50, ge=1, le=100),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     try:
         result = await MailImapService.import_bank_receipts(session, limit=limit)
@@ -133,6 +138,7 @@ async def import_manager_bank_receipts(
                 await NotificationService.notify_admins_bank_receipts_imported(
                     session,
                     result.created_receipt_ids,
+                    tenant_scope=tenant_scope,
                 )
             except Exception:
                 logger.exception(

--- a/routers/manager_orders_read.py
+++ b/routers/manager_orders_read.py
@@ -4,7 +4,8 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from core.database import get_session
-from core.security import get_current_username
+from core.security import get_current_manager_tenant_scope, get_current_username
+from models.tenancy import TenantScope
 from routers.manager_operation_ids import (
     EXPORT_MANAGER_ORDERS,
     GET_MANAGER_ORDER_DETAIL,
@@ -36,6 +37,7 @@ async def get_manager_orders(
     sort: str = Query("created_at_desc"),
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     try:
         return await OrderService.get_orders_for_manager(
@@ -43,6 +45,7 @@ async def get_manager_orders(
             customer_segment=segment,
             page=page,
             limit=limit,
+            tenant_scope=tenant_scope,
             status=status,
             search=search,
             overdue_only=overdue_only,
@@ -63,9 +66,11 @@ async def list_manager_stale_order_stages(
     limit: int = Query(100, ge=1, le=100),
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     return await OrderService.list_stale_order_stages(
         session,
+        tenant_scope=tenant_scope,
         older_than_days=older_than_days,
         include_unscheduled=include_unscheduled,
         limit=limit,
@@ -77,9 +82,14 @@ async def export_manager_orders(
     payload: ManagerOrderExportRequest,
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     try:
-        return await OrderTransferService.export_orders(session, payload)
+        return await OrderTransferService.export_orders(
+            session,
+            payload,
+            tenant_scope=tenant_scope,
+        )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
@@ -89,8 +99,13 @@ async def get_manager_order_detail(
     order_id: int,
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
-    data = await OrderService.get_order_detail_for_manager(session, order_id)
+    data = await OrderService.get_order_detail_for_manager(
+        session,
+        order_id,
+        tenant_scope=tenant_scope,
+    )
     if not data:
         raise HTTPException(status_code=404, detail="Order not found")
     return data

--- a/routers/manager_orders_write.py
+++ b/routers/manager_orders_write.py
@@ -85,9 +85,14 @@ async def cancel_manager_order_stage_direct(
     stage_id: int,
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     try:
-        return await OrderService.cancel_order_stage_direct(session, stage_id)
+        return await OrderService.cancel_order_stage_direct(
+            session,
+            stage_id,
+            tenant_scope=tenant_scope,
+        )
     except ValueError as exc:
         raise manager_http_error(
             status_code=404,
@@ -106,9 +111,14 @@ async def delete_manager_order_stage_direct(
     stage_id: int,
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     try:
-        return await OrderService.delete_order_stage_direct(session, stage_id)
+        return await OrderService.delete_order_stage_direct(
+            session,
+            stage_id,
+            tenant_scope=tenant_scope,
+        )
     except ValueError as exc:
         raise manager_http_error(
             status_code=404,
@@ -124,9 +134,15 @@ async def patch_manager_order(
     payload: ManagerOrderUpdatePayload,
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     try:
-        data = await OrderService.update_order_for_manager(session, order_id, payload)
+        data = await OrderService.update_order_for_manager(
+            session,
+            order_id,
+            payload,
+            tenant_scope=tenant_scope,
+        )
     except ValueError as exc:
         raise manager_http_error(
             status_code=400,
@@ -206,9 +222,15 @@ async def create_manager_order_proposal(
     payload: OrderProposalCreatePayload,
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     try:
-        return await OrderService.create_order_proposal(session, order_id, payload)
+        return await OrderService.create_order_proposal(
+            session,
+            order_id,
+            payload,
+            tenant_scope=tenant_scope,
+        )
     except ValueError as exc:
         raise manager_http_error(status_code=400, endpoint=CREATE_MANAGER_ORDER_PROPOSAL, error_code=BAD_REQUEST, message=str(exc)) from exc
 
@@ -224,13 +246,19 @@ async def duplicate_manager_order_proposal(
     payload: OrderProposalCreatePayload,
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     duplicate_payload = OrderProposalCreatePayload(
         name=payload.name,
         duplicate_from_proposal_id=proposal_id,
     )
     try:
-        return await OrderService.create_order_proposal(session, order_id, duplicate_payload)
+        return await OrderService.create_order_proposal(
+            session,
+            order_id,
+            duplicate_payload,
+            tenant_scope=tenant_scope,
+        )
     except ValueError as exc:
         raise manager_http_error(status_code=400, endpoint=DUPLICATE_MANAGER_ORDER_PROPOSAL, error_code=BAD_REQUEST, message=str(exc)) from exc
 
@@ -246,9 +274,16 @@ async def patch_manager_order_proposal(
     payload: OrderProposalUpdatePayload,
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     try:
-        return await OrderService.update_order_proposal(session, order_id, proposal_id, payload)
+        return await OrderService.update_order_proposal(
+            session,
+            order_id,
+            proposal_id,
+            payload,
+            tenant_scope=tenant_scope,
+        )
     except ValueError as exc:
         raise manager_http_error(status_code=400, endpoint=PATCH_MANAGER_ORDER_PROPOSAL, error_code=BAD_REQUEST, message=str(exc)) from exc
 
@@ -263,6 +298,7 @@ async def archive_manager_order_proposal(
     proposal_id: int,
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     try:
         return await OrderService.update_order_proposal(
@@ -270,6 +306,7 @@ async def archive_manager_order_proposal(
             order_id,
             proposal_id,
             OrderProposalUpdatePayload(is_archived=True),
+            tenant_scope=tenant_scope,
         )
     except ValueError as exc:
         raise manager_http_error(status_code=400, endpoint=ARCHIVE_MANAGER_ORDER_PROPOSAL, error_code=BAD_REQUEST, message=str(exc)) from exc
@@ -285,9 +322,15 @@ async def select_manager_order_proposal(
     proposal_id: int,
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     try:
-        return await OrderService.select_order_proposal(session, order_id, proposal_id)
+        return await OrderService.select_order_proposal(
+            session,
+            order_id,
+            proposal_id,
+            tenant_scope=tenant_scope,
+        )
     except ValueError as exc:
         raise manager_http_error(status_code=400, endpoint=SELECT_MANAGER_ORDER_PROPOSAL, error_code=BAD_REQUEST, message=str(exc)) from exc
 
@@ -314,6 +357,7 @@ async def generate_manager_order_document(
     scope_product_line_ids: Optional[List[int]] = Query(None, description="Order product line IDs included in scoped closing document"),
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     draft_conditions_requested = payload is not None and payload.additional_conditions is not None
     try:
@@ -337,6 +381,7 @@ async def generate_manager_order_document(
             scope_service_line_quantities=scope_service_line_quantities,
             scope_product_line_ids=scope_product_line_ids,
             additional_conditions=payload.additional_conditions if payload else None,
+            tenant_scope=tenant_scope,
         )
     except OrderDocumentsLockedError as exc:
         raise manager_http_error(
@@ -375,9 +420,15 @@ async def add_manager_order_payment(
     payload: PaymentCreatePayload,
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     try:
-        return await OrderService.add_payment(session, order_id, payload)
+        return await OrderService.add_payment(
+            session,
+            order_id,
+            payload,
+            tenant_scope=tenant_scope,
+        )
     except ValueError as exc:
         is_not_found = str(exc) == "Order not found"
         raise manager_http_error(
@@ -398,9 +449,15 @@ async def delete_manager_order_payment(
     payment_id: int,
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     try:
-        return await OrderService.delete_payment(session, order_id, payment_id)
+        return await OrderService.delete_payment(
+            session,
+            order_id,
+            payment_id,
+            tenant_scope=tenant_scope,
+        )
     except ValueError as exc:
         is_not_found = str(exc) == "Order not found"
         raise manager_http_error(
@@ -422,9 +479,15 @@ async def create_manager_order_stage(
     payload: OrderWorkStageCreatePayload,
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     try:
-        return await OrderService.add_order_stage(session, order_id, payload)
+        return await OrderService.add_order_stage(
+            session,
+            order_id,
+            payload,
+            tenant_scope=tenant_scope,
+        )
     except ValueError as exc:
         raise manager_http_error(status_code=400, endpoint=CREATE_MANAGER_ORDER_STAGE, error_code=BAD_REQUEST, message=str(exc)) from exc
 
@@ -440,9 +503,16 @@ async def update_manager_order_stage(
     payload: OrderWorkStageUpdatePayload,
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     try:
-        return await OrderService.update_order_stage(session, order_id, stage_id, payload)
+        return await OrderService.update_order_stage(
+            session,
+            order_id,
+            stage_id,
+            payload,
+            tenant_scope=tenant_scope,
+        )
     except ValueError as exc:
         raise manager_http_error(status_code=400, endpoint=UPDATE_MANAGER_ORDER_STAGE, error_code=BAD_REQUEST, message=str(exc)) from exc
 
@@ -457,9 +527,15 @@ async def delete_manager_order_stage(
     stage_id: int,
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     try:
-        return await OrderService.delete_order_stage(session, order_id, stage_id)
+        return await OrderService.delete_order_stage(
+            session,
+            order_id,
+            stage_id,
+            tenant_scope=tenant_scope,
+        )
     except ValueError as exc:
         raise manager_http_error(status_code=400, endpoint=DELETE_MANAGER_ORDER_STAGE, error_code=BAD_REQUEST, message=str(exc)) from exc
 
@@ -473,9 +549,14 @@ async def delete_manager_order(
     order_id: int,
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     try:
-        await OrderService.delete_order(session, order_id)
+        await OrderService.delete_order(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+        )
         return {"ok": True}
     except ValueError as exc:
         raise manager_http_error(

--- a/routers/manager_service_attachments.py
+++ b/routers/manager_service_attachments.py
@@ -7,7 +7,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from core.config import settings
 from core.database import get_session
-from core.security import get_current_username
+from core.security import get_current_manager_tenant_scope, get_current_username
+from models.tenancy import TenantScope
 from routers.manager_operation_ids import (
     DELETE_MANAGER_SERVICE_ATTACHMENT,
     GET_MANAGER_SERVICE_ATTACHMENT_ACCESS,
@@ -50,8 +51,13 @@ async def list_manager_order_attachments(
     order_id: int,
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
-    data = await ServiceAttachmentService.list_order_attachments(session, order_id=order_id)
+    data = await ServiceAttachmentService.list_order_attachments(
+        session,
+        order_id=order_id,
+        tenant_scope=tenant_scope,
+    )
     if data is None:
         raise HTTPException(status_code=404, detail="Order not found")
     return data
@@ -66,8 +72,13 @@ async def list_manager_equipment_attachments(
     equipment_id: int,
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
-    data = await ServiceAttachmentService.list_equipment_attachments(session, equipment_id=equipment_id)
+    data = await ServiceAttachmentService.list_equipment_attachments(
+        session,
+        equipment_id=equipment_id,
+        tenant_scope=tenant_scope,
+    )
     if data is None:
         raise HTTPException(status_code=404, detail="Equipment not found")
     return data
@@ -90,6 +101,7 @@ async def upload_manager_order_attachment(
     service_history_id: int | None = Form(None),
     username: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     try:
         content = await _read_upload_limited(file)
@@ -106,6 +118,7 @@ async def upload_manager_order_attachment(
             component_id=component_id,
             service_history_id=service_history_id,
             created_by=username,
+            tenant_scope=tenant_scope,
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -121,6 +134,7 @@ async def patch_manager_service_attachment(
     payload: ManagerServiceAttachmentUpdatePayload,
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     try:
         data = await ServiceAttachmentService.update_attachment(
@@ -128,6 +142,7 @@ async def patch_manager_service_attachment(
             attachment_id=attachment_id,
             order_id=payload.order_id,
             payload=payload.model_dump(exclude_unset=True, exclude={"order_id"}),
+            tenant_scope=tenant_scope,
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -146,11 +161,13 @@ async def delete_manager_service_attachment(
     order_id: int | None = Query(None),
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     if not await ServiceAttachmentService.archive_attachment(
         session,
         attachment_id=attachment_id,
         order_id=order_id,
+        tenant_scope=tenant_scope,
     ):
         raise HTTPException(status_code=404, detail="Attachment not found")
     return Response(status_code=status.HTTP_204_NO_CONTENT)
@@ -167,6 +184,7 @@ async def get_manager_service_attachment_access(
     download: bool = Query(False),
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     try:
         data = await ServiceAttachmentService.get_access(
@@ -174,6 +192,7 @@ async def get_manager_service_attachment_access(
             attachment_id=attachment_id,
             variant=variant,
             download=download,
+            tenant_scope=tenant_scope,
         )
     except FileNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc

--- a/scripts/service_attachment_migration/attachment_copy.py
+++ b/scripts/service_attachment_migration/attachment_copy.py
@@ -9,8 +9,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
 from models import Order, OrderAttachmentLink, OrderWorkStage, ServiceAttachment
+from models.tenancy import TenantScope
 from services.private_attachment_storage_service import PrivateAttachmentStorage
 from services.service_attachment_service import ServiceAttachmentService
+from services.tenant_scope_service import tenant_or_fully_legacy_scope_clause
 
 from .legacy_sources import (
     AttachmentDownloadError,
@@ -82,11 +84,18 @@ async def migrate_attachments(
     order_id: int | None,
     stats: MigrationStats,
     storage: PrivateAttachmentStorage | None = None,
+    tenant_scope: TenantScope,
 ) -> None:
-    order_stmt = select(Order).order_by(Order.id.asc())
+    order_stmt = (
+        select(Order)
+        .where(tenant_or_fully_legacy_scope_clause(Order, tenant_scope))
+        .order_by(Order.id.asc())
+    )
     stage_stmt = (
         select(OrderWorkStage)
+        .join(Order, Order.id == OrderWorkStage.order_id)
         .where(OrderWorkStage.installer_report.is_not(None))
+        .where(tenant_or_fully_legacy_scope_clause(Order, tenant_scope))
         .order_by(OrderWorkStage.id.asc())
     )
     if order_id is not None:
@@ -160,6 +169,7 @@ async def migrate_attachments(
                         },
                         storage=storage,
                         commit=False,
+                        tenant_scope=tenant_scope,
                     )
                     attachment = await session.get(ServiceAttachment, int(created["id"]))
                     if not attachment or not attachment.storage_key or storage is None:

--- a/scripts/service_attachment_migration/orchestrator.py
+++ b/scripts/service_attachment_migration/orchestrator.py
@@ -6,6 +6,7 @@ from sqlalchemy import inspect, text
 
 from core.database import async_session_maker, engine
 from services.private_attachment_storage_service import get_private_attachment_storage
+from services.tenant_scope_service import SystemTenantScopeResolver
 
 from .attachment_copy import migrate_attachments
 from .equipment_backfill import migrate_equipment_links, migrate_legacy_coverages
@@ -45,6 +46,7 @@ async def run(
 
     stats = MigrationStats()
     async with async_session_maker() as session:
+        tenant_scope = await SystemTenantScopeResolver.resolve(session)
         if execute and session.get_bind().dialect.name == "postgresql":
             await session.execute(
                 text("SELECT pg_advisory_xact_lock(:lock_key)"),
@@ -56,6 +58,7 @@ async def run(
             order_id=order_id,
             stats=stats,
             storage=storage,
+            tenant_scope=tenant_scope,
         )
         await migrate_equipment_links(
             session,

--- a/services/bot_defect_act_service.py
+++ b/services/bot_defect_act_service.py
@@ -9,11 +9,13 @@ from sqlalchemy.orm.attributes import flag_modified
 from sqlmodel import select
 
 from models import Order
+from models.tenancy import TenantScope
 from schemas import ManagerRepairActAiDraftPayload
 from services.bot_repair_nameplate_service import BotRepairNameplateService
 from services.defect_act_ai_service import DefectActAIService
 from services.order_service import OrderService
 from services.repair_defect_template_service import RepairDefectTemplateService
+from services.tenant_entity_access_service import TenantEntityAccessService
 
 
 class BotDefectActService:
@@ -138,14 +140,14 @@ class BotDefectActService:
         *,
         order_id: int,
         comment: str,
+        tenant_scope: TenantScope,
     ) -> dict[str, Any] | None:
-        result = await session.execute(
-            select(Order)
-            .where(Order.id == order_id)
-            .options(selectinload(Order.customer))
-            .limit(1)
+        order = await TenantEntityAccessService.get_order(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+            options=(selectinload(Order.customer),),
         )
-        order = result.scalars().first()
         if not order or OrderService._normalize_workflow_type(order.workflow_type) != "repair":
             return None
 
@@ -171,18 +173,18 @@ class BotDefectActService:
         *,
         order_id: int,
         fault_type: str,
+        tenant_scope: TenantScope,
     ) -> dict[str, Any] | None:
         normalized_fault_type = RepairDefectTemplateService.normalize_fault_type(fault_type)
         if normalized_fault_type not in cls.PRESET_FAULT_TYPES:
             raise ValueError("Неизвестный шаблон диагностики")
 
-        result = await session.execute(
-            select(Order)
-            .where(Order.id == order_id)
-            .options(selectinload(Order.customer))
-            .limit(1)
+        order = await TenantEntityAccessService.get_order(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+            options=(selectinload(Order.customer),),
         )
-        order = result.scalars().first()
         if not order or OrderService._normalize_workflow_type(order.workflow_type) != "repair":
             return None
 
@@ -225,18 +227,24 @@ class BotDefectActService:
         telegram_chat_id: int | None,
         telegram_message_id: int | None,
         can_attach_any: bool = False,
+        tenant_scope: TenantScope,
     ) -> dict[str, Any] | None:
         allowed = await BotRepairNameplateService.can_use_order(
             session,
             order_id,
             telegram_user_id=telegram_user_id,
             can_attach_any=can_attach_any,
+            tenant_scope=tenant_scope,
         )
         if not allowed:
             return None
 
-        result = await session.execute(select(Order).where(Order.id == order_id).limit(1))
-        order = result.scalars().first()
+        order = await TenantEntityAccessService.get_order(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+            for_update=True,
+        )
         if not order:
             return None
 

--- a/services/bot_media_api_service.py
+++ b/services/bot_media_api_service.py
@@ -8,6 +8,7 @@ from services.bot_api_access import require_bot_manager, require_bot_staff
 from services.bot_order_attachment_service import BotOrderAttachmentService
 from services.bot_repair_nameplate_service import BotRepairNameplateService
 from services.bot_warranty_nameplate_service import BotWarrantyNameplateService
+from services.tenant_scope_service import SystemTenantScopeResolver
 
 
 class BotMediaApiService:
@@ -16,7 +17,12 @@ class BotMediaApiService:
         session: AsyncSession, *, telegram_id: int, limit: int
     ) -> list[dict[str, Any]]:
         await require_bot_manager(session, telegram_id)
-        return await BotOrderAttachmentService.list_recent_orders(session, limit=limit)
+        tenant_scope = await SystemTenantScopeResolver.resolve(session)
+        return await BotOrderAttachmentService.list_recent_orders(
+            session,
+            limit=limit,
+            tenant_scope=tenant_scope,
+        )
 
     @staticmethod
     async def attach_to_order(
@@ -32,11 +38,13 @@ class BotMediaApiService:
         telegram_message_id: int | None,
     ) -> dict[str, Any] | None:
         context = await require_bot_staff(session, telegram_id)
+        tenant_scope = await SystemTenantScopeResolver.resolve(session)
         allowed = await BotOrderAttachmentService.can_attach_to_order(
             session,
             order_id,
             telegram_user_id=telegram_id,
             can_attach_any=context.is_manager,
+            tenant_scope=tenant_scope,
         )
         if not allowed:
             return None
@@ -50,6 +58,7 @@ class BotMediaApiService:
             telegram_chat_id=telegram_chat_id,
             telegram_message_id=telegram_message_id,
             content=content,
+            tenant_scope=tenant_scope,
         )
 
     @staticmethod
@@ -57,11 +66,13 @@ class BotMediaApiService:
         session: AsyncSession, *, telegram_id: int, limit: int
     ) -> list[dict[str, Any]]:
         context = await require_bot_staff(session, telegram_id)
+        tenant_scope = await SystemTenantScopeResolver.resolve(session)
         return await BotRepairNameplateService.list_repair_orders(
             session,
             telegram_user_id=telegram_id,
             can_attach_any=context.is_manager,
             limit=limit,
+            tenant_scope=tenant_scope,
         )
 
     @staticmethod
@@ -75,11 +86,13 @@ class BotMediaApiService:
         mime_type: str,
     ) -> dict[str, Any] | None:
         context = await require_bot_staff(session, telegram_id)
+        tenant_scope = await SystemTenantScopeResolver.resolve(session)
         allowed = await BotRepairNameplateService.can_use_order(
             session,
             order_id,
             telegram_user_id=telegram_id,
             can_attach_any=context.is_manager,
+            tenant_scope=tenant_scope,
         )
         if not allowed:
             return None
@@ -92,6 +105,7 @@ class BotMediaApiService:
             session,
             order_id=order_id,
             extracted=recognized.get("extracted") or {},
+            tenant_scope=tenant_scope,
         )
         return {**recognized, "order_id": order_id, "merge_preview": preview or {}}
 
@@ -112,6 +126,7 @@ class BotMediaApiService:
         telegram_message_id: int | None,
     ) -> dict[str, Any] | None:
         context = await require_bot_staff(session, telegram_id)
+        tenant_scope = await SystemTenantScopeResolver.resolve(session)
         return await BotRepairNameplateService.apply_to_order(
             session,
             order_id,
@@ -126,6 +141,7 @@ class BotMediaApiService:
             telegram_message_id=telegram_message_id,
             can_attach_any=context.is_manager,
             file_content=content,
+            tenant_scope=tenant_scope,
         )
 
     @staticmethod
@@ -133,11 +149,13 @@ class BotMediaApiService:
         session: AsyncSession, *, telegram_id: int, limit: int
     ) -> dict[str, Any]:
         context = await require_bot_staff(session, telegram_id)
+        tenant_scope = await SystemTenantScopeResolver.resolve(session)
         return await BotWarrantyNameplateService.list_installation_orders(
             session,
             telegram_user_id=telegram_id,
             can_attach_any=context.is_manager,
             limit=limit,
+            tenant_scope=tenant_scope,
         )
 
     @staticmethod
@@ -152,11 +170,13 @@ class BotMediaApiService:
         mime_type: str,
     ) -> dict[str, Any] | None:
         context = await require_bot_staff(session, telegram_id)
+        tenant_scope = await SystemTenantScopeResolver.resolve(session)
         allowed = await BotWarrantyNameplateService.can_use_order(
             session,
             order_id,
             telegram_user_id=telegram_id,
             can_attach_any=context.is_manager,
+            tenant_scope=tenant_scope,
         )
         if not allowed:
             return None
@@ -170,6 +190,7 @@ class BotMediaApiService:
             order_id=order_id,
             unit_type=unit_type,
             extracted=recognized.get("extracted") or {},
+            tenant_scope=tenant_scope,
         )
         return {
             **recognized,
@@ -196,6 +217,7 @@ class BotMediaApiService:
         telegram_message_id: int | None,
     ) -> dict[str, Any] | None:
         context = await require_bot_staff(session, telegram_id)
+        tenant_scope = await SystemTenantScopeResolver.resolve(session)
         return await BotWarrantyNameplateService.apply_to_order(
             session,
             order_id,
@@ -211,4 +233,5 @@ class BotMediaApiService:
             telegram_message_id=telegram_message_id,
             can_attach_any=context.is_manager,
             file_content=content,
+            tenant_scope=tenant_scope,
         )

--- a/services/bot_order_attachment_service.py
+++ b/services/bot_order_attachment_service.py
@@ -6,10 +6,21 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 from sqlmodel import select
 
-from models import Order, OrderInstaller, OrderStatus, OrderWorkStage, StaffUser
+from models import (
+    Customer,
+    Order,
+    OrderInstaller,
+    OrderStatus,
+    OrderWorkStage,
+    StaffUser,
+    TenantMembership,
+)
+from models.tenancy import TenantScope
 from services.private_attachment_storage_service import sha256_bytes
 from services.service_attachment_service import ServiceAttachmentService
 from services.staff_user_service import StaffUserService
+from services.tenant_entity_access_service import TenantEntityAccessService
+from services.tenant_scope_service import tenant_or_fully_legacy_scope_clause
 
 
 class BotOrderAttachmentService:
@@ -161,10 +172,21 @@ class BotOrderAttachmentService:
         }
 
     @classmethod
-    async def list_recent_orders(cls, session: AsyncSession, *, limit: int = 5) -> list[dict[str, Any]]:
+    async def list_recent_orders(
+        cls,
+        session: AsyncSession,
+        *,
+        limit: int = 5,
+        tenant_scope: TenantScope,
+    ) -> list[dict[str, Any]]:
         stmt = (
             select(Order)
-            .where(Order.status.in_(list(cls.ACTIVE_STATUSES)))
+            .outerjoin(Customer, Customer.id == Order.customer_id)
+            .where(
+                Order.status.in_(list(cls.ACTIVE_STATUSES)),
+                tenant_or_fully_legacy_scope_clause(Order, tenant_scope),
+                TenantEntityAccessService.order_customer_clause(tenant_scope),
+            )
             .options(selectinload(Order.customer))
             .order_by(Order.updated_at.desc(), Order.created_at.desc(), Order.id.desc())
             .limit(max(1, min(limit, 10)))
@@ -180,7 +202,15 @@ class BotOrderAttachmentService:
         *,
         telegram_user_id: int | str | None,
         can_attach_any: bool = False,
+        tenant_scope: TenantScope,
     ) -> bool:
+        order = await TenantEntityAccessService.get_order(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+        )
+        if order is None:
+            return False
         if can_attach_any:
             return True
 
@@ -195,6 +225,14 @@ class BotOrderAttachmentService:
             select(StaffUser)
             .where(StaffUser.telegram_id == normalized_telegram_id)
             .where(StaffUser.status == StaffUserService.STATUS_ACTIVE)
+            .join(
+                TenantMembership,
+                TenantMembership.staff_user_id == StaffUser.id,
+            )
+            .where(
+                TenantMembership.tenant_id == tenant_scope.tenant_id,
+                TenantMembership.status == "active",
+            )
             .order_by(StaffUser.id.asc())
         )
         staff = staff_result.scalars().first()
@@ -232,10 +270,15 @@ class BotOrderAttachmentService:
         telegram_chat_id: int | None,
         telegram_message_id: int | None,
         content: bytes | None = None,
+        tenant_scope: TenantScope,
     ) -> dict[str, Any] | None:
-        stmt = select(Order).where(Order.id == order_id).options(selectinload(Order.customer))
-        result = await session.execute(stmt)
-        order = result.scalars().first()
+        order = await TenantEntityAccessService.get_order(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+            options=(selectinload(Order.customer),),
+            for_update=True,
+        )
         if not order:
             return None
 
@@ -270,6 +313,7 @@ class BotOrderAttachmentService:
                     "chat_id": telegram_chat_id,
                     "message_id": telegram_message_id,
                 },
+                tenant_scope=tenant_scope,
             )
             storage_meta = {
                 "storage_provider": "private_service_attachment",

--- a/services/bot_quick_order_service.py
+++ b/services/bot_quick_order_service.py
@@ -544,7 +544,12 @@ class BotQuickOrderService:
             session,
             order_id,
             ManagerOrderUpdatePayload(**update_fields),
-        ) if update_fields else await OrderService.get_order_detail_for_manager(session, order_id)
+            tenant_scope=tenant_scope,
+        ) if update_fields else await OrderService.get_order_detail_for_manager(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+        )
         if not order:
             raise ValueError("Не удалось создать заказ")
 
@@ -555,6 +560,7 @@ class BotQuickOrderService:
                     session,
                     order_id,
                     source_label="Telegram-бот",
+                    tenant_scope=tenant_scope,
                 )
             except Exception:
                 logger.exception("BOT_QUICK_ORDER_NOTIFY_FAILED order_id=%s", order_id)
@@ -575,10 +581,19 @@ class BotQuickOrderService:
                 )
             ).scalars().first()
             if existing_stage:
-                order = await OrderService.get_order_detail_for_manager(session, order_id) or order
+                order = await OrderService.get_order_detail_for_manager(
+                    session,
+                    order_id,
+                    tenant_scope=tenant_scope,
+                ) or order
             else:
                 try:
-                    updated = await OrderService.add_order_stage(session, order_id, stage_payload)
+                    updated = await OrderService.add_order_stage(
+                        session,
+                        order_id,
+                        stage_payload,
+                        tenant_scope=tenant_scope,
+                    )
                     order = updated or order
                 except IntegrityError:
                     await session.rollback()
@@ -594,7 +609,11 @@ class BotQuickOrderService:
                     ).scalars().first()
                     if not concurrent_stage:
                         raise
-                    order = await OrderService.get_order_detail_for_manager(session, order_id) or order
+                    order = await OrderService.get_order_detail_for_manager(
+                        session,
+                        order_id,
+                        tenant_scope=tenant_scope,
+                    ) or order
 
         order["_bot_order_created"] = order_created
         return order

--- a/services/bot_repair_context_api_service.py
+++ b/services/bot_repair_context_api_service.py
@@ -7,22 +7,26 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from services.bot_api_access import require_bot_staff
 from services.bot_defect_act_service import BotDefectActService
 from services.bot_repair_nameplate_service import BotRepairNameplateService
+from services.tenant_scope_service import SystemTenantScopeResolver, TenantScope
 
 
 class BotRepairContextApiService:
     @staticmethod
     async def _require_order_access(
         session: AsyncSession, *, telegram_id: int, order_id: int
-    ) -> None:
+    ) -> TenantScope:
         context = await require_bot_staff(session, telegram_id)
+        tenant_scope = await SystemTenantScopeResolver.resolve(session)
         allowed = await BotRepairNameplateService.can_use_order(
             session,
             order_id,
             telegram_user_id=telegram_id,
             can_attach_any=context.is_manager,
+            tenant_scope=tenant_scope,
         )
         if not allowed:
             raise LookupError("Repair order is not available to this staff user")
+        return tenant_scope
 
     @classmethod
     async def build_comment_draft(
@@ -33,13 +37,14 @@ class BotRepairContextApiService:
         order_id: int,
         comment: str,
     ) -> dict[str, Any]:
-        await cls._require_order_access(
+        tenant_scope = await cls._require_order_access(
             session, telegram_id=telegram_id, order_id=order_id
         )
         draft = await BotDefectActService.build_diagnostic_comment_draft(
             session,
             order_id=order_id,
             comment=comment,
+            tenant_scope=tenant_scope,
         )
         if not draft:
             raise LookupError("Repair order not found")
@@ -54,13 +59,14 @@ class BotRepairContextApiService:
         order_id: int,
         fault_type: str,
     ) -> dict[str, Any]:
-        await cls._require_order_access(
+        tenant_scope = await cls._require_order_access(
             session, telegram_id=telegram_id, order_id=order_id
         )
         draft = await BotDefectActService.build_diagnostic_preset_draft(
             session,
             order_id=order_id,
             fault_type=fault_type,
+            tenant_scope=tenant_scope,
         )
         if not draft:
             raise LookupError("Repair order not found")
@@ -79,6 +85,7 @@ class BotRepairContextApiService:
         telegram_message_id: int | None,
     ) -> dict[str, Any]:
         context = await require_bot_staff(session, telegram_id)
+        tenant_scope = await SystemTenantScopeResolver.resolve(session)
         result = await BotDefectActService.apply_diagnostic_comment(
             session,
             order_id,
@@ -88,6 +95,7 @@ class BotRepairContextApiService:
             telegram_chat_id=telegram_chat_id,
             telegram_message_id=telegram_message_id,
             can_attach_any=context.is_manager,
+            tenant_scope=tenant_scope,
         )
         if not result:
             raise LookupError("Repair order is not available to this staff user")

--- a/services/bot_repair_nameplate_service.py
+++ b/services/bot_repair_nameplate_service.py
@@ -10,13 +10,24 @@ from sqlalchemy.orm.attributes import flag_modified
 from sqlmodel import select
 
 from core.config import settings
-from models import Order, OrderInstaller, OrderStatus, OrderWorkStage, StaffUser
+from models import (
+    Customer,
+    Order,
+    OrderInstaller,
+    OrderStatus,
+    OrderWorkStage,
+    StaffUser,
+    TenantMembership,
+)
+from models.tenancy import TenantScope
 from services.bot_order_attachment_service import BotOrderAttachmentService
 from services.customer_requisites_recognition_service import CustomerRequisitesRecognitionService
 from services.order_service import OrderService
 from services.private_attachment_storage_service import sha256_bytes
 from services.service_attachment_service import ServiceAttachmentService
 from services.staff_user_service import StaffUserService
+from services.tenant_entity_access_service import TenantEntityAccessService
+from services.tenant_scope_service import tenant_or_fully_legacy_scope_clause
 
 
 class BotRepairNameplateService:
@@ -336,7 +347,13 @@ class BotRepairNameplateService:
         }
 
     @classmethod
-    async def _legacy_installer_id(cls, session: AsyncSession, telegram_user_id: int | str | None) -> Optional[int]:
+    async def _legacy_installer_id(
+        cls,
+        session: AsyncSession,
+        telegram_user_id: int | str | None,
+        *,
+        tenant_scope: TenantScope,
+    ) -> Optional[int]:
         try:
             normalized_telegram_id = int(telegram_user_id) if telegram_user_id is not None else 0
         except (TypeError, ValueError):
@@ -348,6 +365,14 @@ class BotRepairNameplateService:
             select(StaffUser)
             .where(StaffUser.telegram_id == normalized_telegram_id)
             .where(StaffUser.status == StaffUserService.STATUS_ACTIVE)
+            .join(
+                TenantMembership,
+                TenantMembership.staff_user_id == StaffUser.id,
+            )
+            .where(
+                TenantMembership.tenant_id == tenant_scope.tenant_id,
+                TenantMembership.status == "active",
+            )
             .order_by(StaffUser.id.asc())
             .limit(1)
         )
@@ -363,18 +388,26 @@ class BotRepairNameplateService:
         telegram_user_id: int | str | None,
         can_attach_any: bool = False,
         limit: int = 5,
+        tenant_scope: TenantScope,
     ) -> list[dict[str, Any]]:
         stmt = (
             select(Order)
+            .outerjoin(Customer, Customer.id == Order.customer_id)
             .where(Order.status.in_(list(cls.ACTIVE_REPAIR_STATUSES)))
             .where(Order.workflow_type == "repair")
+            .where(tenant_or_fully_legacy_scope_clause(Order, tenant_scope))
+            .where(TenantEntityAccessService.order_customer_clause(tenant_scope))
             .options(selectinload(Order.customer))
             .order_by(Order.updated_at.desc(), Order.created_at.desc(), Order.id.desc())
             .limit(max(1, min(limit, 10)))
         )
 
         if not can_attach_any:
-            installer_id = await cls._legacy_installer_id(session, telegram_user_id)
+            installer_id = await cls._legacy_installer_id(
+                session,
+                telegram_user_id,
+                tenant_scope=tenant_scope,
+            )
             if not installer_id:
                 return []
             stage_exists = (
@@ -402,9 +435,13 @@ class BotRepairNameplateService:
         *,
         telegram_user_id: int | str | None,
         can_attach_any: bool = False,
+        tenant_scope: TenantScope,
     ) -> bool:
-        result = await session.execute(select(Order).where(Order.id == order_id).limit(1))
-        order = result.scalars().first()
+        order = await TenantEntityAccessService.get_order(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+        )
         if not cls._is_active_repair_order(order):
             return False
         if can_attach_any:
@@ -413,6 +450,7 @@ class BotRepairNameplateService:
             session,
             order_id,
             telegram_user_id=telegram_user_id,
+            tenant_scope=tenant_scope,
         )
 
     @classmethod
@@ -618,9 +656,13 @@ class BotRepairNameplateService:
         *,
         order_id: int,
         extracted: dict[str, Any],
+        tenant_scope: TenantScope,
     ) -> dict[str, Any] | None:
-        result = await session.execute(select(Order).where(Order.id == order_id).limit(1))
-        order = result.scalars().first()
+        order = await TenantEntityAccessService.get_order(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+        )
         if not order:
             return None
         return cls.preview_merge(OrderService._get_repair_meta(order), extracted)
@@ -642,23 +684,25 @@ class BotRepairNameplateService:
         telegram_message_id: int | None,
         can_attach_any: bool = False,
         file_content: bytes | None = None,
+        tenant_scope: TenantScope,
     ) -> dict[str, Any] | None:
         allowed = await cls.can_use_order(
             session,
             order_id,
             telegram_user_id=telegram_user_id,
             can_attach_any=can_attach_any,
+            tenant_scope=tenant_scope,
         )
         if not allowed:
             return None
 
-        result = await session.execute(
-            select(Order)
-            .where(Order.id == order_id)
-            .options(selectinload(Order.customer))
-            .limit(1)
+        order = await TenantEntityAccessService.get_order(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+            options=(selectinload(Order.customer),),
+            for_update=True,
         )
-        order = result.scalars().first()
         if not order:
             return None
 
@@ -709,6 +753,7 @@ class BotRepairNameplateService:
                     "message_id": telegram_message_id,
                     "source_meta": {"purpose": "repair_nameplate"},
                 },
+                tenant_scope=tenant_scope,
             )
             storage_meta = {
                 "storage_provider": "private_service_attachment",

--- a/services/bot_task_mutation_service.py
+++ b/services/bot_task_mutation_service.py
@@ -4,11 +4,11 @@ import logging
 from dataclasses import dataclass
 
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlmodel import select
-
 from models import OrderStageStatus, OrderWorkStage
+from models.tenancy import TenantScope
 from services.bot_access_service import BotAccessService
 from services.notification_service import NotificationService
+from services.tenant_entity_access_service import TenantEntityAccessService
 
 logger = logging.getLogger(__name__)
 
@@ -41,17 +41,18 @@ class BotTaskMutationService:
         *,
         telegram_id: int,
         stage_id: int,
+        tenant_scope: TenantScope,
     ) -> OrderWorkStage:
         context = await BotAccessService.get_context(session, telegram_id)
         if not context.is_staff or not context.legacy_installer_id:
             raise BotTaskMutationAccessDeniedError("Staff task access is required")
 
-        result = await session.execute(
-            select(OrderWorkStage)
-            .where(OrderWorkStage.id == stage_id)
-            .with_for_update()
+        stage = await TenantEntityAccessService.get_order_stage(
+            session,
+            stage_id,
+            tenant_scope=tenant_scope,
+            for_update=True,
         )
-        stage = result.scalars().first()
         if not stage or stage.installer_id != context.legacy_installer_id:
             raise BotTaskMutationAccessDeniedError(
                 "Task was not found or is assigned to another executor"
@@ -66,6 +67,7 @@ class BotTaskMutationService:
         telegram_id: int,
         stage_id: int,
         status: OrderStageStatus,
+        tenant_scope: TenantScope,
     ) -> BotTaskStatusMutationResult:
         if status not in {OrderStageStatus.IN_PROGRESS, OrderStageStatus.COMPLETED}:
             raise ValueError("Bot may only accept or complete a task")
@@ -74,6 +76,7 @@ class BotTaskMutationService:
             session,
             telegram_id=telegram_id,
             stage_id=stage_id,
+            tenant_scope=tenant_scope,
         )
         current_status = OrderStageStatus(stage.status)
         if current_status == status:
@@ -96,6 +99,7 @@ class BotTaskMutationService:
             await NotificationService.notify_admins_work_stage_status_changed(
                 session,
                 stage_id,
+                tenant_scope=tenant_scope,
             )
         except Exception:
             logger.exception("BOT_TASK_STATUS_NOTIFY_FAILED stage_id=%s", stage_id)
@@ -113,6 +117,7 @@ class BotTaskMutationService:
         telegram_id: int,
         stage_id: int,
         report: str,
+        tenant_scope: TenantScope,
     ) -> BotTaskReportMutationResult:
         normalized_report = report.strip()
         if not normalized_report:
@@ -122,6 +127,7 @@ class BotTaskMutationService:
             session,
             telegram_id=telegram_id,
             stage_id=stage_id,
+            tenant_scope=tenant_scope,
         )
         if (stage.installer_report or "").strip() == normalized_report:
             return BotTaskReportMutationResult(stage_id=stage_id, changed=False)

--- a/services/bot_task_read_service.py
+++ b/services/bot_task_read_service.py
@@ -6,6 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from services.bot_access_service import BotAccessService
 from services.bot_task_service import BotTaskService
+from models.tenancy import TenantScope
 
 
 class BotTaskAccessDeniedError(PermissionError):
@@ -22,6 +23,7 @@ class BotTaskReadService:
         date_from: datetime | None = None,
         date_to: datetime | None = None,
         statuses: list[str] | None = None,
+        tenant_scope: TenantScope,
     ) -> list[dict]:
         context = await BotAccessService.get_context(session, telegram_id)
         if not context.is_staff:
@@ -35,4 +37,5 @@ class BotTaskReadService:
             date_from=date_from,
             date_to=date_to,
             statuses=statuses,
+            tenant_scope=tenant_scope,
         )

--- a/services/bot_task_service.py
+++ b/services/bot_task_service.py
@@ -8,8 +8,20 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 from sqlmodel import select
 
-from models import Order, OrderInstaller, OrderStageStatus, OrderStatus, OrderWorkStage, StaffUser
+from models import (
+    Customer,
+    Order,
+    OrderInstaller,
+    OrderStageStatus,
+    OrderStatus,
+    OrderWorkStage,
+    StaffUser,
+    TenantMembership,
+)
+from models.tenancy import TenantScope
 from services.staff_user_service import StaffUserService
+from services.tenant_entity_access_service import TenantEntityAccessService
+from services.tenant_scope_service import tenant_or_fully_legacy_scope_clause
 
 
 class BotTaskService:
@@ -20,7 +32,12 @@ class BotTaskService:
     }
 
     @staticmethod
-    async def _staff_by_telegram_id(session: AsyncSession, telegram_id: int | str | None) -> StaffUser | None:
+    async def _staff_by_telegram_id(
+        session: AsyncSession,
+        telegram_id: int | str | None,
+        *,
+        tenant_scope: TenantScope,
+    ) -> StaffUser | None:
         try:
             normalized_telegram_id = int(telegram_id) if telegram_id is not None else 0
         except (TypeError, ValueError):
@@ -31,6 +48,14 @@ class BotTaskService:
             select(StaffUser)
             .where(StaffUser.telegram_id == normalized_telegram_id)
             .where(StaffUser.status == StaffUserService.STATUS_ACTIVE)
+            .join(
+                TenantMembership,
+                TenantMembership.staff_user_id == StaffUser.id,
+            )
+            .where(
+                TenantMembership.tenant_id == tenant_scope.tenant_id,
+                TenantMembership.status == "active",
+            )
         )
         return result.scalars().first()
 
@@ -44,8 +69,13 @@ class BotTaskService:
         date_from: datetime | None = None,
         date_to: datetime | None = None,
         statuses: list[str] | None = None,
+        tenant_scope: TenantScope,
     ) -> list[dict[str, Any]]:
-        staff = await cls._staff_by_telegram_id(session, telegram_id)
+        staff = await cls._staff_by_telegram_id(
+            session,
+            telegram_id,
+            tenant_scope=tenant_scope,
+        )
         if not staff or not staff.legacy_installer_id:
             return []
 
@@ -56,6 +86,7 @@ class BotTaskService:
             date_from=date_from,
             date_to=date_to,
             statuses=statuses,
+            tenant_scope=tenant_scope,
         )
 
     @classmethod
@@ -69,6 +100,7 @@ class BotTaskService:
         date_to: datetime | None = None,
         statuses: list[str] | None = None,
         reference_time: datetime | None = None,
+        tenant_scope: TenantScope,
     ) -> list[dict[str, Any]]:
         safe_limit = max(1, min(int(limit or 10), 20))
 
@@ -93,6 +125,8 @@ class BotTaskService:
             OrderWorkStage.start_time.is_not(None),
             OrderWorkStage.start_time >= range_start,
             OrderWorkStage.start_time <= range_end,
+            tenant_or_fully_legacy_scope_clause(Order, tenant_scope),
+            TenantEntityAccessService.order_customer_clause(tenant_scope),
         ]
         if requested_statuses:
             active_stage_filters.append(OrderWorkStage.status.in_(stage_statuses))
@@ -107,6 +141,7 @@ class BotTaskService:
         stage_result = await session.execute(
             select(OrderWorkStage)
             .join(Order, Order.id == OrderWorkStage.order_id)
+            .outerjoin(Customer, Customer.id == Order.customer_id)
             .where(*active_stage_filters)
             .options(
                 selectinload(OrderWorkStage.order).selectinload(Order.customer),
@@ -119,13 +154,17 @@ class BotTaskService:
         active_stage_order_ids = (
             select(OrderWorkStage.order_id)
             .join(Order, Order.id == OrderWorkStage.order_id)
+            .outerjoin(Customer, Customer.id == Order.customer_id)
             .where(*active_stage_filters)
         )
 
         order_query = (
             select(Order)
             .join(OrderInstaller, OrderInstaller.order_id == Order.id)
+            .outerjoin(Customer, Customer.id == Order.customer_id)
             .where(OrderInstaller.installer_id == installer_id)
+            .where(tenant_or_fully_legacy_scope_clause(Order, tenant_scope))
+            .where(TenantEntityAccessService.order_customer_clause(tenant_scope))
             .where(Order.status.in_(list(cls.ACTIVE_ORDER_STATUSES)))
             .where(Order.installation_date.is_not(None))
             .where(

--- a/services/bot_warranty_nameplate_service.py
+++ b/services/bot_warranty_nameplate_service.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm.attributes import flag_modified
 from sqlmodel import select
 
 from models import (
+    Customer,
     CustomerEquipment,
     EquipmentComponent,
     Order,
@@ -17,7 +18,9 @@ from models import (
     OrderWorkStage,
     Product,
     StaffUser,
+    TenantMembership,
 )
+from models.tenancy import TenantScope
 from services.bot_order_attachment_service import BotOrderAttachmentService
 from services.bot_repair_nameplate_service import BotRepairNameplateService
 from services.equipment_service import EquipmentService
@@ -25,6 +28,8 @@ from services.order_service import OrderService
 from services.private_attachment_storage_service import sha256_bytes
 from services.service_attachment_service import ServiceAttachmentService
 from services.staff_user_service import StaffUserService
+from services.tenant_entity_access_service import TenantEntityAccessService
+from services.tenant_scope_service import tenant_or_fully_legacy_scope_clause
 
 
 class BotWarrantyNameplateService:
@@ -79,7 +84,13 @@ class BotWarrantyNameplateService:
         }
 
     @classmethod
-    async def _legacy_installer_id(cls, session: AsyncSession, telegram_user_id: int | str | None) -> Optional[int]:
+    async def _legacy_installer_id(
+        cls,
+        session: AsyncSession,
+        telegram_user_id: int | str | None,
+        *,
+        tenant_scope: TenantScope,
+    ) -> Optional[int]:
         try:
             normalized_telegram_id = int(telegram_user_id) if telegram_user_id is not None else 0
         except (TypeError, ValueError):
@@ -91,6 +102,14 @@ class BotWarrantyNameplateService:
             select(StaffUser)
             .where(StaffUser.telegram_id == normalized_telegram_id)
             .where(StaffUser.status == StaffUserService.STATUS_ACTIVE)
+            .join(
+                TenantMembership,
+                TenantMembership.staff_user_id == StaffUser.id,
+            )
+            .where(
+                TenantMembership.tenant_id == tenant_scope.tenant_id,
+                TenantMembership.status == "active",
+            )
             .order_by(StaffUser.id.asc())
             .limit(1)
         )
@@ -123,13 +142,20 @@ class BotWarrantyNameplateService:
         can_attach_any: bool = False,
         limit: int = 5,
         now: Optional[datetime] = None,
+        tenant_scope: TenantScope,
     ) -> dict[str, Any]:
         base_filters = [
             Order.status == OrderStatus.EXECUTION,
             Order.workflow_type.in_(sorted(cls.ORDER_WORKFLOWS)),
+            tenant_or_fully_legacy_scope_clause(Order, tenant_scope),
+            TenantEntityAccessService.order_customer_clause(tenant_scope),
         ]
         if not can_attach_any:
-            installer_id = await cls._legacy_installer_id(session, telegram_user_id)
+            installer_id = await cls._legacy_installer_id(
+                session,
+                telegram_user_id,
+                tenant_scope=tenant_scope,
+            )
             if not installer_id:
                 return {"items": [], "scope": "today"}
             base_filters.append(cls._permission_filters(installer_id))
@@ -138,6 +164,7 @@ class BotWarrantyNameplateService:
         start, end = cls._today_bounds(now)
         today_stmt = (
             select(Order)
+            .outerjoin(Customer, Customer.id == Order.customer_id)
             .where(*base_filters)
             .where(Order.installation_date >= start)
             .where(Order.installation_date <= end)
@@ -152,6 +179,7 @@ class BotWarrantyNameplateService:
 
         fallback_stmt = (
             select(Order)
+            .outerjoin(Customer, Customer.id == Order.customer_id)
             .where(*base_filters)
             .options(selectinload(Order.customer))
             .order_by(Order.installation_date.desc().nullslast(), Order.updated_at.desc(), Order.id.desc())
@@ -168,9 +196,13 @@ class BotWarrantyNameplateService:
         *,
         telegram_user_id: int | str | None,
         can_attach_any: bool = False,
+        tenant_scope: TenantScope,
     ) -> bool:
-        result = await session.execute(select(Order).where(Order.id == order_id).limit(1))
-        order = result.scalars().first()
+        order = await TenantEntityAccessService.get_order(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+        )
         if not cls._is_installation_order(order):
             return False
         if can_attach_any:
@@ -179,6 +211,7 @@ class BotWarrantyNameplateService:
             session,
             order_id,
             telegram_user_id=telegram_user_id,
+            tenant_scope=tenant_scope,
         )
 
     @classmethod
@@ -227,19 +260,24 @@ class BotWarrantyNameplateService:
         return {"applied": applied, "conflicts": conflicts, "skipped": skipped}
 
     @classmethod
-    async def _load_order(cls, session: AsyncSession, order_id: int) -> Optional[Order]:
-        result = await session.execute(
-            select(Order)
-            .where(Order.id == order_id)
-            .options(
+    async def _load_order(
+        cls,
+        session: AsyncSession,
+        order_id: int,
+        *,
+        tenant_scope: TenantScope,
+    ) -> Optional[Order]:
+        return await TenantEntityAccessService.get_order(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+            options=(
                 selectinload(Order.customer),
                 selectinload(Order.customer_branch),
                 selectinload(Order.proposals),
                 selectinload(Order.product_links).selectinload(OrderProductLink.product).selectinload(Product.brand),
-            )
-            .limit(1)
+            ),
         )
-        return result.scalars().first()
 
     @classmethod
     async def _existing_equipment_for_order(cls, session: AsyncSession, order_id: int) -> list[CustomerEquipment]:
@@ -264,7 +302,13 @@ class BotWarrantyNameplateService:
         return list(result.scalars().all())
 
     @classmethod
-    async def _ensure_equipment_for_order(cls, session: AsyncSession, order: Order) -> list[CustomerEquipment]:
+    async def _ensure_equipment_for_order(
+        cls,
+        session: AsyncSession,
+        order: Order,
+        *,
+        tenant_scope: TenantScope,
+    ) -> list[CustomerEquipment]:
         order_id = int(order.id or 0)
         equipment = await cls._existing_equipment_for_order(session, order_id)
         if equipment:
@@ -279,6 +323,7 @@ class BotWarrantyNameplateService:
                     "warranty_start_date": order.installation_date,
                     "include_component_placeholders": True,
                 },
+                tenant_scope=tenant_scope,
             )
         except ValueError:
             if order.customer_id is None:
@@ -342,10 +387,15 @@ class BotWarrantyNameplateService:
         order_id: int,
         unit_type: str,
         extracted: dict[str, Any],
+        tenant_scope: TenantScope,
     ) -> dict[str, Any] | None:
         if unit_type not in cls.UNIT_TYPES:
             raise ValueError("Неизвестный тип блока")
-        order = await cls._load_order(session, order_id)
+        order = await cls._load_order(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+        )
         if not cls._is_installation_order(order):
             return None
         equipment = await cls._existing_equipment_for_order(session, order_id)
@@ -386,6 +436,7 @@ class BotWarrantyNameplateService:
         telegram_message_id: int | None,
         can_attach_any: bool = False,
         file_content: bytes | None = None,
+        tenant_scope: TenantScope,
     ) -> dict[str, Any] | None:
         if unit_type not in cls.UNIT_TYPES:
             raise ValueError("Неизвестный тип блока")
@@ -394,14 +445,23 @@ class BotWarrantyNameplateService:
             order_id,
             telegram_user_id=telegram_user_id,
             can_attach_any=can_attach_any,
+            tenant_scope=tenant_scope,
         )
         if not allowed:
             return None
-        order = await cls._load_order(session, order_id)
+        order = await cls._load_order(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+        )
         if not order:
             return None
 
-        equipment = await cls._ensure_equipment_for_order(session, order)
+        equipment = await cls._ensure_equipment_for_order(
+            session,
+            order,
+            tenant_scope=tenant_scope,
+        )
         if not equipment:
             raise ValueError("Не удалось создать карточку оборудования для заказа")
         components = await cls._components_for_equipment(session, [int(item.id or 0) for item in equipment])
@@ -477,6 +537,7 @@ class BotWarrantyNameplateService:
                     "message_id": telegram_message_id,
                     "source_meta": {"purpose": "warranty_nameplate", "unit_type": unit_type},
                 },
+                tenant_scope=tenant_scope,
             )
             storage_meta = {
                 "storage_provider": "private_service_attachment",

--- a/services/document_service.py
+++ b/services/document_service.py
@@ -14,6 +14,7 @@ from services.documents.base import TEMPLATES, DOC_NAMES, BaseDocumentStrategy
 from services.documents.factory import DocumentFactory
 from services.document_role_service import DocumentRoleService
 from services.document_template_service import DocumentTemplateService
+from services.tenant_entity_access_service import TenantEntityAccessService
 from services.tenant_scope_service import (
     tenant_or_fully_legacy_scope_clause,
     tenant_or_legacy_owner_scope_clause,
@@ -265,19 +266,25 @@ class DocumentService:
         scope_service_line_quantities: Any = None,
         scope_product_line_ids: Optional[List[int]] = None,
         additional_conditions: Optional[str] = None,
+        *,
+        tenant_scope: TenantScope,
     ) -> dict:
         if doc_type not in DocumentService.ALLOWED_DOC_TYPES:
             raise ValueError(f"Unsupported document type: {doc_type}")
 
+        owned_order = await TenantEntityAccessService.get_order(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+        )
+        if owned_order is None:
+            raise ValueError("Order not found")
         await DocumentService.ensure_order_documents_mutable(session, order_id)
 
         if additional_conditions is not None:
-            order = await session.get(Order, order_id)
-            if not order:
-                raise ValueError("Order not found")
             cleaned_conditions = additional_conditions.strip()
-            order.additional_conditions = cleaned_conditions or None
-            session.add(order)
+            owned_order.additional_conditions = cleaned_conditions or None
+            session.add(owned_order)
             await session.flush()
 
         doc = await DocumentService.create_or_get_document(
@@ -313,14 +320,23 @@ class DocumentService:
     @staticmethod
     async def get_download_stream(
         session: AsyncSession,
-        doc_id: int
+        doc_id: int,
+        *,
+        tenant_scope: TenantScope | None = None,
     ) -> tuple:
         """
         Возвращает поток данных PDF и имя файла.
         """
-        query = select(OrderDocument).where(OrderDocument.id == doc_id)
-        result = await session.execute(query)
-        document = result.scalar_one_or_none()
+        if tenant_scope is None:
+            query = select(OrderDocument).where(OrderDocument.id == doc_id)
+            result = await session.execute(query)
+            document = result.scalar_one_or_none()
+        else:
+            document = await TenantEntityAccessService.get_order_document(
+                session,
+                doc_id,
+                tenant_scope=tenant_scope,
+            )
 
         if not document:
             return None, None
@@ -342,15 +358,20 @@ class DocumentService:
     @staticmethod
     async def delete_document(
         session: AsyncSession,
-        doc_id: int
+        doc_id: int,
+        *,
+        tenant_scope: TenantScope,
     ) -> Optional[int]:
         """
         Удаляет документ из БД и Google Drive.
         Возвращает order_id удаленного документа.
         """
-        query = select(OrderDocument).where(OrderDocument.id == doc_id)
-        result = await session.execute(query)
-        document = result.scalar_one_or_none()
+        document = await TenantEntityAccessService.get_order_document(
+            session,
+            doc_id,
+            tenant_scope=tenant_scope,
+            for_update=True,
+        )
 
         if not document:
             return None
@@ -383,13 +404,21 @@ class DocumentService:
     async def upload_document(
         session: AsyncSession,
         order_id: int,
-        file: "fastapi.UploadFile"
+        file: "fastapi.UploadFile",
+        *,
+        tenant_scope: TenantScope,
     ) -> OrderDocument:
         """
         Загружает произвольный документ в Google Drive и связывает его с заказом.
         """
         import os
 
+        if await TenantEntityAccessService.get_order(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+        ) is None:
+            raise ValueError("Order not found")
         await DocumentService.ensure_order_documents_mutable(session, order_id)
         original_filename, suffix = DocumentService._validate_upload_file(file)
         tmp_path = await DocumentService._save_upload_to_temp(file, suffix)
@@ -489,8 +518,15 @@ class DocumentService:
         session: AsyncSession,
         doc_id: int,
         file: "fastapi.UploadFile",
+        *,
+        tenant_scope: TenantScope,
     ) -> Optional[OrderDocument]:
-        document = await session.get(OrderDocument, doc_id)
+        document = await TenantEntityAccessService.get_order_document(
+            session,
+            doc_id,
+            tenant_scope=tenant_scope,
+            for_update=True,
+        )
         if not document:
             return None
 
@@ -521,9 +557,18 @@ class DocumentService:
         contract_date: datetime,
         external_url: Optional[str] = None,
         file: object = None,
+        tenant_scope: TenantScope,
     ) -> OrderDocument:
         """Registers a customer-provided one-time contract for closing docs."""
-        order = await DocumentService.ensure_order_documents_mutable(session, order_id)
+        order = await TenantEntityAccessService.get_order(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+            for_update=True,
+        )
+        if order is None:
+            raise ValueError("Order not found")
+        await DocumentService.ensure_order_documents_mutable(session, order_id)
 
         cleaned_number = str(number or "").strip()
         if not cleaned_number:
@@ -568,12 +613,23 @@ class DocumentService:
     @staticmethod
     async def list_order_documents(
         session: AsyncSession,
-        order_id: int
-    ) -> list[OrderDocument]:
+        order_id: int,
+        *,
+        tenant_scope: TenantScope,
+    ) -> Optional[list[OrderDocument]]:
         """Возвращает список документов заказа"""
-        query = select(OrderDocument).where(
-            OrderDocument.order_id == order_id
-        ).order_by(OrderDocument.created_at.desc())
+        owned_order = await TenantEntityAccessService.get_order(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+        )
+        if owned_order is None:
+            return None
+        query = (
+            select(OrderDocument)
+            .where(OrderDocument.order_id == order_id)
+            .order_by(OrderDocument.created_at.desc())
+        )
 
         result = await session.execute(query)
         return result.scalars().all()

--- a/services/email_lead_import_job_service.py
+++ b/services/email_lead_import_job_service.py
@@ -120,6 +120,7 @@ class EmailLeadImportJobService:
                         notified_admins = await NotificationService.notify_admins_email_leads_imported(
                             session,
                             result.created_order_ids,
+                            tenant_scope=tenant_scope,
                         )
                     except Exception:
                         logger.exception(

--- a/services/email_lead_intake_service.py
+++ b/services/email_lead_intake_service.py
@@ -11,13 +11,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
 from core.config import settings
-from models import LeadSource, Order, OrderStatus
+from models import Customer, LeadSource, Order, OrderStatus
 from services.bank_email_parser_service import BankEmailParserService
 from services.order_service import OrderService
-from services.tenant_scope_service import (
-    TenantScope,
-    tenant_or_fully_legacy_scope_clause,
-)
+from services.tenant_entity_access_service import TenantEntityAccessService
+from services.tenant_scope_service import TenantScope
 
 
 @dataclass
@@ -204,9 +202,11 @@ class EmailLeadIntakeService:
             predicates.append(cast(Order.technical_meta, String).ilike(f"%{message_id}%"))
         result = await session.execute(
             select(Order)
+            .outerjoin(Customer, Customer.id == Order.customer_id)
             .where(
                 Order.lead_source == LeadSource.EMAIL,
-                tenant_or_fully_legacy_scope_clause(Order, tenant_scope),
+                TenantEntityAccessService.order_clause(tenant_scope),
+                TenantEntityAccessService.order_customer_clause(tenant_scope),
                 or_(*predicates),
             )
             .order_by(Order.created_at.desc())

--- a/services/equipment_component_service.py
+++ b/services/equipment_component_service.py
@@ -5,6 +5,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
 from models import EquipmentComponent
+from models.tenancy import TenantScope
 from services.equipment_service import EquipmentService
 
 
@@ -15,7 +16,14 @@ class EquipmentComponentService:
         *,
         equipment_id: int,
         include_archived: bool = False,
+        tenant_scope: TenantScope,
     ) -> list[Dict[str, Any]]:
+        if not await EquipmentService._get_equipment(
+            session,
+            equipment_id,
+            tenant_scope=tenant_scope,
+        ):
+            return []
         filters = [EquipmentComponent.equipment_id == equipment_id]
         if not include_archived:
             filters.append(EquipmentComponent.is_archived == False)
@@ -36,8 +44,13 @@ class EquipmentComponentService:
         *,
         equipment_id: int,
         payload: Dict[str, Any],
+        tenant_scope: TenantScope,
     ) -> Optional[Dict[str, Any]]:
-        equipment = await EquipmentService._get_equipment(session, equipment_id)
+        equipment = await EquipmentService._get_equipment(
+            session,
+            equipment_id,
+            tenant_scope=tenant_scope,
+        )
         if not equipment:
             return None
 
@@ -66,7 +79,14 @@ class EquipmentComponentService:
         equipment_id: int,
         component_id: int,
         payload: Dict[str, Any],
+        tenant_scope: TenantScope,
     ) -> Optional[Dict[str, Any]]:
+        if not await EquipmentService._get_equipment(
+            session,
+            equipment_id,
+            tenant_scope=tenant_scope,
+        ):
+            return None
         component = await EquipmentService._get_equipment_component(
             session,
             equipment_id=equipment_id,

--- a/services/equipment_history_service.py
+++ b/services/equipment_history_service.py
@@ -1,13 +1,15 @@
 from datetime import datetime
 from typing import Any, Dict, Optional
 
-from sqlalchemy import func
+from sqlalchemy import and_, func, or_
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 from sqlmodel import select
 
-from models import EquipmentServiceEventType, EquipmentServiceHistory, Order
+from models import Customer, EquipmentServiceEventType, EquipmentServiceHistory, Order
+from models.tenancy import TenantScope
 from services.equipment_service import EquipmentService
+from services.tenant_entity_access_service import TenantEntityAccessService
 
 
 class EquipmentHistoryService:
@@ -18,17 +20,40 @@ class EquipmentHistoryService:
         equipment_id: int,
         page: int,
         limit: int,
+        tenant_scope: TenantScope,
     ) -> Optional[Dict[str, Any]]:
-        if not await EquipmentService._get_equipment(session, equipment_id):
+        if not await EquipmentService._get_equipment(
+            session,
+            equipment_id,
+            tenant_scope=tenant_scope,
+        ):
             return None
 
+        history_scope = or_(
+            EquipmentServiceHistory.order_id.is_(None),
+            and_(
+                TenantEntityAccessService.order_clause(tenant_scope),
+                TenantEntityAccessService.order_customer_clause(tenant_scope),
+            ),
+        )
         count_result = await session.execute(
-            select(func.count(EquipmentServiceHistory.id)).where(EquipmentServiceHistory.equipment_id == equipment_id)
+            select(func.count(EquipmentServiceHistory.id))
+            .outerjoin(Order, Order.id == EquipmentServiceHistory.order_id)
+            .outerjoin(Customer, Customer.id == Order.customer_id)
+            .where(
+                EquipmentServiceHistory.equipment_id == equipment_id,
+                history_scope,
+            )
         )
         total = int(count_result.scalar() or 0)
         result = await session.execute(
             select(EquipmentServiceHistory)
-            .where(EquipmentServiceHistory.equipment_id == equipment_id)
+            .outerjoin(Order, Order.id == EquipmentServiceHistory.order_id)
+            .outerjoin(Customer, Customer.id == Order.customer_id)
+            .where(
+                EquipmentServiceHistory.equipment_id == equipment_id,
+                history_scope,
+            )
             .options(selectinload(EquipmentServiceHistory.order))
             .order_by(EquipmentServiceHistory.event_date.desc(), EquipmentServiceHistory.id.desc())
             .offset((page - 1) * limit)
@@ -65,8 +90,13 @@ class EquipmentHistoryService:
         *,
         equipment_id: int,
         payload: Dict[str, Any],
+        tenant_scope: TenantScope,
     ) -> Optional[Dict[str, Any]]:
-        equipment = await EquipmentService._get_equipment(session, equipment_id)
+        equipment = await EquipmentService._get_equipment(
+            session,
+            equipment_id,
+            tenant_scope=tenant_scope,
+        )
         if not equipment:
             return None
 
@@ -76,6 +106,7 @@ class EquipmentHistoryService:
                 session,
                 equipment=equipment,
                 order_id=int(order_id),
+                tenant_scope=tenant_scope,
             )
 
         event_type = EquipmentService._normalize_event_type(payload.get("event_type"))
@@ -186,14 +217,20 @@ class EquipmentHistoryService:
         *,
         equipment_id: int,
         payload: Dict[str, Any],
+        tenant_scope: TenantScope,
     ) -> Optional[Dict[str, Any]]:
-        equipment = await EquipmentService._get_equipment(session, equipment_id)
+        equipment = await EquipmentService._get_equipment(
+            session,
+            equipment_id,
+            tenant_scope=tenant_scope,
+        )
         if not equipment:
             return None
         order = await EquipmentService._validate_order_link(
             session,
             equipment=equipment,
             order_id=int(payload["order_id"]),
+            tenant_scope=tenant_scope,
         )
         order_id = int(order.id)
         await EquipmentService._lock_order_for_history_sync(session, order_id=order_id)

--- a/services/equipment_link_service.py
+++ b/services/equipment_link_service.py
@@ -6,14 +6,25 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 from sqlmodel import select
 
-from models import CustomerEquipment, EquipmentOrderLink, Order
+from models import Customer, CustomerEquipment, EquipmentOrderLink, Order
+from models.tenancy import TenantScope
 from services.equipment_service import EquipmentService
+from services.tenant_entity_access_service import TenantEntityAccessService
 
 
 class EquipmentLinkService:
     @staticmethod
-    async def list_for_order(session: AsyncSession, *, order_id: int) -> dict[str, Any] | None:
-        order = await session.get(Order, order_id)
+    async def list_for_order(
+        session: AsyncSession,
+        *,
+        order_id: int,
+        tenant_scope: TenantScope,
+    ) -> dict[str, Any] | None:
+        order = await TenantEntityAccessService.get_order(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+        )
         if not order:
             return None
         result = await session.execute(
@@ -46,6 +57,7 @@ class EquipmentLinkService:
                 session,
                 equipment_id=int(equipment.id or 0),
                 history_limit=3,
+                tenant_scope=tenant_scope,
             )
             if detail:
                 items.append(
@@ -65,12 +77,26 @@ class EquipmentLinkService:
         order_id: int,
         equipment_id: int,
         role: str,
+        tenant_scope: TenantScope,
     ) -> dict[str, Any] | None:
-        order = await session.get(Order, order_id)
-        equipment = await session.get(CustomerEquipment, equipment_id)
+        order = await TenantEntityAccessService.get_order(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+        )
+        equipment = await TenantEntityAccessService.get_equipment(
+            session,
+            equipment_id,
+            tenant_scope=tenant_scope,
+        )
         if not order or not equipment:
             return None
-        await EquipmentService._validate_order_link(session, equipment=equipment, order_id=order_id)
+        await EquipmentService._validate_order_link(
+            session,
+            equipment=equipment,
+            order_id=order_id,
+            tenant_scope=tenant_scope,
+        )
         link = await EquipmentService._ensure_equipment_order_link(
             session,
             equipment_id=equipment_id,
@@ -78,7 +104,12 @@ class EquipmentLinkService:
             role=role,
         )
         await session.commit()
-        detail = await EquipmentService.get_equipment_detail(session, equipment_id=equipment_id, history_limit=3)
+        detail = await EquipmentService.get_equipment_detail(
+            session,
+            equipment_id=equipment_id,
+            history_limit=3,
+            tenant_scope=tenant_scope,
+        )
         return {
             "link_id": int(link.id or 0),
             "role": link.role,
@@ -87,7 +118,19 @@ class EquipmentLinkService:
         }
 
     @staticmethod
-    async def unlink(session: AsyncSession, *, order_id: int, link_id: int) -> bool:
+    async def unlink(
+        session: AsyncSession,
+        *,
+        order_id: int,
+        link_id: int,
+        tenant_scope: TenantScope,
+    ) -> bool:
+        if await TenantEntityAccessService.get_order(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+        ) is None:
+            return False
         result = await session.execute(
             select(EquipmentOrderLink).where(
                 EquipmentOrderLink.id == link_id,
@@ -97,7 +140,13 @@ class EquipmentLinkService:
         link = result.scalars().first()
         if not link:
             return False
-        equipment = await session.get(CustomerEquipment, link.equipment_id)
+        equipment = await TenantEntityAccessService.get_equipment(
+            session,
+            link.equipment_id,
+            tenant_scope=tenant_scope,
+        )
+        if equipment is None:
+            return False
         if equipment and equipment.source_order_id == order_id:
             equipment.source_order_id = None
             session.add(equipment)
@@ -106,11 +155,28 @@ class EquipmentLinkService:
         return True
 
     @staticmethod
-    async def list_linked_orders(session: AsyncSession, *, equipment_id: int) -> list[dict[str, Any]]:
+    async def list_linked_orders(
+        session: AsyncSession,
+        *,
+        equipment_id: int,
+        tenant_scope: TenantScope,
+    ) -> list[dict[str, Any]]:
+        equipment = await TenantEntityAccessService.get_equipment(
+            session,
+            equipment_id,
+            tenant_scope=tenant_scope,
+        )
+        if equipment is None:
+            return []
         result = await session.execute(
             select(EquipmentOrderLink, Order)
             .join(Order, Order.id == EquipmentOrderLink.order_id)
-            .where(EquipmentOrderLink.equipment_id == equipment_id)
+            .outerjoin(Customer, Customer.id == Order.customer_id)
+            .where(
+                EquipmentOrderLink.equipment_id == equipment_id,
+                TenantEntityAccessService.order_clause(tenant_scope),
+                TenantEntityAccessService.order_customer_clause(tenant_scope),
+            )
             .options(selectinload(Order.customer))
             .order_by(Order.created_at.desc(), Order.id.desc())
         )
@@ -127,9 +193,12 @@ class EquipmentLinkService:
                     "created_at": order.created_at,
                 }
             )
-        equipment = await session.get(CustomerEquipment, equipment_id)
         if equipment and equipment.source_order_id and int(equipment.source_order_id) not in seen:
-            order = await session.get(Order, int(equipment.source_order_id))
+            order = await TenantEntityAccessService.get_order(
+                session,
+                int(equipment.source_order_id),
+                tenant_scope=tenant_scope,
+            )
             if order:
                 items.append(
                     {

--- a/services/equipment_registry_service.py
+++ b/services/equipment_registry_service.py
@@ -7,12 +7,15 @@ from sqlalchemy.orm import selectinload
 from sqlmodel import select
 
 from models import (
+    Customer,
     CustomerBranch,
     CustomerEquipment,
     EquipmentServiceHistory,
     EquipmentWarrantyCoverage,
 )
+from models.tenancy import TenantScope
 from services.equipment_service import EquipmentService
+from services.tenant_scope_service import tenant_or_legacy_owner_scope_clause
 
 
 class EquipmentRegistryService:
@@ -27,8 +30,13 @@ class EquipmentRegistryService:
         include_archived: bool = False,
         q: str | None = None,
         attention: str | None = None,
+        tenant_scope: TenantScope,
     ) -> Optional[Dict[str, Any]]:
-        if customer_id is not None and not await EquipmentService._ensure_customer_exists(session, customer_id):
+        if customer_id is not None and not await EquipmentService._ensure_customer_exists(
+            session,
+            customer_id,
+            tenant_scope=tenant_scope,
+        ):
             return None
         if customer_id is not None and customer_branch_id is not None:
             await EquipmentService._ensure_branch_for_customer(
@@ -37,7 +45,7 @@ class EquipmentRegistryService:
                 customer_branch_id=customer_branch_id,
             )
 
-        filters = []
+        filters = [tenant_or_legacy_owner_scope_clause(Customer, tenant_scope)]
         if customer_id is not None:
             filters.append(CustomerEquipment.customer_id == customer_id)
         if customer_branch_id is not None:
@@ -111,10 +119,15 @@ class EquipmentRegistryService:
                 matching_equipment_ids = select(EquipmentWarrantyCoverage.equipment_id).where(*selected_conditions)
                 filters.append(CustomerEquipment.id.in_(matching_equipment_ids))
 
-        count_result = await session.execute(select(func.count(CustomerEquipment.id)).where(*filters))
+        count_result = await session.execute(
+            select(func.count(CustomerEquipment.id))
+            .join(Customer, Customer.id == CustomerEquipment.customer_id)
+            .where(*filters)
+        )
         total = int(count_result.scalar() or 0)
         result = await session.execute(
             select(CustomerEquipment)
+            .join(Customer, Customer.id == CustomerEquipment.customer_id)
             .options(
                 selectinload(CustomerEquipment.customer),
                 selectinload(CustomerEquipment.customer_branch),
@@ -217,8 +230,13 @@ class EquipmentRegistryService:
         *,
         equipment_id: int,
         history_limit: int,
+        tenant_scope: TenantScope,
     ) -> Optional[Dict[str, Any]]:
-        equipment = await EquipmentService._get_equipment(session, equipment_id)
+        equipment = await EquipmentService._get_equipment(
+            session,
+            equipment_id,
+            tenant_scope=tenant_scope,
+        )
         if not equipment:
             return None
         history = await EquipmentService.list_history(
@@ -226,11 +244,13 @@ class EquipmentRegistryService:
             equipment_id=equipment_id,
             page=1,
             limit=history_limit,
+            tenant_scope=tenant_scope,
         )
         components = await EquipmentService.list_components(
             session,
             equipment_id=equipment_id,
             include_archived=True,
+            tenant_scope=tenant_scope,
         )
         data = EquipmentService._to_equipment_item(equipment)
         data["components"] = components
@@ -246,5 +266,9 @@ class EquipmentRegistryService:
         coverage_models = list(coverage_result.scalars().all())
         data["coverages"] = [WarrantyService.to_item(item) for item in coverage_models]
         EquipmentService._apply_coverage_summary(data, coverage_models)
-        data["linked_orders"] = await EquipmentLinkService.list_linked_orders(session, equipment_id=equipment_id)
+        data["linked_orders"] = await EquipmentLinkService.list_linked_orders(
+            session,
+            equipment_id=equipment_id,
+            tenant_scope=tenant_scope,
+        )
         return data

--- a/services/equipment_service.py
+++ b/services/equipment_service.py
@@ -19,6 +19,8 @@ from models import (
     Supplier,
 )
 from services.tenant_scope_service import TenantScope
+from services.tenant_entity_access_service import TenantEntityAccessService
+from services.tenant_scope_service import tenant_or_legacy_owner_scope_clause
 
 
 class EquipmentService:
@@ -457,8 +459,22 @@ class EquipmentService:
         return preserved_payload
 
     @staticmethod
-    async def _ensure_customer_exists(session: AsyncSession, customer_id: int) -> Optional[Customer]:
-        return await session.get(Customer, customer_id)
+    async def _ensure_customer_exists(
+        session: AsyncSession,
+        customer_id: int,
+        *,
+        tenant_scope: TenantScope | None = None,
+    ) -> Optional[Customer]:
+        if tenant_scope is None:
+            return await session.get(Customer, customer_id)
+        return (
+            await session.execute(
+                select(Customer).where(
+                    Customer.id == customer_id,
+                    tenant_or_legacy_owner_scope_clause(Customer, tenant_scope),
+                )
+            )
+        ).scalars().first()
 
     @staticmethod
     async def _ensure_product_exists(session: AsyncSession, product_id: int) -> Product:
@@ -480,8 +496,17 @@ class EquipmentService:
         *,
         customer_id: int,
         source_order_id: int,
+        tenant_scope: TenantScope | None = None,
     ) -> Order:
-        order = await session.get(Order, source_order_id)
+        order = (
+            await TenantEntityAccessService.get_order(
+                session,
+                source_order_id,
+                tenant_scope=tenant_scope,
+            )
+            if tenant_scope is not None
+            else await session.get(Order, source_order_id)
+        )
         if not order:
             raise ValueError("Source order not found")
         if order.customer_id is None:
@@ -505,7 +530,18 @@ class EquipmentService:
         return branch
 
     @staticmethod
-    async def _get_equipment(session: AsyncSession, equipment_id: int) -> Optional[CustomerEquipment]:
+    async def _get_equipment(
+        session: AsyncSession,
+        equipment_id: int,
+        *,
+        tenant_scope: TenantScope | None = None,
+    ) -> Optional[CustomerEquipment]:
+        if tenant_scope is not None:
+            return await TenantEntityAccessService.get_equipment(
+                session,
+                equipment_id,
+                tenant_scope=tenant_scope,
+            )
         result = await session.execute(select(CustomerEquipment).where(CustomerEquipment.id == equipment_id))
         return result.scalars().first()
 
@@ -530,8 +566,17 @@ class EquipmentService:
         *,
         equipment: CustomerEquipment,
         order_id: int,
+        tenant_scope: TenantScope | None = None,
     ) -> Order:
-        order = await session.get(Order, order_id)
+        order = (
+            await TenantEntityAccessService.get_order(
+                session,
+                order_id,
+                tenant_scope=tenant_scope,
+            )
+            if tenant_scope is not None
+            else await session.get(Order, order_id)
+        )
         if not order:
             raise ValueError("Order not found")
         if order.customer_id is None:
@@ -557,45 +602,57 @@ class EquipmentService:
         include_archived: bool = False,
         q: str | None = None,
         attention: str | None = None,
+        tenant_scope: TenantScope,
     ) -> Optional[Dict[str, Any]]:
         from services.equipment_registry_service import EquipmentRegistryService
         return await EquipmentRegistryService.list_equipment(
             session, customer_id=customer_id, customer_branch_id=customer_branch_id,
             page=page, limit=limit, include_archived=include_archived, q=q, attention=attention,
+            tenant_scope=tenant_scope,
         )
 
     @staticmethod
     async def get_equipment_detail(
         session: AsyncSession, *, equipment_id: int, history_limit: int,
+        tenant_scope: TenantScope,
     ) -> Optional[Dict[str, Any]]:
         from services.equipment_registry_service import EquipmentRegistryService
         return await EquipmentRegistryService.get_equipment_detail(
             session, equipment_id=equipment_id, history_limit=history_limit,
+            tenant_scope=tenant_scope,
         )
 
     @staticmethod
     async def create_equipment(
-        session: AsyncSession, *, payload: Dict[str, Any],
+        session: AsyncSession, *, payload: Dict[str, Any], tenant_scope: TenantScope,
     ) -> Optional[Dict[str, Any]]:
         from services.equipment_workflow_service import EquipmentWorkflowService
-        return await EquipmentWorkflowService.create_equipment(session, payload=payload)
+        return await EquipmentWorkflowService.create_equipment(
+            session,
+            payload=payload,
+            tenant_scope=tenant_scope,
+        )
 
     @staticmethod
     async def update_equipment(
         session: AsyncSession, *, equipment_id: int, payload: Dict[str, Any],
+        tenant_scope: TenantScope,
     ) -> Optional[Dict[str, Any]]:
         from services.equipment_workflow_service import EquipmentWorkflowService
         return await EquipmentWorkflowService.update_equipment(
             session, equipment_id=equipment_id, payload=payload,
+            tenant_scope=tenant_scope,
         )
 
     @staticmethod
     async def create_equipment_from_order(
         session: AsyncSession, *, order_id: int, payload: Dict[str, Any],
+        tenant_scope: TenantScope,
     ) -> Dict[str, Any]:
         from services.equipment_workflow_service import EquipmentWorkflowService
         return await EquipmentWorkflowService.create_equipment_from_order(
             session, order_id=order_id, payload=payload,
+            tenant_scope=tenant_scope,
         )
 
     @staticmethod
@@ -615,37 +672,45 @@ class EquipmentService:
     @staticmethod
     async def list_components(
         session: AsyncSession, *, equipment_id: int, include_archived: bool = False,
+        tenant_scope: TenantScope,
     ) -> list[Dict[str, Any]]:
         from services.equipment_component_service import EquipmentComponentService
         return await EquipmentComponentService.list_components(
             session, equipment_id=equipment_id, include_archived=include_archived,
+            tenant_scope=tenant_scope,
         )
 
     @staticmethod
     async def create_component(
         session: AsyncSession, *, equipment_id: int, payload: Dict[str, Any],
+        tenant_scope: TenantScope,
     ) -> Optional[Dict[str, Any]]:
         from services.equipment_component_service import EquipmentComponentService
         return await EquipmentComponentService.create_component(
             session, equipment_id=equipment_id, payload=payload,
+            tenant_scope=tenant_scope,
         )
 
     @staticmethod
     async def update_component(
         session: AsyncSession, *, equipment_id: int, component_id: int, payload: Dict[str, Any],
+        tenant_scope: TenantScope,
     ) -> Optional[Dict[str, Any]]:
         from services.equipment_component_service import EquipmentComponentService
         return await EquipmentComponentService.update_component(
             session, equipment_id=equipment_id, component_id=component_id, payload=payload,
+            tenant_scope=tenant_scope,
         )
 
     @staticmethod
     async def list_history(
         session: AsyncSession, *, equipment_id: int, page: int, limit: int,
+        tenant_scope: TenantScope,
     ) -> Optional[Dict[str, Any]]:
         from services.equipment_history_service import EquipmentHistoryService
         return await EquipmentHistoryService.list_history(
             session, equipment_id=equipment_id, page=page, limit=limit,
+            tenant_scope=tenant_scope,
         )
 
     @staticmethod
@@ -665,10 +730,12 @@ class EquipmentService:
     @staticmethod
     async def add_history(
         session: AsyncSession, *, equipment_id: int, payload: Dict[str, Any],
+        tenant_scope: TenantScope,
     ) -> Optional[Dict[str, Any]]:
         from services.equipment_history_service import EquipmentHistoryService
         return await EquipmentHistoryService.add_history(
             session, equipment_id=equipment_id, payload=payload,
+            tenant_scope=tenant_scope,
         )
 
     @staticmethod
@@ -689,8 +756,10 @@ class EquipmentService:
     @staticmethod
     async def add_history_from_repair_order(
         session: AsyncSession, *, equipment_id: int, payload: Dict[str, Any],
+        tenant_scope: TenantScope,
     ) -> Optional[Dict[str, Any]]:
         from services.equipment_history_service import EquipmentHistoryService
         return await EquipmentHistoryService.add_history_from_repair_order(
             session, equipment_id=equipment_id, payload=payload,
+            tenant_scope=tenant_scope,
         )

--- a/services/equipment_workflow_service.py
+++ b/services/equipment_workflow_service.py
@@ -7,6 +7,7 @@ from sqlmodel import select
 
 from models import CustomerEquipment, EquipmentComponent, Order, OrderProductLink, Product
 from services.equipment_service import EquipmentService
+from services.tenant_entity_access_service import TenantEntityAccessService
 from services.tenant_scope_service import TenantScope
 
 
@@ -16,9 +17,14 @@ class EquipmentWorkflowService:
         session: AsyncSession,
         *,
         payload: Dict[str, Any],
+        tenant_scope: TenantScope,
     ) -> Optional[Dict[str, Any]]:
         customer_id = int(payload["customer_id"])
-        if not await EquipmentService._ensure_customer_exists(session, customer_id):
+        if not await EquipmentService._ensure_customer_exists(
+            session,
+            customer_id,
+            tenant_scope=tenant_scope,
+        ):
             return None
         customer_branch_id = payload.get("customer_branch_id")
         if customer_branch_id is not None:
@@ -38,6 +44,7 @@ class EquipmentWorkflowService:
                 session,
                 customer_id=customer_id,
                 source_order_id=int(source_order_id),
+                tenant_scope=tenant_scope,
             )
             if customer_branch_id is None:
                 customer_branch_id = source_order.customer_branch_id
@@ -116,8 +123,13 @@ class EquipmentWorkflowService:
         *,
         equipment_id: int,
         payload: Dict[str, Any],
+        tenant_scope: TenantScope,
     ) -> Optional[Dict[str, Any]]:
-        equipment = await EquipmentService._get_equipment(session, equipment_id)
+        equipment = await EquipmentService._get_equipment(
+            session,
+            equipment_id,
+            tenant_scope=tenant_scope,
+        )
         if not equipment:
             return None
 
@@ -150,6 +162,7 @@ class EquipmentWorkflowService:
                     session,
                     customer_id=int(equipment.customer_id),
                     source_order_id=int(source_order_id),
+                    tenant_scope=tenant_scope,
                 )
                 if (
                     source_order.customer_branch_id is not None
@@ -214,18 +227,19 @@ class EquipmentWorkflowService:
         *,
         order_id: int,
         payload: Dict[str, Any],
+        tenant_scope: TenantScope,
     ) -> Dict[str, Any]:
-        result = await session.execute(
-            select(Order)
-            .where(Order.id == order_id)
-            .options(
+        order = await TenantEntityAccessService.get_order(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+            options=(
                 selectinload(Order.customer),
                 selectinload(Order.customer_branch),
                 selectinload(Order.proposals),
                 selectinload(Order.product_links).selectinload(OrderProductLink.product).selectinload(Product.brand),
-            )
+            ),
         )
-        order = result.scalars().first()
         if not order:
             raise ValueError("Order not found")
         if order.customer_id is None:
@@ -391,6 +405,7 @@ class EquipmentWorkflowService:
                 session,
                 equipment_id=equipment_id,
                 history_limit=0,
+                tenant_scope=tenant_scope,
             )
             if detail:
                 items.append(detail)
@@ -407,15 +422,15 @@ class EquipmentWorkflowService:
         equipment_id: int,
         tenant_scope: TenantScope,
     ) -> Optional[Dict[str, Any]]:
-        result = await session.execute(
-            select(CustomerEquipment)
-            .where(CustomerEquipment.id == equipment_id)
-            .options(
+        equipment = await TenantEntityAccessService.get_equipment(
+            session,
+            equipment_id,
+            tenant_scope=tenant_scope,
+            options=(
                 selectinload(CustomerEquipment.customer),
                 selectinload(CustomerEquipment.customer_branch),
-            )
+            ),
         )
-        equipment = result.scalars().first()
         if not equipment or equipment.is_archived or not equipment.customer:
             return None
 
@@ -468,4 +483,8 @@ class EquipmentWorkflowService:
             role="maintenance",
         )
         await session.commit()
-        return await OrderService.get_order_detail_for_manager(session, order_id)
+        return await OrderService.get_order_detail_for_manager(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+        )

--- a/services/installation_estimate_lead_service.py
+++ b/services/installation_estimate_lead_service.py
@@ -18,7 +18,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
-from models import LeadSource, Order, OrderStatus
+from models import Customer, LeadSource, Order, OrderStatus
 from schemas_installation_estimate import (
     InstallationEstimateLeadPayload,
     InstallationEstimateLeadResponse,
@@ -33,11 +33,9 @@ from services.communications.installation_activation_fence import (
 from services.communications.template_registry import (
     INSTALLATION_ESTIMATE_LEAD_CREATED_EVENT,
 )
+from services.tenant_entity_access_service import TenantEntityAccessService
 from services.order_service import OrderService
-from services.tenant_scope_service import (
-    TenantScope,
-    tenant_or_fully_legacy_scope_clause,
-)
+from services.tenant_scope_service import TenantScope
 from services.private_attachment_storage_service import (
     PrivateAttachmentStorage,
     get_private_attachment_storage,
@@ -264,6 +262,7 @@ class InstallationEstimateLeadService:
                     storage=selected_storage,
                     created_storage_keys=created_storage_keys,
                     commit=False,
+                    tenant_scope=tenant_scope,
                 )
 
             await IntegrationOutboxService.enqueue(
@@ -336,9 +335,11 @@ class InstallationEstimateLeadService:
     ) -> Order | None:
         return await session.scalar(
             select(Order)
+            .outerjoin(Customer, Customer.id == Order.customer_id)
             .where(
                 Order.source_fingerprint == fingerprint,
-                tenant_or_fully_legacy_scope_clause(Order, tenant_scope),
+                TenantEntityAccessService.order_clause(tenant_scope),
+                TenantEntityAccessService.order_customer_clause(tenant_scope),
             )
             .limit(1)
         )

--- a/services/installer_service.py
+++ b/services/installer_service.py
@@ -2,7 +2,7 @@ from typing import Optional
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select, or_, func
 
-from models import Installer, StaffUser
+from models import Installer, StaffUser, TenantMembership
 from models.tenancy import TenantScope
 from schemas import (
     ManagerInstallerCreatePayload,
@@ -12,12 +12,20 @@ from schemas import (
     Meta,
 )
 from services.staff_user_service import StaffUserService
+from services.staff_tenant_membership_service import StaffTenantMembershipService
 
 class ManagerInstallerService:
     @staticmethod
-    def _response_from_installer(inst: Installer, staff_user: StaffUser | None = None) -> ManagerInstallerResponse:
+    def _response_from_installer(
+        inst: Installer,
+        staff_user: StaffUser | None = None,
+        *,
+        tenant_is_active: bool | None = None,
+    ) -> ManagerInstallerResponse:
         status_active = (
-            StaffUserService.is_active(staff_user)
+            tenant_is_active
+            if tenant_is_active is not None
+            else StaffUserService.is_active(staff_user)
             if staff_user is not None
             else bool(inst.is_active)
         )
@@ -40,10 +48,73 @@ class ManagerInstallerService:
         )
 
     @classmethod
-    async def _staff_by_legacy_installer_id(cls, session: AsyncSession) -> dict[int, StaffUser]:
-        result = await session.execute(select(StaffUser).where(StaffUser.legacy_installer_id.is_not(None)))
+    async def _staff_by_legacy_installer_id(
+        cls,
+        session: AsyncSession,
+        *,
+        tenant_scope: TenantScope,
+        active_membership_only: bool = False,
+    ) -> dict[int, StaffUser]:
+        stmt = (
+            select(StaffUser)
+            .join(
+                TenantMembership,
+                TenantMembership.staff_user_id == StaffUser.id,
+            )
+            .where(
+                StaffUser.legacy_installer_id.is_not(None),
+                TenantMembership.tenant_id == tenant_scope.tenant_id,
+            )
+        )
+        if active_membership_only:
+            stmt = stmt.where(TenantMembership.status == "active")
+        result = await session.execute(stmt)
         users = list(result.scalars().all())
         return {int(user.legacy_installer_id): user for user in users if user.legacy_installer_id is not None}
+
+    @staticmethod
+    async def _active_tenant_installer_ids(
+        session: AsyncSession,
+        *,
+        tenant_scope: TenantScope,
+    ) -> set[int]:
+        result = await session.execute(
+            select(StaffUser.legacy_installer_id)
+            .join(
+                TenantMembership,
+                TenantMembership.staff_user_id == StaffUser.id,
+            )
+            .where(
+                StaffUser.legacy_installer_id.is_not(None),
+                TenantMembership.tenant_id == tenant_scope.tenant_id,
+                TenantMembership.status == "active",
+            )
+        )
+        return {int(installer_id) for installer_id in result.scalars().all()}
+
+    @staticmethod
+    def _tenant_installer_clause(tenant_scope: TenantScope):
+        tenant_installer_ids = (
+            select(StaffUser.legacy_installer_id)
+            .join(
+                TenantMembership,
+                TenantMembership.staff_user_id == StaffUser.id,
+            )
+            .where(
+                StaffUser.legacy_installer_id.is_not(None),
+                TenantMembership.tenant_id == tenant_scope.tenant_id,
+            )
+        )
+        if not tenant_scope.is_system:
+            return Installer.id.in_(tenant_installer_ids)
+
+        all_linked_installer_ids = select(StaffUser.legacy_installer_id).where(
+            StaffUser.legacy_installer_id.is_not(None)
+        )
+        return or_(
+            Installer.id.in_(tenant_installer_ids),
+            Installer.id.not_in(all_linked_installer_ids),
+        )
 
     @classmethod
     async def get_all(
@@ -52,14 +123,21 @@ class ManagerInstallerService:
         page: int = 1,
         limit: int = 100,
         search: Optional[str] = None,
+        *,
+        tenant_scope: TenantScope,
     ) -> ManagerInstallerListResponse:
-        stmt = select(Installer)
+        stmt = select(Installer).where(cls._tenant_installer_clause(tenant_scope))
 
         if search:
             search_query = f"%{search.lower()}%"
             staff_match = select(StaffUser.legacy_installer_id).where(
                 StaffUser.legacy_installer_id.is_not(None),
                 func.lower(StaffUser.display_name).like(search_query),
+                StaffUser.id.in_(
+                    select(TenantMembership.staff_user_id).where(
+                        TenantMembership.tenant_id == tenant_scope.tenant_id,
+                    )
+                ),
             )
             stmt = stmt.where(or_(func.lower(Installer.name).like(search_query), Installer.id.in_(staff_match)))
 
@@ -73,10 +151,26 @@ class ManagerInstallerService:
         res = await session.execute(stmt)
         installers = res.scalars().all()
 
-        staff_by_installer_id = await cls._staff_by_legacy_installer_id(session)
+        staff_by_installer_id = await cls._staff_by_legacy_installer_id(
+            session,
+            tenant_scope=tenant_scope,
+        )
+        active_installer_ids = await cls._active_tenant_installer_ids(
+            session,
+            tenant_scope=tenant_scope,
+        )
         items = []
         for inst in installers:
-            items.append(cls._response_from_installer(inst, staff_by_installer_id.get(int(inst.id))))
+            staff_user = staff_by_installer_id.get(int(inst.id))
+            items.append(
+                cls._response_from_installer(
+                    inst,
+                    staff_user,
+                    tenant_is_active=(int(inst.id) in active_installer_ids)
+                    if staff_user is not None
+                    else None,
+                )
+            )
 
         pages = (total + limit - 1) // limit if total > 0 else 1
         return ManagerInstallerListResponse(
@@ -108,7 +202,11 @@ class ManagerInstallerService:
         await session.commit()
         await session.refresh(inst)
         staff_user = await StaffUserService.get_by_legacy_installer_id(session, int(inst.id))
-        return cls._response_from_installer(inst, staff_user)
+        return cls._response_from_installer(
+            inst,
+            staff_user,
+            tenant_is_active=payload.is_active,
+        )
 
     @classmethod
     async def update(
@@ -123,11 +221,43 @@ class ManagerInstallerService:
         inst = res.scalar_one_or_none()
         if not inst:
             return None
+
+        staff_user = await StaffUserService.get_by_legacy_installer_id(
+            session,
+            installer_id,
+        )
+        membership = None
+        memberships = []
+        if staff_user is not None:
+            membership = await StaffTenantMembershipService.get_for_tenant(
+                session,
+                tenant_id=tenant_scope.tenant_id,
+                staff_user_id=int(staff_user.id or 0),
+            )
+            if membership is None:
+                return None
+            memberships = await StaffTenantMembershipService.list_for_staff(
+                session,
+                staff_user_id=int(staff_user.id or 0),
+                lock=True,
+            )
+            shared_fields: set[str] = set()
+            if payload.name is not None:
+                shared_fields.add("display_name")
+            if payload.default_rate is not None:
+                shared_fields.add("default_rate")
+            if payload.telegram_id is not None:
+                shared_fields.add("telegram_id")
+            StaffTenantMembershipService.validate_shared_identity_update(
+                changed_fields=shared_fields,
+                membership_count=len(memberships),
+                is_system_tenant=tenant_scope.is_system,
+            )
+        elif not tenant_scope.is_system:
+            return None
             
         if payload.name is not None:
             inst.name = payload.name
-        if payload.is_active is not None:
-            inst.is_active = payload.is_active
         if payload.default_rate is not None:
             inst.default_rate = payload.default_rate
         if payload.telegram_id is not None:
@@ -141,13 +271,40 @@ class ManagerInstallerService:
             tenant_scope=tenant_scope,
         )
         if payload.is_active is not None:
-            staff_user.status = StaffUserService.STATUS_ACTIVE if payload.is_active else StaffUserService.STATUS_INACTIVE
+            membership = await StaffTenantMembershipService.get_for_tenant(
+                session,
+                tenant_id=tenant_scope.tenant_id,
+                staff_user_id=int(staff_user.id or 0),
+            )
+            if membership is None:
+                return None
+            membership.status = "active" if payload.is_active else "disabled"
+            StaffTenantMembershipService.touch(membership)
+            session.add(membership)
+            memberships = await StaffTenantMembershipService.list_for_staff(
+                session,
+                staff_user_id=int(staff_user.id or 0),
+            )
+            staff_user.status = StaffTenantMembershipService.aggregate_staff_status(
+                memberships
+            )
+            inst.is_active = StaffUserService.is_active(staff_user)
             session.add(staff_user)
+            session.add(inst)
         await session.commit()
         await session.refresh(inst)
 
         staff_user = await StaffUserService.get_by_legacy_installer_id(session, int(inst.id))
-        return cls._response_from_installer(inst, staff_user)
+        membership = await StaffTenantMembershipService.get_for_tenant(
+            session,
+            tenant_id=tenant_scope.tenant_id,
+            staff_user_id=int(staff_user.id or 0),
+        )
+        return cls._response_from_installer(
+            inst,
+            staff_user,
+            tenant_is_active=bool(membership and membership.status == "active"),
+        )
 
     @classmethod
     async def search(
@@ -155,12 +312,15 @@ class ManagerInstallerService:
         session: AsyncSession,
         q: str,
         limit: int = 50,
+        *,
+        tenant_scope: TenantScope,
     ) -> ManagerInstallerListResponse:
         staff_users = await StaffUserService.find_active_executors_by_role(
             session,
             StaffUserService.ROLE_INSTALLER,
             search=q,
             limit=limit,
+            tenant_scope=tenant_scope,
         )
         items = [
             cls._response_from_staff_user(user)
@@ -168,9 +328,20 @@ class ManagerInstallerService:
             if user.legacy_installer_id is not None
         ]
 
-        staff_by_installer_id = await cls._staff_by_legacy_installer_id(session)
+        active_staff_by_installer_id = await cls._staff_by_legacy_installer_id(
+            session,
+            tenant_scope=tenant_scope,
+            active_membership_only=True,
+        )
+        tenant_staff_by_installer_id = await cls._staff_by_legacy_installer_id(
+            session,
+            tenant_scope=tenant_scope,
+        )
         if len(items) < limit:
-            stmt = select(Installer).where(Installer.is_active == True)
+            stmt = select(Installer).where(
+                Installer.is_active == True,
+                cls._tenant_installer_clause(tenant_scope),
+            )
 
             if q:
                 search_query = f"%{q.lower()}%"
@@ -184,12 +355,14 @@ class ManagerInstallerService:
             for inst in installers:
                 if inst.id in existing_response_ids:
                     continue
-                if inst.id in staff_by_installer_id:
-                    staff_user = staff_by_installer_id[inst.id]
+                if inst.id in active_staff_by_installer_id:
+                    staff_user = active_staff_by_installer_id[inst.id]
                     if StaffUserService.can_be_executor(staff_user, StaffUserService.ROLE_INSTALLER):
                         items.append(cls._response_from_installer(inst, staff_user))
                         if len(items) >= limit:
                             break
+                    continue
+                if inst.id in tenant_staff_by_installer_id:
                     continue
                 items.append(cls._response_from_installer(inst))
                 if len(items) >= limit:

--- a/services/lead_service.py
+++ b/services/lead_service.py
@@ -26,6 +26,7 @@ from services.tenant_scope_service import (
     tenant_or_fully_legacy_scope_clause,
     tenant_or_legacy_owner_scope_clause,
 )
+from services.tenant_entity_access_service import TenantEntityAccessService
 
 
 class LeadService:
@@ -183,6 +184,8 @@ class LeadService:
         session: AsyncSession,
         page: int,
         limit: int,
+        *,
+        tenant_scope: TenantScope,
         status: Optional[str] = None,
         source: Optional[str] = None,
         search: Optional[str] = None,
@@ -190,8 +193,9 @@ class LeadService:
         include_archived: bool = False,
         sort: str = "created_at_desc",
     ) -> Dict[str, Any]:
-        stmt = select(Lead)
-        count_stmt = select(func.count(Lead.id))
+        ownership_clause = TenantEntityAccessService.lead_clause(tenant_scope)
+        stmt = select(Lead).where(ownership_clause)
+        count_stmt = select(func.count(Lead.id)).where(ownership_clause)
 
         if not include_archived:
             stmt = stmt.where(Lead.archived_at.is_(None))
@@ -261,8 +265,19 @@ class LeadService:
         }
 
     @staticmethod
-    async def update_lead(session: AsyncSession, lead_id: int, payload: Any) -> Optional[Dict[str, Any]]:
-        lead = await session.get(Lead, lead_id)
+    async def update_lead(
+        session: AsyncSession,
+        lead_id: int,
+        payload: Any,
+        *,
+        tenant_scope: TenantScope,
+    ) -> Optional[Dict[str, Any]]:
+        lead = await TenantEntityAccessService.get_lead(
+            session,
+            lead_id,
+            tenant_scope=tenant_scope,
+            for_update=True,
+        )
         if not lead:
             return None
 
@@ -319,8 +334,19 @@ class LeadService:
         return LeadService._map_lead(lead)
 
     @staticmethod
-    async def mark_lead_lost(session: AsyncSession, lead_id: int, payload: Any) -> Optional[Dict[str, Any]]:
-        lead = await session.get(Lead, lead_id)
+    async def mark_lead_lost(
+        session: AsyncSession,
+        lead_id: int,
+        payload: Any,
+        *,
+        tenant_scope: TenantScope,
+    ) -> Optional[Dict[str, Any]]:
+        lead = await TenantEntityAccessService.get_lead(
+            session,
+            lead_id,
+            tenant_scope=tenant_scope,
+            for_update=True,
+        )
         if not lead:
             return None
 

--- a/services/notification_service.py
+++ b/services/notification_service.py
@@ -4,9 +4,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 from sqlmodel import select
 
+from models import Customer
 from models.order import BankReceipt, Order, OrderProductLink, OrderWorkStage
+from models.tenancy import TenantScope
 from services.bot_service import BotService
 from services.staff_user_service import StaffUserService
+from services.tenant_entity_access_service import TenantEntityAccessService
 
 logger = logging.getLogger(__name__)
 
@@ -33,8 +36,15 @@ class NotificationService:
     }
 
     @staticmethod
-    async def _admin_recipient_ids(session: AsyncSession) -> list[int]:
-        return await StaffUserService.get_active_owner_admin_telegram_recipient_ids(session)
+    async def _admin_recipient_ids(
+        session: AsyncSession,
+        *,
+        tenant_scope: TenantScope,
+    ) -> list[int]:
+        return await StaffUserService.get_active_owner_admin_telegram_recipient_ids(
+            session,
+            tenant_scope=tenant_scope,
+        )
 
     @staticmethod
     async def notify_admins_new_order(
@@ -43,20 +53,27 @@ class NotificationService:
         customer_name: str | None,
         customer_username: str | None,
         customer_phone: str | None,
+        *,
+        tenant_scope: TenantScope,
     ) -> None:
-        admin_ids = await NotificationService._admin_recipient_ids(session)
-        if not admin_ids:
-            return
-
-        stmt = (
-            select(Order)
-            .where(Order.id == order_id)
-            .options(selectinload(Order.product_links).selectinload(OrderProductLink.product))
+        order = await TenantEntityAccessService.get_order(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+            options=(
+                selectinload(Order.product_links).selectinload(
+                    OrderProductLink.product
+                ),
+            ),
         )
-        result = await session.execute(stmt)
-        order = result.scalar_one_or_none()
         if not order:
             logger.warning("NOTIFY_NEW_ORDER_SKIPPED missing_order_id=%s", order_id)
+            return
+        admin_ids = await NotificationService._admin_recipient_ids(
+            session,
+            tenant_scope=tenant_scope,
+        )
+        if not admin_ids:
             return
 
         message_lines = [
@@ -105,20 +122,22 @@ class NotificationService:
         order_id: int,
         *,
         source_label: str = "рабочий бот",
+        tenant_scope: TenantScope,
     ) -> int:
-        admin_ids = await NotificationService._admin_recipient_ids(session)
-        if not admin_ids:
-            return 0
-
-        stmt = (
-            select(Order)
-            .where(Order.id == order_id)
-            .options(selectinload(Order.customer))
+        order = await TenantEntityAccessService.get_order(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+            options=(selectinload(Order.customer),),
         )
-        result = await session.execute(stmt)
-        order = result.scalar_one_or_none()
         if not order:
             logger.warning("NOTIFY_STAFF_ORDER_SKIPPED missing_order_id=%s", order_id)
+            return 0
+        admin_ids = await NotificationService._admin_recipient_ids(
+            session,
+            tenant_scope=tenant_scope,
+        )
+        if not admin_ids:
             return 0
 
         customer = getattr(order, "customer", None)
@@ -184,23 +203,26 @@ class NotificationService:
     async def notify_admins_work_stage_status_changed(
         session: AsyncSession,
         stage_id: int,
+        *,
+        tenant_scope: TenantScope,
     ) -> int:
-        admin_ids = await NotificationService._admin_recipient_ids(session)
-        if not admin_ids:
-            return 0
-
-        stmt = (
-            select(OrderWorkStage)
-            .where(OrderWorkStage.id == stage_id)
-            .options(
+        stage = await TenantEntityAccessService.get_order_stage(
+            session,
+            stage_id,
+            tenant_scope=tenant_scope,
+            options=(
                 selectinload(OrderWorkStage.order).selectinload(Order.customer),
                 selectinload(OrderWorkStage.installer),
-            )
+            ),
         )
-        result = await session.execute(stmt)
-        stage = result.scalar_one_or_none()
         if not stage:
             logger.warning("NOTIFY_WORK_STAGE_STATUS_SKIPPED missing_stage_id=%s", stage_id)
+            return 0
+        admin_ids = await NotificationService._admin_recipient_ids(
+            session,
+            tenant_scope=tenant_scope,
+        )
+        if not admin_ids:
             return 0
 
         order = getattr(stage, "order", None)
@@ -276,8 +298,19 @@ class NotificationService:
     async def notify_admins_bank_receipts_imported(
         session: AsyncSession,
         receipt_ids: list[int],
+        *,
+        tenant_scope: TenantScope,
     ) -> int:
-        admin_ids = await NotificationService._admin_recipient_ids(session)
+        if not tenant_scope.is_system:
+            logger.warning(
+                "NOTIFY_BANK_RECEIPTS_SKIPPED non_system_tenant_id=%s",
+                tenant_scope.tenant_id,
+            )
+            return 0
+        admin_ids = await NotificationService._admin_recipient_ids(
+            session,
+            tenant_scope=tenant_scope,
+        )
         if not admin_ids or not receipt_ids:
             return 0
 
@@ -367,14 +400,24 @@ class NotificationService:
     async def notify_admins_email_leads_imported(
         session: AsyncSession,
         order_ids: list[int],
+        *,
+        tenant_scope: TenantScope,
     ) -> int:
-        admin_ids = await NotificationService._admin_recipient_ids(session)
+        admin_ids = await NotificationService._admin_recipient_ids(
+            session,
+            tenant_scope=tenant_scope,
+        )
         if not admin_ids or not order_ids:
             return 0
 
         stmt = (
             select(Order)
-            .where(Order.id.in_(order_ids))
+            .outerjoin(Customer, Customer.id == Order.customer_id)
+            .where(
+                Order.id.in_(order_ids),
+                TenantEntityAccessService.order_clause(tenant_scope),
+                TenantEntityAccessService.order_customer_clause(tenant_scope),
+            )
             .order_by(Order.created_at.desc())
         )
         result = await session.execute(stmt)

--- a/services/order_service.py
+++ b/services/order_service.py
@@ -26,8 +26,10 @@ from services.order_proposal_lifecycle import (
 )
 from services.tenant_scope_service import (
     TenantScope,
+    tenant_or_fully_legacy_scope_clause,
     tenant_or_legacy_owner_scope_clause,
 )
+from services.tenant_entity_access_service import TenantEntityAccessService
 
 logger = logging.getLogger(__name__)
 
@@ -784,9 +786,11 @@ class OrderService:
 
     @staticmethod
     async def get_calendar_events(
-        session: AsyncSession, 
-        start_date: datetime, 
-        end_date: datetime
+        session: AsyncSession,
+        start_date: datetime,
+        end_date: datetime,
+        *,
+        tenant_scope: TenantScope,
     ) -> List["CalendarEventResponse"]:
         """
         Get calendar events for orders (assessments and installations).
@@ -806,7 +810,10 @@ class OrderService:
         stmt = (
             select(Order)
             .outerjoin(OrderWorkStage, Order.id == OrderWorkStage.order_id)
+            .outerjoin(Customer, Customer.id == Order.customer_id)
             .where(
+                TenantEntityAccessService.order_clause(tenant_scope),
+                TenantEntityAccessService.order_customer_clause(tenant_scope),
                 or_(
                     and_(Order.measurement_date >= start_date, Order.measurement_date <= end_date),
                     and_(Order.installation_date >= start_date, Order.installation_date <= end_date),
@@ -977,7 +984,11 @@ class OrderService:
             await session.commit()
             await session.refresh(order)
 
-        return await OrderService.get_order_detail_for_manager(session, int(order.id))
+        return await OrderService.get_order_detail_for_manager(
+            session,
+            int(order.id),
+            tenant_scope=tenant_scope,
+        )
 
     @staticmethod
     async def create_from_website(
@@ -1562,28 +1573,60 @@ class OrderService:
     async def _ensure_assignable_legacy_executor(
         session: AsyncSession,
         installer_id: int,
+        *,
+        tenant_scope: TenantScope,
     ) -> None:
         from models import Installer
         from services.staff_user_service import StaffUserService
 
         staff_user = await StaffUserService.get_by_legacy_installer_id(session, installer_id)
         if staff_user is not None:
-            if not StaffUserService.can_be_any_executor(staff_user):
+            from services.staff_tenant_membership_service import (
+                StaffTenantMembershipService,
+            )
+
+            membership = await StaffTenantMembershipService.get_for_tenant(
+                session,
+                tenant_id=tenant_scope.tenant_id,
+                staff_user_id=int(staff_user.id or 0),
+                active_only=True,
+            )
+            if (
+                membership is None
+                or not StaffUserService.can_be_any_executor(staff_user)
+            ):
                 raise ValueError("Selected installer is inactive or blocked")
             return
 
+        if not tenant_scope.is_system:
+            raise ValueError("Selected installer is not available for this tenant")
         installer = await session.get(Installer, installer_id)
         if not installer or not installer.is_active:
             raise ValueError("Selected installer is inactive or blocked")
 
     @staticmethod
-    async def update_order_installers(session: AsyncSession, order_id: int, installers_data: List[Dict[str, Any]]) -> None:
+    async def update_order_installers(
+        session: AsyncSession,
+        order_id: int,
+        installers_data: List[Dict[str, Any]],
+        *,
+        tenant_scope: TenantScope,
+    ) -> None:
         """
         Updates installers for an order and triggers notifications for NEW assignments.
         """
         from models import OrderInstaller, Installer
         from services.bot_service import BotService
         from services.staff_user_service import StaffUserService
+
+        owned_order = await TenantEntityAccessService.get_order(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+            for_update=True,
+        )
+        if owned_order is None:
+            raise ValueError("Order not found")
         
         # 1. Забираем текущие назначения чтобы понять, кто новый
         existing = await session.execute(select(OrderInstaller).where(OrderInstaller.order_id == order_id))
@@ -1605,7 +1648,11 @@ class OrderService:
         for i_data in installers_data:
             i_id = int(i_data['installer_id'])
             if i_id not in existing_map:
-                await OrderService._ensure_assignable_legacy_executor(session, i_id)
+                await OrderService._ensure_assignable_legacy_executor(
+                    session,
+                    i_id,
+                    tenant_scope=tenant_scope,
+                )
                 # Это новый!
                 item = OrderInstaller(
                     order_id=order_id,
@@ -1665,7 +1712,9 @@ class OrderService:
     async def update_all_items(
         session: AsyncSession, 
         order_id: int, 
-        items_data: Dict[str, Any]
+        items_data: Dict[str, Any],
+        *,
+        tenant_scope: TenantScope,
     ) -> None:
         """
         Full sync of order items including products, services, and installers.
@@ -1677,7 +1726,19 @@ class OrderService:
             items_data: Dict with 'products', 'services', 'installers' lists
         """
         from models import OrderInstaller
-        order = await OrderDAO.get_with_links(session, order_id)
+        order = await TenantEntityAccessService.get_order(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+            options=(
+                selectinload(Order.proposals),
+                selectinload(Order.product_links),
+                selectinload(Order.service_links),
+                selectinload(Order.payments),
+                selectinload(Order.installers),
+            ),
+            for_update=True,
+        )
         if not order:
             return
         proposal = await OrderService.ensure_default_proposal(session, order)
@@ -1728,7 +1789,11 @@ class OrderService:
         
         # 4. Add installers
         for inst in items_data.get("installers", []):
-            await OrderService._ensure_assignable_legacy_executor(session, int(inst["installer_id"]))
+            await OrderService._ensure_assignable_legacy_executor(
+                session,
+                int(inst["installer_id"]),
+                tenant_scope=tenant_scope,
+            )
             new_inst = OrderInstaller(
                 order_id=order_id,
                 installer_id=int(inst["installer_id"]),
@@ -1782,18 +1847,30 @@ class OrderService:
         return await OrderDAO.get_all(session)
 
     @staticmethod
-    async def add_order_stage(session: AsyncSession, order_id: int, payload: Any):
+    async def add_order_stage(
+        session: AsyncSession,
+        order_id: int,
+        payload: Any,
+        *,
+        tenant_scope: TenantScope,
+    ):
         from models import OrderWorkStage
         from services.staff_task_notification_event_service import (
             StaffTaskNotificationEventService,
         )
-        order = await session.get(Order, order_id)
+        order = await TenantEntityAccessService.get_order(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+            for_update=True,
+        )
         if not order:
             raise ValueError("Order not found")
         if payload.installer_id is not None:
             await OrderService._ensure_assignable_legacy_executor(
                 session,
                 int(payload.installer_id),
+                tenant_scope=tenant_scope,
             )
         stage = OrderWorkStage(
             order_id=order_id,
@@ -1812,9 +1889,14 @@ class OrderService:
                 session,
                 stage=stage,
                 previous_installer_id=None,
+                tenant_scope=tenant_scope,
             )
         await session.commit()
-        return await OrderService.get_order_detail_for_manager(session, order_id)
+        return await OrderService.get_order_detail_for_manager(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+        )
 
     @staticmethod
     def _map_stale_order_stage(stage: OrderWorkStage) -> Dict[str, Any]:
@@ -1843,6 +1925,7 @@ class OrderService:
     async def list_stale_order_stages(
         session: AsyncSession,
         *,
+        tenant_scope: TenantScope,
         older_than_days: int = 7,
         include_unscheduled: bool = True,
         limit: int = 100,
@@ -1854,6 +1937,8 @@ class OrderService:
             stale_conditions.append(OrderWorkStage.start_time.is_(None))
 
         base_filters = [
+            TenantEntityAccessService.order_clause(tenant_scope),
+            TenantEntityAccessService.order_customer_clause(tenant_scope),
             OrderWorkStage.status.notin_([OrderStageStatus.COMPLETED, OrderStageStatus.CANCELED]),
             or_(*stale_conditions),
         ]
@@ -1861,6 +1946,7 @@ class OrderService:
             select(func.count())
             .select_from(OrderWorkStage)
             .join(Order, Order.id == OrderWorkStage.order_id)
+            .outerjoin(Customer, Customer.id == Order.customer_id)
             .where(*base_filters)
         )
         total = int(count_result.scalar_one() or 0)
@@ -1868,6 +1954,7 @@ class OrderService:
         result = await session.execute(
             select(OrderWorkStage)
             .join(Order, Order.id == OrderWorkStage.order_id)
+            .outerjoin(Customer, Customer.id == Order.customer_id)
             .where(*base_filters)
             .options(
                 selectinload(OrderWorkStage.order).selectinload(Order.customer),
@@ -1882,11 +1969,21 @@ class OrderService:
         }
 
     @staticmethod
-    async def cancel_order_stage_direct(session: AsyncSession, stage_id: int) -> Dict[str, Any]:
+    async def cancel_order_stage_direct(
+        session: AsyncSession,
+        stage_id: int,
+        *,
+        tenant_scope: TenantScope,
+    ) -> Dict[str, Any]:
         from services.staff_task_notification_event_service import (
             StaffTaskNotificationEventService,
         )
-        stage = await session.get(OrderWorkStage, stage_id)
+        stage = await TenantEntityAccessService.get_order_stage(
+            session,
+            stage_id,
+            tenant_scope=tenant_scope,
+            for_update=True,
+        )
         if not stage:
             raise ValueError("Stage not found")
         previous_status = stage.status
@@ -1897,22 +1994,36 @@ class OrderService:
                 session,
                 stage=stage,
                 previous_status=previous_status,
+                tenant_scope=tenant_scope,
             )
         await session.commit()
         await session.refresh(stage)
-        result = await session.execute(
-            select(OrderWorkStage)
-            .where(OrderWorkStage.id == stage_id)
-            .options(
+        stage = await TenantEntityAccessService.get_order_stage(
+            session,
+            stage_id,
+            tenant_scope=tenant_scope,
+            options=(
                 selectinload(OrderWorkStage.order).selectinload(Order.customer),
                 selectinload(OrderWorkStage.installer),
-            )
+            ),
         )
-        return OrderService._map_stale_order_stage(result.scalars().one())
+        if stage is None:
+            raise ValueError("Stage not found")
+        return OrderService._map_stale_order_stage(stage)
 
     @staticmethod
-    async def delete_order_stage_direct(session: AsyncSession, stage_id: int) -> Dict[str, Any]:
-        stage = await session.get(OrderWorkStage, stage_id)
+    async def delete_order_stage_direct(
+        session: AsyncSession,
+        stage_id: int,
+        *,
+        tenant_scope: TenantScope,
+    ) -> Dict[str, Any]:
+        stage = await TenantEntityAccessService.get_order_stage(
+            session,
+            stage_id,
+            tenant_scope=tenant_scope,
+            for_update=True,
+        )
         if not stage:
             raise ValueError("Stage not found")
         await session.delete(stage)
@@ -1920,13 +2031,26 @@ class OrderService:
         return {"ok": True, "id": stage_id}
 
     @staticmethod
-    async def update_order_stage(session: AsyncSession, order_id: int, stage_id: int, payload: Any):
+    async def update_order_stage(
+        session: AsyncSession,
+        order_id: int,
+        stage_id: int,
+        payload: Any,
+        *,
+        tenant_scope: TenantScope,
+    ):
         from models import OrderWorkStage, Order, OrderStatus, OrderStageStatus
         from services.staff_task_notification_event_service import (
             StaffTaskNotificationEventService,
         )
-        stage = await session.get(OrderWorkStage, stage_id)
-        if not stage or stage.order_id != order_id:
+        stage = await TenantEntityAccessService.get_order_stage(
+            session,
+            stage_id,
+            tenant_scope=tenant_scope,
+            order_id=order_id,
+            for_update=True,
+        )
+        if not stage:
             raise ValueError("Stage not found")
         previous_installer_id = stage.installer_id
         previous_start_time = stage.start_time
@@ -1938,6 +2062,7 @@ class OrderService:
             await OrderService._ensure_assignable_legacy_executor(
                 session,
                 int(next_installer_id),
+                tenant_scope=tenant_scope,
             )
         for key, value in update_data.items():
             if key in ("start_time", "end_time"):
@@ -1957,12 +2082,14 @@ class OrderService:
                 session,
                 stage=stage,
                 previous_status=previous_status,
+                tenant_scope=tenant_scope,
             )
         elif stage.installer_id != previous_installer_id and stage.installer_id is not None:
             await StaffTaskNotificationEventService.enqueue_assigned(
                 session,
                 stage=stage,
                 previous_installer_id=previous_installer_id,
+                tenant_scope=tenant_scope,
             )
         elif stage.installer_id is not None:
             changed_fields = []
@@ -1979,10 +2106,15 @@ class OrderService:
                     stage=stage,
                     change_fields=changed_fields,
                     previous_values=previous_values,
+                    tenant_scope=tenant_scope,
                 )
         
         # Auto-pause logic
-        order = await session.get(Order, order_id)
+        order = await TenantEntityAccessService.get_order(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+        )
         if order:
             await session.refresh(order, ['work_stages'])
             all_completed = True
@@ -1998,17 +2130,37 @@ class OrderService:
                 session.add(order)
                 
         await session.commit()
-        return await OrderService.get_order_detail_for_manager(session, order_id)
+        return await OrderService.get_order_detail_for_manager(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+        )
 
     @staticmethod
-    async def delete_order_stage(session: AsyncSession, order_id: int, stage_id: int):
+    async def delete_order_stage(
+        session: AsyncSession,
+        order_id: int,
+        stage_id: int,
+        *,
+        tenant_scope: TenantScope,
+    ):
         from models import OrderWorkStage
-        stage = await session.get(OrderWorkStage, stage_id)
-        if not stage or stage.order_id != order_id:
+        stage = await TenantEntityAccessService.get_order_stage(
+            session,
+            stage_id,
+            tenant_scope=tenant_scope,
+            order_id=order_id,
+            for_update=True,
+        )
+        if not stage:
             raise ValueError("Stage not found")
         await session.delete(stage)
         await session.commit()
-        return await OrderService.get_order_detail_for_manager(session, order_id)
+        return await OrderService.get_order_detail_for_manager(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+        )
 
     @staticmethod
     async def update_status(session: AsyncSession, order_id: int, new_status: Any) -> bool:
@@ -2203,6 +2355,8 @@ class OrderService:
         customer_segment: str,
         page: int,
         limit: int,
+        *,
+        tenant_scope: TenantScope,
         status: Optional[str] = None,
         search: Optional[str] = None,
         overdue_only: bool = False,
@@ -2221,7 +2375,14 @@ class OrderService:
             cast(Customer.type, String) == CustomerType.company.value,
             has_inn,
         )
-        base_filters = [Order.status != OrderStatus.NEW_LEAD]
+        base_filters = [
+            TenantEntityAccessService.order_clause(tenant_scope),
+            Order.status != OrderStatus.NEW_LEAD,
+            or_(
+                Order.customer_id.is_(None),
+                tenant_or_legacy_owner_scope_clause(Customer, tenant_scope),
+            ),
+        ]
         if segment == "b2b":
             base_filters.append(is_b2b)
         elif segment == "b2c":
@@ -2315,11 +2476,17 @@ class OrderService:
         }
 
     @staticmethod
-    async def get_order_detail_for_manager(session: AsyncSession, order_id: int) -> Optional[Dict[str, Any]]:
-        stmt = (
-            select(Order)
-            .where(Order.id == order_id)
-            .options(
+    async def get_order_detail_for_manager(
+        session: AsyncSession,
+        order_id: int,
+        *,
+        tenant_scope: TenantScope,
+    ) -> Optional[Dict[str, Any]]:
+        order = await TenantEntityAccessService.get_order(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+            options=(
                 selectinload(Order.customer),
                 selectinload(Order.customer_branch),
                 selectinload(Order.customer_contract),
@@ -2330,13 +2497,25 @@ class OrderService:
                 selectinload(Order.documents),
                 selectinload(Order.payments).selectinload(Payment.bank_receipt),
                 selectinload(Order.work_stages).selectinload(OrderWorkStage.installer),
-            )
-            .execution_options(populate_existing=True)
+            ),
+            populate_existing=True,
         )
-        result = await session.execute(stmt)
-        order = result.scalars().first()
         if not order:
             return None
+        if order.customer_id is not None:
+            owned_customer_id = (
+                await session.execute(
+                    select(Customer.id).where(
+                        Customer.id == order.customer_id,
+                        tenant_or_legacy_owner_scope_clause(
+                            Customer,
+                            tenant_scope,
+                        ),
+                    )
+                )
+            ).scalar_one_or_none()
+            if owned_customer_id is None:
+                return None
         await OrderService.ensure_default_proposal(session, order)
 
         data = OrderService._map_order_list_item(order)
@@ -2346,15 +2525,28 @@ class OrderService:
         data["attachment_count"] = await ServiceAttachmentService.order_attachment_count(
             session,
             order=order,
+            tenant_scope=tenant_scope,
         )
         linked_equipment_result = await session.execute(
-            select(EquipmentOrderLink.equipment_id).where(EquipmentOrderLink.order_id == order_id)
+            select(EquipmentOrderLink.equipment_id)
+            .join(
+                CustomerEquipment,
+                CustomerEquipment.id == EquipmentOrderLink.equipment_id,
+            )
+            .join(Customer, Customer.id == CustomerEquipment.customer_id)
+            .where(
+                EquipmentOrderLink.order_id == order_id,
+                tenant_or_legacy_owner_scope_clause(Customer, tenant_scope),
+            )
         )
         linked_equipment_ids = {int(value) for value in linked_equipment_result.scalars().all()}
         source_equipment_result = await session.execute(
-            select(CustomerEquipment.id).where(
+            select(CustomerEquipment.id)
+            .join(Customer, Customer.id == CustomerEquipment.customer_id)
+            .where(
                 CustomerEquipment.source_order_id == order_id,
                 CustomerEquipment.is_archived == False,
+                tenant_or_legacy_owner_scope_clause(Customer, tenant_scope),
             )
         )
         linked_equipment_ids.update(int(value) for value in source_equipment_result.scalars().all())
@@ -2417,28 +2609,43 @@ class OrderService:
         return data
 
     @staticmethod
-    async def _load_order_for_proposal_write(session: AsyncSession, order_id: int) -> Order:
-        stmt = (
-            select(Order)
-            .where(Order.id == order_id)
-            .options(
+    async def _load_order_for_proposal_write(
+        session: AsyncSession,
+        order_id: int,
+        *,
+        tenant_scope: TenantScope,
+    ) -> Order:
+        order = await TenantEntityAccessService.get_order(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+            options=(
                 selectinload(Order.proposals),
                 selectinload(Order.product_links).selectinload(OrderProductLink.product),
                 selectinload(Order.service_links).selectinload(OrderServiceLink.service),
                 selectinload(Order.payments),
                 selectinload(Order.installers),
-            )
+            ),
+            for_update=True,
         )
-        result = await session.execute(stmt)
-        order = result.scalars().first()
         if not order:
             raise ValueError("Order not found")
         await OrderService.ensure_default_proposal(session, order)
         return order
 
     @staticmethod
-    async def create_order_proposal(session: AsyncSession, order_id: int, payload: Any) -> Dict[str, Any]:
-        order = await OrderService._load_order_for_proposal_write(session, order_id)
+    async def create_order_proposal(
+        session: AsyncSession,
+        order_id: int,
+        payload: Any,
+        *,
+        tenant_scope: TenantScope,
+    ) -> Dict[str, Any]:
+        order = await OrderService._load_order_for_proposal_write(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+        )
         source = None
         source_id = getattr(payload, "duplicate_from_proposal_id", None)
         if source_id:
@@ -2491,11 +2698,26 @@ class OrderService:
         await OrderService._refresh_order_financials(session, order)
         session.add(order)
         await session.commit()
-        return await OrderService.get_order_detail_for_manager(session, order_id)
+        return await OrderService.get_order_detail_for_manager(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+        )
 
     @staticmethod
-    async def update_order_proposal(session: AsyncSession, order_id: int, proposal_id: int, payload: Any) -> Dict[str, Any]:
-        order = await OrderService._load_order_for_proposal_write(session, order_id)
+    async def update_order_proposal(
+        session: AsyncSession,
+        order_id: int,
+        proposal_id: int,
+        payload: Any,
+        *,
+        tenant_scope: TenantScope,
+    ) -> Dict[str, Any]:
+        order = await OrderService._load_order_for_proposal_write(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+        )
         proposal = next((item for item in order.proposals if item.id == proposal_id), None)
         if not proposal:
             raise ValueError("Proposal not found")
@@ -2536,11 +2758,25 @@ class OrderService:
         await OrderService._refresh_order_financials(session, order)
         session.add(order)
         await session.commit()
-        return await OrderService.get_order_detail_for_manager(session, order_id)
+        return await OrderService.get_order_detail_for_manager(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+        )
 
     @staticmethod
-    async def select_order_proposal(session: AsyncSession, order_id: int, proposal_id: int) -> Dict[str, Any]:
-        order = await OrderService._load_order_for_proposal_write(session, order_id)
+    async def select_order_proposal(
+        session: AsyncSession,
+        order_id: int,
+        proposal_id: int,
+        *,
+        tenant_scope: TenantScope,
+    ) -> Dict[str, Any]:
+        order = await OrderService._load_order_for_proposal_write(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+        )
         proposal = next((item for item in order.proposals if item.id == proposal_id and not item.is_archived), None)
         if not proposal:
             raise ValueError("Proposal not found")
@@ -2553,7 +2789,11 @@ class OrderService:
         await OrderService._refresh_order_financials(session, order)
         session.add(order)
         await session.commit()
-        return await OrderService.get_order_detail_for_manager(session, order_id)
+        return await OrderService.get_order_detail_for_manager(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+        )
 
 
     @staticmethod
@@ -2642,8 +2882,15 @@ class OrderService:
         session: AsyncSession,
         order_id: int,
         payload: Any,
+        *,
+        tenant_scope: TenantScope,
     ) -> Optional[Dict[str, Any]]:
-        order = await session.get(Order, order_id)
+        order = await TenantEntityAccessService.get_order(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+            for_update=True,
+        )
         if not order:
             return None
         from models import Customer  # noqa: avoid UnboundLocalError from conditional import below
@@ -2723,7 +2970,11 @@ class OrderService:
             order.measurement_required = payload.measurement_required
         if "measurer_id" in fields_set:
             if payload.measurer_id is not None and payload.measurer_id != order.measurer_id:
-                await OrderService._ensure_assignable_legacy_executor(session, int(payload.measurer_id))
+                await OrderService._ensure_assignable_legacy_executor(
+                    session,
+                    int(payload.measurer_id),
+                    tenant_scope=tenant_scope,
+                )
             order.measurer_id = payload.measurer_id
         if "measurement_result" in fields_set:
             order.measurement_result = payload.measurement_result
@@ -2823,7 +3074,11 @@ class OrderService:
             )
             existing_installer_ids = set(existing_installer_ids_res.scalars().all())
             if getattr(payload, "installer_id", None) is not None and payload.installer_id not in existing_installer_ids:
-                await OrderService._ensure_assignable_legacy_executor(session, int(payload.installer_id))
+                await OrderService._ensure_assignable_legacy_executor(
+                    session,
+                    int(payload.installer_id),
+                    tenant_scope=tenant_scope,
+                )
             await session.execute(delete(OrderInstaller).where(OrderInstaller.order_id == order_id))
             if getattr(payload, "installer_id", None) is not None:
                 new_installer_link = OrderInstaller(
@@ -2837,7 +3092,17 @@ class OrderService:
         if "customer_id" in fields_set and payload.customer_id is not None:
             if order.customer_id != payload.customer_id:
                 # Link to new existing customer
-                new_customer = await session.get(Customer, payload.customer_id)
+                new_customer = (
+                    await session.execute(
+                        select(Customer).where(
+                            Customer.id == payload.customer_id,
+                            tenant_or_legacy_owner_scope_clause(
+                                Customer,
+                                tenant_scope,
+                            ),
+                        )
+                    )
+                ).scalars().first()
                 if not new_customer:
                     raise ValueError("Customer not found")
                 order.customer_id = payload.customer_id
@@ -2910,7 +3175,17 @@ class OrderService:
         # 2. Update customer fields
         requested_customer_fields = [field for field in customer_field_map if field in fields_set]
         if requested_customer_fields and order.customer_id:
-            customer = await session.get(Customer, order.customer_id)
+            customer = (
+                await session.execute(
+                    select(Customer).where(
+                        Customer.id == order.customer_id,
+                        tenant_or_legacy_owner_scope_clause(
+                            Customer,
+                            tenant_scope,
+                        ),
+                    )
+                )
+            ).scalars().first()
             if customer:
                 def _clean_optional(value: Any) -> Optional[str]:
                     if value is None:
@@ -3114,6 +3389,7 @@ class OrderService:
                 .where(
                     Order.customer_id == order.customer_id,
                     Order.id != order.id,
+                    TenantEntityAccessService.order_clause(tenant_scope),
                     not_(
                         or_(
                             Order.status == OrderStatus.NEW_LEAD,
@@ -3125,7 +3401,17 @@ class OrderService:
             other_real_result = await session.execute(other_real_orders_stmt)
             other_real_count = int(other_real_result.scalar() or 0)
             if other_real_count == 0:
-                customer = await session.get(Customer, order.customer_id)
+                customer = (
+                    await session.execute(
+                        select(Customer).where(
+                            Customer.id == order.customer_id,
+                            tenant_or_legacy_owner_scope_clause(
+                                Customer,
+                                tenant_scope,
+                            ),
+                        )
+                    )
+                ).scalars().first()
                 if customer and not customer.is_archived:
                     customer.is_archived = True
                     session.add(customer)
@@ -3142,15 +3428,31 @@ class OrderService:
                 order_id=order_id,
                 previous_address=previous_delivery_address,
                 current_address=order.delivery_address,
+                tenant_scope=tenant_scope,
             )
         await session.commit()
 
-        return await OrderService.get_order_detail_for_manager(session, order_id)
+        return await OrderService.get_order_detail_for_manager(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+        )
 
     @staticmethod
-    async def add_payment(session: AsyncSession, order_id: int, payload: Any):
+    async def add_payment(
+        session: AsyncSession,
+        order_id: int,
+        payload: Any,
+        *,
+        tenant_scope: TenantScope,
+    ):
         from models import Payment, PaymentType
-        order = await session.get(Order, order_id)
+        order = await TenantEntityAccessService.get_order(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+            for_update=True,
+        )
         if not order:
             raise ValueError("Order not found")
         
@@ -3181,9 +3483,20 @@ class OrderService:
         return [OrderService._map_payment(p) for p in sorted(order.payments, key=lambda d: d.date, reverse=True)]
 
     @staticmethod
-    async def delete_payment(session: AsyncSession, order_id: int, payment_id: int):
+    async def delete_payment(
+        session: AsyncSession,
+        order_id: int,
+        payment_id: int,
+        *,
+        tenant_scope: TenantScope,
+    ):
         from models import BankReceipt, Payment
-        order = await session.get(Order, order_id)
+        order = await TenantEntityAccessService.get_order(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+            for_update=True,
+        )
         if not order:
             raise ValueError("Order not found")
             
@@ -3195,10 +3508,30 @@ class OrderService:
         affected_order_ids = {int(order_id)}
 
         if bank_receipt_id:
+            all_linked_ids = list(
+                (
+                    await session.execute(
+                        select(Payment.id).where(
+                            Payment.bank_receipt_id == bank_receipt_id
+                        )
+                    )
+                ).scalars()
+            )
             linked_payments_result = await session.execute(
-                select(Payment).where(Payment.bank_receipt_id == bank_receipt_id)
+                select(Payment)
+                .join(Order, Order.id == Payment.order_id)
+                .outerjoin(Customer, Customer.id == Order.customer_id)
+                .where(
+                    Payment.bank_receipt_id == bank_receipt_id,
+                    TenantEntityAccessService.order_clause(tenant_scope),
+                    TenantEntityAccessService.order_customer_clause(
+                        tenant_scope
+                    ),
+                )
             )
             linked_payments = list(linked_payments_result.scalars().all())
+            if len(linked_payments) != len(all_linked_ids):
+                raise ValueError("Bank receipt spans a tenant boundary")
             deleted_payment_ids = [int(item.id or 0) for item in linked_payments if item.id]
             for linked_payment in linked_payments:
                 if linked_payment.order_id:
@@ -3228,7 +3561,11 @@ class OrderService:
         await session.flush()
 
         for affected_order_id in affected_order_ids:
-            affected_order = await session.get(Order, affected_order_id)
+            affected_order = await TenantEntityAccessService.get_order(
+                session,
+                affected_order_id,
+                tenant_scope=tenant_scope,
+            )
             if not affected_order:
                 continue
             await OrderService._refresh_order_financials(session, affected_order)
@@ -3249,13 +3586,26 @@ class OrderService:
     # -----------------------------------------------------------------
 
     @staticmethod
-    async def get_new_lead_counter(session: AsyncSession) -> tuple[int, bool]:
+    async def get_new_lead_counter(
+        session: AsyncSession,
+        *,
+        tenant_scope: TenantScope,
+    ) -> tuple[int, bool]:
         """Fast count of orders with status 'new_lead'.
 
         Intended for the Dashboard/Sidebar badge — runs a single
         indexed COUNT query with no joins.
         """
-        stmt = select(func.count()).where(Order.status == OrderStatus.NEW_LEAD)
+        stmt = (
+            select(func.count())
+            .select_from(Order)
+            .outerjoin(Customer, Customer.id == Order.customer_id)
+            .where(
+                Order.status == OrderStatus.NEW_LEAD,
+                TenantEntityAccessService.order_clause(tenant_scope),
+                TenantEntityAccessService.order_customer_clause(tenant_scope),
+            )
+        )
         result = await session.execute(stmt)
         count: int = result.scalar() or 0
         return count, count > 0
@@ -3321,6 +3671,8 @@ class OrderService:
     @staticmethod
     async def get_leads_inbox(
         session: AsyncSession,
+        *,
+        tenant_scope: TenantScope,
         scope: str = "active",
         page: int = 1,
         limit: int = 50,
@@ -3336,8 +3688,22 @@ class OrderService:
 
         page = max(1, int(page or 1))
         limit = min(100, max(1, int(limit or 50)))
-        stmt = select(Order).options(selectinload(Order.customer))
-        count_stmt = select(func.count(Order.id))
+        ownership_clause = TenantEntityAccessService.order_clause(tenant_scope)
+        customer_ownership_clause = or_(
+            Order.customer_id.is_(None),
+            tenant_or_legacy_owner_scope_clause(Customer, tenant_scope),
+        )
+        stmt = (
+            select(Order)
+            .outerjoin(Customer, Customer.id == Order.customer_id)
+            .where(ownership_clause, customer_ownership_clause)
+            .options(selectinload(Order.customer))
+        )
+        count_stmt = (
+            select(func.count(Order.id))
+            .outerjoin(Customer, Customer.id == Order.customer_id)
+            .where(ownership_clause, customer_ownership_clause)
+        )
 
         if scope == "archive":
             # Archived leads are just closed/lost leads
@@ -3373,6 +3739,7 @@ class OrderService:
         attachment_counts = await ServiceAttachmentService.order_attachment_counts(
             session,
             order_ids=[int(order.id or 0) for order in orders],
+            tenant_scope=tenant_scope,
         )
 
         items = [
@@ -3419,7 +3786,12 @@ class OrderService:
         )
 
     @staticmethod
-    async def delete_order(session: AsyncSession, order_id: int) -> bool:
+    async def delete_order(
+        session: AsyncSession,
+        order_id: int,
+        *,
+        tenant_scope: TenantScope,
+    ) -> bool:
         """
         Delete an order and all cascading dependencies from DB.
         Google Drive files are deleted on a best-effort basis and do not block DB deletion.
@@ -3440,14 +3812,23 @@ class OrderService:
         from services.document_service import DocumentService
         from services.google_service import get_google_service
         
-        order = await session.get(Order, order_id)
+        order = await TenantEntityAccessService.get_order(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+            for_update=True,
+        )
         if not order:
             raise ValueError(f"Order {order_id} not found")
 
         # Delete associated documents from Google Drive (best-effort).
         # OrderDocument rows themselves are deleted by ORM cascade together with the order.
-        docs = await DocumentService.list_order_documents(session, order_id)
-        for doc in docs:
+        docs = await DocumentService.list_order_documents(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+        )
+        for doc in docs or []:
             if not doc.google_file_id:
                 continue
             try:

--- a/services/order_transfer_service.py
+++ b/services/order_transfer_service.py
@@ -48,6 +48,7 @@ from schemas import (
     ManagerOrderTransferWorkStage,
 )
 from services.order_service import OrderService
+from services.tenant_entity_access_service import TenantEntityAccessService
 from services.tenant_scope_service import (
     TenantScope,
     tenant_or_legacy_owner_scope_clause,
@@ -268,14 +269,24 @@ class OrderTransferService:
         )
 
     @staticmethod
-    async def export_orders(session: AsyncSession, payload: ManagerOrderExportRequest) -> ManagerOrderTransferPackage:
+    async def export_orders(
+        session: AsyncSession,
+        payload: ManagerOrderExportRequest,
+        *,
+        tenant_scope: TenantScope,
+    ) -> ManagerOrderTransferPackage:
         order_ids = list(dict.fromkeys(int(order_id) for order_id in payload.order_ids if int(order_id) > 0))
         if not order_ids:
             raise ValueError("No orders selected")
 
         stmt = (
             select(Order)
-            .where(Order.id.in_(order_ids))
+            .outerjoin(Customer, Customer.id == Order.customer_id)
+            .where(
+                Order.id.in_(order_ids),
+                TenantEntityAccessService.order_clause(tenant_scope),
+                TenantEntityAccessService.order_customer_clause(tenant_scope),
+            )
             .options(
                 selectinload(Order.customer),
                 selectinload(Order.customer_branch),

--- a/services/repair_diagnostic_service.py
+++ b/services/repair_diagnostic_service.py
@@ -272,7 +272,13 @@ class RepairDiagnosticService:
         await session.commit()
         await session.refresh(order)
 
-        await RepairDiagnosticService._notify_admins(session, order, payload, photos)
+        await RepairDiagnosticService._notify_admins(
+            session,
+            order,
+            payload,
+            photos,
+            tenant_scope=tenant_scope,
+        )
 
         response = RepairDiagnosticLeadResponse(
             order_id=int(order.id or 0),
@@ -523,8 +529,13 @@ class RepairDiagnosticService:
         order: Order,
         payload: RepairDiagnosticLeadPayload,
         photos: Dict[str, List[Dict[str, Any]]],
+        *,
+        tenant_scope: TenantScope,
     ) -> None:
-        admin_ids = await StaffUserService.get_active_owner_admin_telegram_recipient_ids(session)
+        admin_ids = await StaffUserService.get_active_owner_admin_telegram_recipient_ids(
+            session,
+            tenant_scope=tenant_scope,
+        )
         if not admin_ids:
             return
         photo_count = sum(len(items) for items in photos.values())

--- a/services/scheduler_service.py
+++ b/services/scheduler_service.py
@@ -322,15 +322,18 @@ class SchedulerService:
         from services.staff_task_notification_event_service import (
             StaffTaskNotificationEventService,
         )
+        from services.tenant_scope_service import SystemTenantScopeResolver
 
         while True:
             try:
                 async with async_session_maker() as session:
+                    tenant_scope = await SystemTenantScopeResolver.resolve(session)
                     created = (
                         await StaffTaskNotificationEventService.enqueue_departure_reminders(
                             session,
                             offset_minutes=120,
                             scan_window_minutes=10,
+                            tenant_scope=tenant_scope,
                         )
                     )
                     await session.commit()
@@ -354,13 +357,16 @@ class SchedulerService:
 
                 from services.mail_imap_service import MailImapService
                 from services.notification_service import NotificationService
+                from services.tenant_scope_service import SystemTenantScopeResolver
 
                 logger.info("⏳ Bank mail import job started...")
                 async with async_session_maker() as session:
+                    tenant_scope = await SystemTenantScopeResolver.resolve(session)
                     result = await MailImapService.import_bank_receipts(session, limit=50)
                     notified_admins = await NotificationService.notify_admins_bank_receipts_imported(
                         session,
                         result.created_receipt_ids,
+                        tenant_scope=tenant_scope,
                     )
                 logger.info(
                     "✅ Bank mail import done. processed=%s created=%s duplicates=%s failed=%s notified_admins=%s",

--- a/services/service_attachment_service.py
+++ b/services/service_attachment_service.py
@@ -16,12 +16,14 @@ from sqlmodel import func, select
 
 from core.config import settings
 from models import (
+    Customer,
     CustomerEquipment,
     EquipmentAttachmentLink,
     Order,
     OrderAttachmentLink,
     ServiceAttachment,
 )
+from models.tenancy import TenantScope
 from services.private_attachment_storage_service import (
     PrivateAttachmentStorage,
     extension_for,
@@ -35,6 +37,11 @@ from services.service_attachment_presenter import (
     legacy_attachment_items,
 )
 from services.service_attachment_link_service import ServiceAttachmentLinkService
+from services.tenant_entity_access_service import TenantEntityAccessService
+from services.tenant_scope_service import (
+    tenant_or_fully_legacy_scope_clause,
+    tenant_or_legacy_owner_scope_clause,
+)
 
 class ServiceAttachmentService:
     CATEGORIES = {
@@ -119,12 +126,17 @@ class ServiceAttachmentService:
         storage: PrivateAttachmentStorage | None = None,
         created_storage_keys: set[str] | None = None,
         commit: bool = True,
+        tenant_scope: TenantScope,
     ) -> dict[str, Any]:
         if not content:
             raise ValueError("Attachment is empty")
         if len(content) > int(settings.SERVICE_ATTACHMENT_MAX_SIZE_BYTES):
             raise ValueError("Attachment exceeds the configured size limit")
-        order = await session.get(Order, order_id)
+        order = await TenantEntityAccessService.get_order(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+        )
         if not order:
             raise ValueError("Order not found")
         context = await ServiceAttachmentLinkService.validate_order_context(
@@ -348,6 +360,7 @@ class ServiceAttachmentService:
         session: AsyncSession,
         *,
         order_ids: list[int],
+        tenant_scope: TenantScope,
     ) -> dict[int, int]:
         normalized_ids = sorted(
             {int(order_id) for order_id in order_ids if int(order_id) > 0}
@@ -357,6 +370,8 @@ class ServiceAttachmentService:
         rows = (
             await session.execute(
                 select(OrderAttachmentLink.order_id, func.count(OrderAttachmentLink.id))
+                .join(Order, Order.id == OrderAttachmentLink.order_id)
+                .outerjoin(Customer, Customer.id == Order.customer_id)
                 .join(
                     ServiceAttachment,
                     ServiceAttachment.id == OrderAttachmentLink.attachment_id,
@@ -365,6 +380,8 @@ class ServiceAttachmentService:
                     OrderAttachmentLink.order_id.in_(normalized_ids),
                     OrderAttachmentLink.archived_at.is_(None),
                     ServiceAttachment.archived_at.is_(None),
+                    tenant_or_fully_legacy_scope_clause(Order, tenant_scope),
+                    TenantEntityAccessService.order_customer_clause(tenant_scope),
                 )
                 .group_by(OrderAttachmentLink.order_id)
             )
@@ -372,8 +389,18 @@ class ServiceAttachmentService:
         return {int(order_id): int(count) for order_id, count in rows}
 
     @classmethod
-    async def list_order_attachments(cls, session: AsyncSession, *, order_id: int) -> dict[str, Any] | None:
-        order = await session.get(Order, order_id)
+    async def list_order_attachments(
+        cls,
+        session: AsyncSession,
+        *,
+        order_id: int,
+        tenant_scope: TenantScope,
+    ) -> dict[str, Any] | None:
+        order = await TenantEntityAccessService.get_order(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+        )
         if not order:
             return None
         result = await session.execute(
@@ -434,8 +461,13 @@ class ServiceAttachmentService:
         session: AsyncSession,
         *,
         equipment_id: int,
+        tenant_scope: TenantScope,
     ) -> dict[str, Any] | None:
-        equipment = await session.get(CustomerEquipment, equipment_id)
+        equipment = await TenantEntityAccessService.get_equipment(
+            session,
+            equipment_id,
+            tenant_scope=tenant_scope,
+        )
         if not equipment:
             return None
         result = await session.execute(
@@ -461,7 +493,20 @@ class ServiceAttachmentService:
         return {"items": items, "total": len(items)}
 
     @classmethod
-    async def order_attachment_count(cls, session: AsyncSession, *, order: Order) -> int:
+    async def order_attachment_count(
+        cls,
+        session: AsyncSession,
+        *,
+        order: Order,
+        tenant_scope: TenantScope,
+    ) -> int:
+        owned_order = await TenantEntityAccessService.get_order(
+            session,
+            int(order.id or 0),
+            tenant_scope=tenant_scope,
+        )
+        if owned_order is None:
+            return 0
         db_count = await session.scalar(
             select(func.count(OrderAttachmentLink.id))
             .join(ServiceAttachment, ServiceAttachment.id == OrderAttachmentLink.attachment_id)
@@ -499,12 +544,26 @@ class ServiceAttachmentService:
         attachment_id: int,
         order_id: int | None,
         payload: dict[str, Any],
+        tenant_scope: TenantScope,
     ) -> dict[str, Any] | None:
         attachment = await session.get(ServiceAttachment, attachment_id)
         if not attachment or attachment.archived_at is not None:
             return None
+        if "transcript" in payload and not await cls._all_active_links_belong_to_scope(
+            session,
+            attachment_id=attachment_id,
+            tenant_scope=tenant_scope,
+        ):
+            return None
         link = None
         if order_id is not None:
+            order = await TenantEntityAccessService.get_order(
+                session,
+                order_id,
+                tenant_scope=tenant_scope,
+            )
+            if order is None:
+                return None
             link_result = await session.execute(
                 select(OrderAttachmentLink).where(
                     OrderAttachmentLink.order_id == order_id,
@@ -515,6 +574,12 @@ class ServiceAttachmentService:
             link = link_result.scalars().first()
             if not link:
                 raise ValueError("Attachment does not belong to this order")
+        elif not await cls._all_active_links_belong_to_scope(
+            session,
+            attachment_id=attachment_id,
+            tenant_scope=tenant_scope,
+        ):
+            return None
         if "category" in payload:
             if not link:
                 raise ValueError("order_id is required to change attachment category")
@@ -531,8 +596,7 @@ class ServiceAttachmentService:
         if {"equipment_id", "component_id", "service_history_id"}.intersection(payload):
             if order_id is None:
                 raise ValueError("order_id is required to change equipment link")
-            order = await session.get(Order, order_id)
-            if not order or link is None:
+            if link is None:
                 raise ValueError("Order or attachment link not found")
             await ServiceAttachmentLinkService.replace_equipment_link(
                 session,
@@ -592,16 +656,130 @@ class ServiceAttachmentService:
         return active_equipment_link is not None
 
     @staticmethod
+    async def _has_active_link_for_scope(
+        session: AsyncSession,
+        *,
+        attachment_id: int,
+        tenant_scope: TenantScope,
+    ) -> bool:
+        active_order_link = await session.scalar(
+            select(OrderAttachmentLink.id)
+            .join(Order, Order.id == OrderAttachmentLink.order_id)
+            .outerjoin(Customer, Customer.id == Order.customer_id)
+            .where(
+                OrderAttachmentLink.attachment_id == attachment_id,
+                OrderAttachmentLink.archived_at.is_(None),
+                tenant_or_fully_legacy_scope_clause(Order, tenant_scope),
+                TenantEntityAccessService.order_customer_clause(tenant_scope),
+            )
+            .limit(1)
+        )
+        if active_order_link is not None:
+            return True
+        active_equipment_link = await session.scalar(
+            select(EquipmentAttachmentLink.id)
+            .join(
+                CustomerEquipment,
+                CustomerEquipment.id == EquipmentAttachmentLink.equipment_id,
+            )
+            .join(Customer, Customer.id == CustomerEquipment.customer_id)
+            .where(
+                EquipmentAttachmentLink.attachment_id == attachment_id,
+                EquipmentAttachmentLink.archived_at.is_(None),
+                tenant_or_legacy_owner_scope_clause(Customer, tenant_scope),
+            )
+            .limit(1)
+        )
+        return active_equipment_link is not None
+
+    @staticmethod
+    async def _all_active_links_belong_to_scope(
+        session: AsyncSession,
+        *,
+        attachment_id: int,
+        tenant_scope: TenantScope,
+    ) -> bool:
+        all_order_link_ids = set(
+            (
+                await session.execute(
+                    select(OrderAttachmentLink.id).where(
+                        OrderAttachmentLink.attachment_id == attachment_id,
+                        OrderAttachmentLink.archived_at.is_(None),
+                    )
+                )
+            ).scalars().all()
+        )
+        scoped_order_link_ids = set(
+            (
+                await session.execute(
+                    select(OrderAttachmentLink.id)
+                    .join(Order, Order.id == OrderAttachmentLink.order_id)
+                    .outerjoin(Customer, Customer.id == Order.customer_id)
+                    .where(
+                        OrderAttachmentLink.attachment_id == attachment_id,
+                        OrderAttachmentLink.archived_at.is_(None),
+                        tenant_or_fully_legacy_scope_clause(Order, tenant_scope),
+                        TenantEntityAccessService.order_customer_clause(
+                            tenant_scope
+                        ),
+                    )
+                )
+            ).scalars().all()
+        )
+        all_equipment_link_ids = set(
+            (
+                await session.execute(
+                    select(EquipmentAttachmentLink.id).where(
+                        EquipmentAttachmentLink.attachment_id == attachment_id,
+                        EquipmentAttachmentLink.archived_at.is_(None),
+                    )
+                )
+            ).scalars().all()
+        )
+        scoped_equipment_link_ids = set(
+            (
+                await session.execute(
+                    select(EquipmentAttachmentLink.id)
+                    .join(
+                        CustomerEquipment,
+                        CustomerEquipment.id == EquipmentAttachmentLink.equipment_id,
+                    )
+                    .join(Customer, Customer.id == CustomerEquipment.customer_id)
+                    .where(
+                        EquipmentAttachmentLink.attachment_id == attachment_id,
+                        EquipmentAttachmentLink.archived_at.is_(None),
+                        tenant_or_legacy_owner_scope_clause(
+                            Customer,
+                            tenant_scope,
+                        ),
+                    )
+                )
+            ).scalars().all()
+        )
+        return bool(all_order_link_ids or all_equipment_link_ids) and (
+            all_order_link_ids == scoped_order_link_ids
+            and all_equipment_link_ids == scoped_equipment_link_ids
+        )
+
+    @staticmethod
     async def archive_attachment(
         session: AsyncSession,
         *,
         attachment_id: int,
         order_id: int | None = None,
+        tenant_scope: TenantScope,
     ) -> bool:
         attachment = await session.get(ServiceAttachment, attachment_id)
         if not attachment or attachment.archived_at is not None:
             return False
         if order_id is not None:
+            order = await TenantEntityAccessService.get_order(
+                session,
+                order_id,
+                tenant_scope=tenant_scope,
+            )
+            if order is None:
+                return False
             link_result = await session.execute(
                 select(OrderAttachmentLink).where(
                     OrderAttachmentLink.order_id == order_id,
@@ -624,6 +802,12 @@ class ServiceAttachmentService:
                 equipment_link.archived_at = datetime.now()
                 session.add(equipment_link)
         else:
+            if not await ServiceAttachmentService._all_active_links_belong_to_scope(
+                session,
+                attachment_id=attachment_id,
+                tenant_scope=tenant_scope,
+            ):
+                return False
             order_links_result = await session.execute(
                 select(OrderAttachmentLink).where(
                     OrderAttachmentLink.attachment_id == attachment_id,
@@ -680,11 +864,16 @@ class ServiceAttachmentService:
         variant: str,
         download: bool,
         storage: PrivateAttachmentStorage | None = None,
+        tenant_scope: TenantScope,
     ) -> dict[str, Any] | None:
         attachment = await session.get(ServiceAttachment, attachment_id)
         if not attachment or attachment.archived_at is not None:
             return None
-        if not await cls._has_active_link(session, attachment_id=attachment_id):
+        if not await cls._has_active_link_for_scope(
+            session,
+            attachment_id=attachment_id,
+            tenant_scope=tenant_scope,
+        ):
             return None
         normalized_variant = "preview" if variant == "preview" and attachment.preview_storage_key else "original"
         storage_key = attachment.preview_storage_key if normalized_variant == "preview" else attachment.storage_key

--- a/services/staff_task_notification_event_service.py
+++ b/services/staff_task_notification_event_service.py
@@ -10,7 +10,14 @@ from typing import Iterable
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
-from models import Customer, Order, OrderStageStatus, OrderWorkStage
+from models import (
+    Customer,
+    Order,
+    OrderStageStatus,
+    OrderWorkStage,
+    TenantMembership,
+)
+from models.tenancy import TenantScope
 from services.bot_task_service import BotTaskService
 from services.communications.outbox_service import IntegrationOutboxService
 from services.communications.staff_task_contracts import (
@@ -20,6 +27,10 @@ from services.communications.staff_task_contracts import (
     StaffTaskNotificationPayloadV1,
 )
 from services.staff_user_service import StaffUserService
+from services.tenant_scope_service import (
+    tenant_or_fully_legacy_scope_clause,
+    tenant_or_legacy_owner_scope_clause,
+)
 
 
 class StaffTaskNotificationEventService:
@@ -55,6 +66,7 @@ class StaffTaskNotificationEventService:
         installer_id: int | None,
         event_kind: StaffTaskEventKind,
         identity: list[object],
+        tenant_scope: TenantScope,
         change_fields: Iterable[StaffTaskChangeField] = (),
         reminder_offset_minutes: int | None = None,
     ) -> bool:
@@ -71,10 +83,22 @@ class StaffTaskNotificationEventService:
             or staff_user.telegram_id is None
         ):
             return False
+        membership = (
+            await session.execute(
+                select(TenantMembership).where(
+                    TenantMembership.tenant_id == tenant_scope.tenant_id,
+                    TenantMembership.staff_user_id == int(staff_user.id),
+                    TenantMembership.status == "active",
+                )
+            )
+        ).scalars().first()
+        if membership is None:
+            return False
         order_row = (
             await session.execute(
                 select(Order.customer_id, Order.delivery_address).where(
-                    Order.id == int(stage.order_id)
+                    Order.id == int(stage.order_id),
+                    tenant_or_fully_legacy_scope_clause(Order, tenant_scope),
                 )
             )
         ).one_or_none()
@@ -85,10 +109,16 @@ class StaffTaskNotificationEventService:
             customer_row = (
                 await session.execute(
                     select(Customer.name, Customer.phone).where(
-                        Customer.id == int(order_row.customer_id)
+                        Customer.id == int(order_row.customer_id),
+                        tenant_or_legacy_owner_scope_clause(
+                            Customer,
+                            tenant_scope,
+                        ),
                     )
                 )
             ).one_or_none()
+            if customer_row is None:
+                return False
         payload = StaffTaskNotificationPayloadV1(
             event_kind=event_kind,
             staff_user_id=int(staff_user.id),
@@ -113,7 +143,12 @@ class StaffTaskNotificationEventService:
             payload=payload,
             idempotency_key=cls._idempotency_key(
                 event_kind,
-                [int(stage.id), int(staff_user.id), *identity],
+                [
+                    tenant_scope.tenant_id,
+                    int(stage.id),
+                    int(staff_user.id),
+                    *identity,
+                ],
             ),
             priority=cls.PRIORITY,
             max_attempts=cls.MAX_ATTEMPTS,
@@ -127,6 +162,7 @@ class StaffTaskNotificationEventService:
         *,
         stage: OrderWorkStage,
         previous_installer_id: int | None,
+        tenant_scope: TenantScope,
     ) -> bool:
         return await cls._enqueue(
             session,
@@ -134,6 +170,7 @@ class StaffTaskNotificationEventService:
             installer_id=stage.installer_id,
             event_kind="assigned",
             identity=[previous_installer_id, stage.installer_id],
+            tenant_scope=tenant_scope,
             change_fields=("assignee",),
         )
 
@@ -145,6 +182,7 @@ class StaffTaskNotificationEventService:
         stage: OrderWorkStage,
         change_fields: Iterable[StaffTaskChangeField],
         previous_values: list[object],
+        tenant_scope: TenantScope,
     ) -> bool:
         normalized_fields = tuple(dict.fromkeys(change_fields))
         if not normalized_fields:
@@ -155,6 +193,7 @@ class StaffTaskNotificationEventService:
             installer_id=stage.installer_id,
             event_kind="rescheduled",
             identity=[*previous_values, stage.start_time, stage.end_time, normalized_fields],
+            tenant_scope=tenant_scope,
             change_fields=normalized_fields,
         )
 
@@ -165,6 +204,7 @@ class StaffTaskNotificationEventService:
         *,
         stage: OrderWorkStage,
         previous_status: object,
+        tenant_scope: TenantScope,
     ) -> bool:
         return await cls._enqueue(
             session,
@@ -172,6 +212,7 @@ class StaffTaskNotificationEventService:
             installer_id=stage.installer_id,
             event_kind="canceled",
             identity=[str(previous_status), cls._status_text(stage)],
+            tenant_scope=tenant_scope,
         )
 
     @classmethod
@@ -182,17 +223,24 @@ class StaffTaskNotificationEventService:
         order_id: int,
         previous_address: str | None,
         current_address: str | None,
+        tenant_scope: TenantScope,
     ) -> int:
         if (previous_address or "").strip() == (current_address or "").strip():
             return 0
         stages = list(
             (
                 await session.execute(
-                    select(OrderWorkStage).where(
+                    select(OrderWorkStage)
+                    .join(Order, Order.id == OrderWorkStage.order_id)
+                    .where(
                         OrderWorkStage.order_id == order_id,
                         OrderWorkStage.installer_id.is_not(None),
                         OrderWorkStage.status.notin_(
                             [OrderStageStatus.CANCELED, OrderStageStatus.COMPLETED]
+                        ),
+                        tenant_or_fully_legacy_scope_clause(
+                            Order,
+                            tenant_scope,
                         ),
                     )
                 )
@@ -206,6 +254,7 @@ class StaffTaskNotificationEventService:
                     stage=stage,
                     change_fields=("address",),
                     previous_values=[previous_address, current_address],
+                    tenant_scope=tenant_scope,
                 )
             )
         return created
@@ -218,6 +267,7 @@ class StaffTaskNotificationEventService:
         now: datetime | None = None,
         offset_minutes: int = 120,
         scan_window_minutes: int = 10,
+        tenant_scope: TenantScope,
     ) -> int:
         current = now or datetime.now()
         target_from = current + timedelta(minutes=max(1, int(offset_minutes)))
@@ -227,12 +277,18 @@ class StaffTaskNotificationEventService:
         stages = list(
             (
                 await session.execute(
-                    select(OrderWorkStage).where(
+                    select(OrderWorkStage)
+                    .join(Order, Order.id == OrderWorkStage.order_id)
+                    .where(
                         OrderWorkStage.start_time >= target_from,
                         OrderWorkStage.start_time < target_to,
                         OrderWorkStage.installer_id.is_not(None),
                         OrderWorkStage.status.notin_(
                             [OrderStageStatus.CANCELED, OrderStageStatus.COMPLETED]
+                        ),
+                        tenant_or_fully_legacy_scope_clause(
+                            Order,
+                            tenant_scope,
                         ),
                     )
                 )
@@ -247,6 +303,7 @@ class StaffTaskNotificationEventService:
                     installer_id=stage.installer_id,
                     event_kind="departure_reminder",
                     identity=[stage.start_time, int(offset_minutes)],
+                    tenant_scope=tenant_scope,
                     reminder_offset_minutes=int(offset_minutes),
                 )
             )

--- a/services/staff_tenant_membership_service.py
+++ b/services/staff_tenant_membership_service.py
@@ -97,6 +97,22 @@ class StaffTenantMembershipService:
             statement = statement.with_for_update()
         return list((await session.execute(statement)).scalars().all())
 
+    @staticmethod
+    async def get_for_tenant(
+        session: AsyncSession,
+        *,
+        tenant_id: int,
+        staff_user_id: int,
+        active_only: bool = False,
+    ) -> TenantMembership | None:
+        statement = select(TenantMembership).where(
+            TenantMembership.tenant_id == int(tenant_id),
+            TenantMembership.staff_user_id == int(staff_user_id),
+        )
+        if active_only:
+            statement = statement.where(TenantMembership.status == "active")
+        return (await session.execute(statement)).scalars().first()
+
     @classmethod
     async def ensure(
         cls,

--- a/services/staff_user_service.py
+++ b/services/staff_user_service.py
@@ -514,8 +514,21 @@ class StaffUserService:
         *,
         search: Optional[str] = None,
         limit: int = 100,
+        tenant_scope: TenantScope,
     ) -> list[StaffUser]:
-        stmt = select(StaffUser).where(StaffUser.status == cls.STATUS_ACTIVE).order_by(StaffUser.display_name.asc())
+        stmt = (
+            select(StaffUser)
+            .join(
+                TenantMembership,
+                TenantMembership.staff_user_id == StaffUser.id,
+            )
+            .where(
+                StaffUser.status == cls.STATUS_ACTIVE,
+                TenantMembership.tenant_id == tenant_scope.tenant_id,
+                TenantMembership.status == "active",
+            )
+            .order_by(StaffUser.display_name.asc())
+        )
         result = await session.execute(stmt)
         users = list(result.scalars().all())
 
@@ -532,24 +545,42 @@ class StaffUserService:
         return filtered
 
     @classmethod
-    async def get_active_owner_admin_telegram_recipient_ids(cls, session: AsyncSession) -> list[int]:
+    async def get_active_owner_admin_telegram_recipient_ids(
+        cls,
+        session: AsyncSession,
+        *,
+        tenant_scope: TenantScope,
+    ) -> list[int]:
         try:
             stmt = (
-                select(StaffUser)
-                .where(StaffUser.status == cls.STATUS_ACTIVE)
-                .where(StaffUser.telegram_id.is_not(None))
+                select(StaffUser, TenantMembership)
+                .join(
+                    TenantMembership,
+                    TenantMembership.staff_user_id == StaffUser.id,
+                )
+                .where(
+                    StaffUser.status == cls.STATUS_ACTIVE,
+                    StaffUser.telegram_id.is_not(None),
+                    TenantMembership.tenant_id == tenant_scope.tenant_id,
+                    TenantMembership.status == "active",
+                )
                 .order_by(StaffUser.id.asc())
             )
             result = await session.execute(stmt)
-            users = list(result.scalars().all())
+            rows = list(result.all())
         except Exception:
-            logger.debug("STAFF_RECIPIENTS_DB_LOOKUP_FAILED using legacy ADMIN_IDS fallback", exc_info=True)
-            return settings.admin_list
+            logger.debug(
+                "STAFF_RECIPIENTS_DB_LOOKUP_FAILED tenant_id=%s",
+                tenant_scope.tenant_id,
+                exc_info=True,
+            )
+            return settings.admin_list if tenant_scope.is_system else []
 
         recipient_ids: list[int] = []
         seen: set[int] = set()
-        for user in users:
-            if not cls.can_receive_admin_notifications(user):
+        for user, membership in rows:
+            membership_role = cls.normalize_primary_role(membership.role)
+            if membership_role not in cls.OWNER_ADMIN_ROLES:
                 continue
             telegram_id = int(user.telegram_id)
             if telegram_id in seen:
@@ -557,7 +588,9 @@ class StaffUserService:
             seen.add(telegram_id)
             recipient_ids.append(telegram_id)
 
-        return recipient_ids or settings.admin_list
+        if recipient_ids:
+            return recipient_ids
+        return settings.admin_list if tenant_scope.is_system else []
 
     @classmethod
     async def is_active_owner_admin_telegram_user(

--- a/services/stats_service.py
+++ b/services/stats_service.py
@@ -1,31 +1,57 @@
 from datetime import datetime, timedelta
-from sqlalchemy import select, func
+from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from models.order import BankReceipt, Order
 from models.customer import Customer, CustomerContract
 from models.common import OrderStatus
+from models.tenancy import TenantScope
 from schemas import DashboardBankReceiptReviewItem, DashboardContractExpiry, DashboardStatsResponse, DashboardTouchpoint
+from services.tenant_scope_service import (
+    tenant_or_fully_legacy_scope_clause,
+    tenant_or_legacy_owner_scope_clause,
+)
 
 class StatsService:
     @staticmethod
-    async def get_dashboard_stats(session: AsyncSession) -> DashboardStatsResponse:
+    async def get_dashboard_stats(
+        session: AsyncSession,
+        *,
+        tenant_scope: TenantScope,
+    ) -> DashboardStatsResponse:
         now = datetime.now()
         start_of_month = datetime(now.year, now.month, 1)
+        order_scope = tenant_or_fully_legacy_scope_clause(Order, tenant_scope)
+        order_customer_scope = or_(
+            Order.customer_id.is_(None),
+            tenant_or_legacy_owner_scope_clause(Customer, tenant_scope),
+        )
 
         # 1. Total Amount for CLOSED deals in the current month
-        total_stmt = select(func.sum(Order.total_amount)).where(
-            Order.status == OrderStatus.CLOSED,
-            Order.created_at >= start_of_month
+        total_stmt = (
+            select(func.sum(Order.total_amount))
+            .outerjoin(Customer, Customer.id == Order.customer_id)
+            .where(
+                order_scope,
+                order_customer_scope,
+                Order.status == OrderStatus.CLOSED,
+                Order.created_at >= start_of_month,
+            )
         )
         total_result = await session.execute(total_stmt)
         total_amount = total_result.scalar() or 0.0
 
         # 2. New Leads count in the current month
-        leads_stmt = select(func.count(Order.id)).where(
-            Order.status == OrderStatus.NEW_LEAD,
-            Order.created_at >= start_of_month
+        leads_stmt = (
+            select(func.count(Order.id))
+            .outerjoin(Customer, Customer.id == Order.customer_id)
+            .where(
+                order_scope,
+                order_customer_scope,
+                Order.status == OrderStatus.NEW_LEAD,
+                Order.created_at >= start_of_month,
+            )
         )
         leads_result = await session.execute(leads_stmt)
         new_leads_count = leads_result.scalar() or 0
@@ -36,8 +62,11 @@ class StatsService:
         
         touchpoints_stmt = (
             select(Order)
+            .outerjoin(Customer, Customer.id == Order.customer_id)
             .options(selectinload(Order.customer))
             .where(
+                order_scope,
+                order_customer_scope,
                 Order.next_followup_date.is_not(None),
                 Order.next_followup_date <= end_of_window,
                 Order.status != OrderStatus.CLOSED
@@ -65,8 +94,10 @@ class StatsService:
 
         contracts_stmt = (
             select(CustomerContract)
+            .join(Customer, Customer.id == CustomerContract.customer_id)
             .options(selectinload(CustomerContract.customer))
             .where(
+                tenant_or_legacy_owner_scope_clause(Customer, tenant_scope),
                 CustomerContract.status == "active",
                 CustomerContract.valid_until <= end_of_window,
             )
@@ -87,33 +118,42 @@ class StatsService:
             for contract in contracts
         ]
 
-        bank_receipts_count_stmt = select(func.count(BankReceipt.id)).where(BankReceipt.status == "requires_review")
-        bank_receipts_count = int((await session.execute(bank_receipts_count_stmt)).scalar() or 0)
-        bank_receipts_stmt = (
-            select(BankReceipt)
-            .where(BankReceipt.status == "requires_review")
-            .order_by(BankReceipt.received_at.desc().nullslast(), BankReceipt.created_at.desc())
-            .limit(5)
-        )
-        bank_receipts_result = await session.execute(bank_receipts_stmt)
         bank_receipts_review = []
-        for receipt in bank_receipts_result.scalars().all():
-            meta = receipt.match_meta if isinstance(receipt.match_meta, dict) else {}
-            raw_ids = meta.get("candidate_order_ids") or []
-            candidate_order_ids = [int(item) for item in raw_ids if item]
-            bank_receipts_review.append(
-                DashboardBankReceiptReviewItem(
-                    id=int(receipt.id or 0),
-                    received_at=receipt.received_at,
-                    amount=float(receipt.amount or 0),
-                    currency=receipt.currency,
-                    payer_name=receipt.payer_name,
-                    payer_unp=receipt.payer_unp,
-                    payment_document_number=receipt.payment_document_number,
-                    payment_purpose=receipt.payment_purpose,
-                    candidate_order_ids=candidate_order_ids,
-                )
+        bank_receipts_count = 0
+        if tenant_scope.is_system:
+            bank_receipts_count_stmt = select(func.count(BankReceipt.id)).where(
+                BankReceipt.status == "requires_review"
             )
+            bank_receipts_count = int(
+                (await session.execute(bank_receipts_count_stmt)).scalar() or 0
+            )
+            bank_receipts_stmt = (
+                select(BankReceipt)
+                .where(BankReceipt.status == "requires_review")
+                .order_by(
+                    BankReceipt.received_at.desc().nullslast(),
+                    BankReceipt.created_at.desc(),
+                )
+                .limit(5)
+            )
+            bank_receipts_result = await session.execute(bank_receipts_stmt)
+            for receipt in bank_receipts_result.scalars().all():
+                meta = receipt.match_meta if isinstance(receipt.match_meta, dict) else {}
+                raw_ids = meta.get("candidate_order_ids") or []
+                candidate_order_ids = [int(item) for item in raw_ids if item]
+                bank_receipts_review.append(
+                    DashboardBankReceiptReviewItem(
+                        id=int(receipt.id or 0),
+                        received_at=receipt.received_at,
+                        amount=float(receipt.amount or 0),
+                        currency=receipt.currency,
+                        payer_name=receipt.payer_name,
+                        payer_unp=receipt.payer_unp,
+                        payment_document_number=receipt.payment_document_number,
+                        payment_purpose=receipt.payment_purpose,
+                        candidate_order_ids=candidate_order_ids,
+                    )
+                )
 
         return DashboardStatsResponse(
             total_amount=float(total_amount),

--- a/services/tenant_entity_access_service.py
+++ b/services/tenant_entity_access_service.py
@@ -1,0 +1,187 @@
+"""Central tenant ownership checks for CRM root and child entities.
+
+Manager-facing code must resolve ownership through this module before reading
+or mutating an entity by an opaque database id.  Child objects inherit the
+security boundary from their Order or Customer; they are never trusted on
+their id alone.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from sqlalchemy import or_
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from models import (
+    Customer,
+    CustomerEquipment,
+    Lead,
+    Order,
+    OrderDocument,
+    OrderWorkStage,
+)
+from models.tenancy import TenantScope
+from services.tenant_scope_service import (
+    tenant_or_fully_legacy_scope_clause,
+    tenant_or_legacy_owner_scope_clause,
+)
+
+
+class TenantEntityAccessService:
+    """Load tenant-owned CRM entities without leaking foreign existence."""
+
+    @staticmethod
+    def order_clause(tenant_scope: TenantScope):
+        return tenant_or_fully_legacy_scope_clause(Order, tenant_scope)
+
+    @staticmethod
+    def lead_clause(tenant_scope: TenantScope):
+        return tenant_or_fully_legacy_scope_clause(Lead, tenant_scope)
+
+    @staticmethod
+    def order_customer_clause(tenant_scope: TenantScope):
+        return or_(
+            Order.customer_id.is_(None),
+            tenant_or_legacy_owner_scope_clause(Customer, tenant_scope),
+        )
+
+    @staticmethod
+    async def get_customer(
+        session: AsyncSession,
+        customer_id: int,
+        *,
+        tenant_scope: TenantScope,
+        for_update: bool = False,
+    ) -> Customer | None:
+        statement = select(Customer).where(
+            Customer.id == int(customer_id),
+            tenant_or_legacy_owner_scope_clause(Customer, tenant_scope),
+        )
+        if for_update:
+            statement = statement.with_for_update(of=Customer)
+        return (await session.execute(statement)).scalars().first()
+
+    @classmethod
+    async def get_order(
+        cls,
+        session: AsyncSession,
+        order_id: int,
+        *,
+        tenant_scope: TenantScope,
+        options: Iterable[Any] = (),
+        for_update: bool = False,
+        populate_existing: bool = False,
+    ) -> Order | None:
+        statement = (
+            select(Order)
+            .outerjoin(Customer, Customer.id == Order.customer_id)
+            .where(
+                Order.id == int(order_id),
+                cls.order_clause(tenant_scope),
+                cls.order_customer_clause(tenant_scope),
+            )
+        )
+        for option in options:
+            statement = statement.options(option)
+        if populate_existing:
+            statement = statement.execution_options(populate_existing=True)
+        if for_update:
+            statement = statement.with_for_update(of=Order)
+        return (await session.execute(statement)).scalars().first()
+
+    @classmethod
+    async def get_lead(
+        cls,
+        session: AsyncSession,
+        lead_id: int,
+        *,
+        tenant_scope: TenantScope,
+        for_update: bool = False,
+    ) -> Lead | None:
+        statement = select(Lead).where(
+            Lead.id == int(lead_id),
+            cls.lead_clause(tenant_scope),
+        )
+        if for_update:
+            statement = statement.with_for_update()
+        return (await session.execute(statement)).scalars().first()
+
+    @classmethod
+    async def get_order_stage(
+        cls,
+        session: AsyncSession,
+        stage_id: int,
+        *,
+        tenant_scope: TenantScope,
+        order_id: int | None = None,
+        options: Iterable[Any] = (),
+        for_update: bool = False,
+    ) -> OrderWorkStage | None:
+        statement = (
+            select(OrderWorkStage)
+            .join(Order, Order.id == OrderWorkStage.order_id)
+            .outerjoin(Customer, Customer.id == Order.customer_id)
+            .where(
+                OrderWorkStage.id == int(stage_id),
+                cls.order_clause(tenant_scope),
+                cls.order_customer_clause(tenant_scope),
+            )
+        )
+        if order_id is not None:
+            statement = statement.where(OrderWorkStage.order_id == int(order_id))
+        for option in options:
+            statement = statement.options(option)
+        if for_update:
+            statement = statement.with_for_update(of=(OrderWorkStage, Order))
+        return (await session.execute(statement)).scalars().first()
+
+    @staticmethod
+    async def get_equipment(
+        session: AsyncSession,
+        equipment_id: int,
+        *,
+        tenant_scope: TenantScope,
+        options: Iterable[Any] = (),
+        for_update: bool = False,
+    ) -> CustomerEquipment | None:
+        statement = (
+            select(CustomerEquipment)
+            .join(Customer, Customer.id == CustomerEquipment.customer_id)
+            .where(
+                CustomerEquipment.id == int(equipment_id),
+                tenant_or_legacy_owner_scope_clause(Customer, tenant_scope),
+            )
+        )
+        for option in options:
+            statement = statement.options(option)
+        if for_update:
+            statement = statement.with_for_update(
+                of=(CustomerEquipment, Customer)
+            )
+        return (await session.execute(statement)).scalars().first()
+
+    @classmethod
+    async def get_order_document(
+        cls,
+        session: AsyncSession,
+        document_id: int,
+        *,
+        tenant_scope: TenantScope,
+        for_update: bool = False,
+    ) -> OrderDocument | None:
+        statement = (
+            select(OrderDocument)
+            .join(Order, Order.id == OrderDocument.order_id)
+            .outerjoin(Customer, Customer.id == Order.customer_id)
+            .where(
+                OrderDocument.id == int(document_id),
+                cls.order_clause(tenant_scope),
+                cls.order_customer_clause(tenant_scope),
+            )
+        )
+        if for_update:
+            statement = statement.with_for_update(of=(OrderDocument, Order))
+        return (await session.execute(statement)).scalars().first()

--- a/services/website_lead_service.py
+++ b/services/website_lead_service.py
@@ -61,6 +61,7 @@ class WebsiteLeadService:
             session=session,
             lead_id=int(lead_data["id"]),
             payload=payload,
+            tenant_scope=tenant_scope,
         )
         return PublicContactLeadResponse(
             lead_id=int(lead_data["id"]),
@@ -74,8 +75,12 @@ class WebsiteLeadService:
         session: AsyncSession,
         lead_id: int,
         payload: PublicContactLeadPayload,
+        tenant_scope: TenantScope,
     ) -> None:
-        admin_ids = await StaffUserService.get_active_owner_admin_telegram_recipient_ids(session)
+        admin_ids = await StaffUserService.get_active_owner_admin_telegram_recipient_ids(
+            session,
+            tenant_scope=tenant_scope,
+        )
         if not admin_ids:
             return
 
@@ -147,6 +152,7 @@ class WebsiteLeadService:
                     payload=payload,
                     now=now,
                     is_repeat=True,
+                    tenant_scope=tenant_scope,
                 )
             return ProductAvailabilityLeadResponse(
                 lead_id=int(order.id or 0),
@@ -183,6 +189,7 @@ class WebsiteLeadService:
             payload=payload,
             now=now,
             is_repeat=False,
+            tenant_scope=tenant_scope,
         )
 
         return ProductAvailabilityLeadResponse(
@@ -292,8 +299,12 @@ class WebsiteLeadService:
         payload: ProductAvailabilityLeadPayload,
         now: datetime,
         is_repeat: bool,
+        tenant_scope: TenantScope,
     ) -> None:
-        admin_ids = await StaffUserService.get_active_owner_admin_telegram_recipient_ids(session)
+        admin_ids = await StaffUserService.get_active_owner_admin_telegram_recipient_ids(
+            session,
+            tenant_scope=tenant_scope,
+        )
         if not admin_ids:
             return
 

--- a/services/website_order_service.py
+++ b/services/website_order_service.py
@@ -66,7 +66,12 @@ class WebsiteOrderService:
             tenant_scope=tenant_scope,
         )
 
-        await WebsiteOrderService._notify_admins(session, order, payload)
+        await WebsiteOrderService._notify_admins(
+            session,
+            order,
+            payload,
+            tenant_scope=tenant_scope,
+        )
 
         return OrderResponse(
             id=order.id,
@@ -76,8 +81,17 @@ class WebsiteOrderService:
         )
 
     @staticmethod
-    async def _notify_admins(session: AsyncSession, order: Order, payload: OrderPayload) -> None:
-        admin_ids = await StaffUserService.get_active_owner_admin_telegram_recipient_ids(session)
+    async def _notify_admins(
+        session: AsyncSession,
+        order: Order,
+        payload: OrderPayload,
+        *,
+        tenant_scope: TenantScope,
+    ) -> None:
+        admin_ids = await StaffUserService.get_active_owner_admin_telegram_recipient_ids(
+            session,
+            tenant_scope=tenant_scope,
+        )
         if not admin_ids:
             return
 

--- a/tests/integration/test_bot_task_mutation_concurrency.py
+++ b/tests/integration/test_bot_task_mutation_concurrency.py
@@ -90,6 +90,7 @@ async def test_postgres_duplicate_bot_task_mutations_change_each_value_once(
                 telegram_id=987654321,
                 stage_id=status_stage.id,
                 status=OrderStageStatus.IN_PROGRESS,
+                tenant_scope=tenant_scope,
             )
             return result.changed
 
@@ -105,6 +106,7 @@ async def test_postgres_duplicate_bot_task_mutations_change_each_value_once(
                 telegram_id=987654321,
                 stage_id=report_stage.id,
                 report="Один и тот же отчет",
+                tenant_scope=tenant_scope,
             )
             return result.changed
 

--- a/tests/integration/test_manager_installers_api.py
+++ b/tests/integration/test_manager_installers_api.py
@@ -1,7 +1,7 @@
 import pytest
 
 from core.config import settings
-from models import Installer, StaffUser
+from models import Installer, StaffUser, TenantMembership
 
 
 async def _auth_headers(async_client):
@@ -22,29 +22,47 @@ async def test_manager_installers_search_uses_active_staff_users(async_client, d
     db.add_all([active, blocked, inactive])
     await db.flush()
 
-    db.add(
-        StaffUser(
-            display_name="Active Staff Installer",
-            status="active",
-            roles=["installer"],
-            legacy_installer_id=active.id,
-        )
+    active_staff = StaffUser(
+        display_name="Active Staff Installer",
+        status="active",
+        roles=["installer"],
+        legacy_installer_id=active.id,
     )
-    db.add(
-        StaffUser(
-            display_name="Blocked Staff Installer",
-            status="blocked",
-            roles=["installer"],
-            legacy_installer_id=blocked.id,
-        )
+    blocked_staff = StaffUser(
+        display_name="Blocked Staff Installer",
+        status="blocked",
+        roles=["installer"],
+        legacy_installer_id=blocked.id,
     )
-    db.add(
-        StaffUser(
-            display_name="Inactive Staff Installer",
-            status="inactive",
-            roles=["installer"],
-            legacy_installer_id=inactive.id,
-        )
+    inactive_staff = StaffUser(
+        display_name="Inactive Staff Installer",
+        status="inactive",
+        roles=["installer"],
+        legacy_installer_id=inactive.id,
+    )
+    db.add_all([active_staff, blocked_staff, inactive_staff])
+    await db.flush()
+    db.add_all(
+        [
+            TenantMembership(
+                tenant_id=1,
+                staff_user_id=int(active_staff.id),
+                role="installer",
+                status="active",
+            ),
+            TenantMembership(
+                tenant_id=1,
+                staff_user_id=int(blocked_staff.id),
+                role="installer",
+                status="suspended",
+            ),
+            TenantMembership(
+                tenant_id=1,
+                staff_user_id=int(inactive_staff.id),
+                role="installer",
+                status="disabled",
+            ),
+        ]
     )
     await db.commit()
 
@@ -75,12 +93,20 @@ async def test_manager_installers_list_keeps_blocked_historical_staff_visible(as
     installer = Installer(name="Legacy Historical", is_active=True)
     db.add(installer)
     await db.flush()
+    staff = StaffUser(
+        display_name="Blocked Historical Staff",
+        status="blocked",
+        roles=["installer"],
+        legacy_installer_id=installer.id,
+    )
+    db.add(staff)
+    await db.flush()
     db.add(
-        StaffUser(
-            display_name="Blocked Historical Staff",
-            status="blocked",
-            roles=["installer"],
-            legacy_installer_id=installer.id,
+        TenantMembership(
+            tenant_id=1,
+            staff_user_id=int(staff.id),
+            role="installer",
+            status="suspended",
         )
     )
     await db.commit()

--- a/tests/integration/test_manager_mail_api.py
+++ b/tests/integration/test_manager_mail_api.py
@@ -301,7 +301,8 @@ async def test_manager_mail_import_endpoint_uses_imap_service(async_client, monk
             created_receipt_ids=[10],
         )
 
-    async def fake_notify(_session, receipt_ids):
+    async def fake_notify(_session, receipt_ids, *, tenant_scope):
+        assert tenant_scope.is_system is True
         notified_receipt_ids.extend(receipt_ids)
         return 1
 

--- a/tests/integration/test_manager_tenant_isolation.py
+++ b/tests/integration/test_manager_tenant_isolation.py
@@ -1,4 +1,4 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 import pytest
 from httpx import AsyncClient
@@ -7,7 +7,15 @@ from sqlmodel import select
 from core.security import create_access_token
 from models import (
     Customer,
+    CustomerEquipment,
     CustomerRequisitesRecognition,
+    Installer,
+    Lead,
+    Order,
+    OrderDocument,
+    OrderStatus,
+    OrderWorkStage,
+    Payment,
     StaffUser,
     Storefront,
     Tenant,
@@ -207,6 +215,611 @@ async def test_customer_api_isolates_tenants_and_legacy_rows(
     assert claim_legacy.status_code == 200
     await db.refresh(legacy)
     assert legacy.tenant_id == 1
+
+
+@pytest.mark.asyncio
+async def test_lead_and_order_api_isolates_tenants_and_legacy_rows(
+    async_client: AsyncClient,
+    db,
+):
+    tenant_b, storefront_b = await _create_tenant(db, slug="crm-b")
+    owner_a = await _create_staff(
+        db,
+        tenant_id=1,
+        username="crm-owner-a",
+    )
+    owner_b = await _create_staff(
+        db,
+        tenant_id=int(tenant_b.id),
+        username="crm-owner-b",
+    )
+
+    legacy_customer = Customer(
+        name="Legacy CRM customer",
+        phone="+375290000011",
+        type=CustomerType.individual,
+    )
+    customer_a = Customer(
+        tenant_id=1,
+        name="CRM customer A",
+        phone="+375290000012",
+        type=CustomerType.individual,
+    )
+    customer_b = Customer(
+        tenant_id=int(tenant_b.id),
+        name="CRM customer B",
+        phone="+375290000013",
+        type=CustomerType.individual,
+    )
+    db.add_all([legacy_customer, customer_a, customer_b])
+    await db.flush()
+
+    legacy_lead = Lead(
+        source="manager",
+        name="Legacy lead",
+        request_text="Legacy request",
+    )
+    lead_a = Lead(
+        tenant_id=1,
+        storefront_id=1,
+        source="manager",
+        name="Lead A",
+        request_text="Tenant A request",
+    )
+    lead_b = Lead(
+        tenant_id=int(tenant_b.id),
+        storefront_id=int(storefront_b.id),
+        source="manager",
+        name="Lead B",
+        request_text="Tenant B request",
+    )
+    legacy_order = Order(
+        customer_id=int(legacy_customer.id),
+        status=OrderStatus.NEGOTIATION,
+        title="Legacy order",
+    )
+    order_a = Order(
+        tenant_id=1,
+        storefront_id=1,
+        customer_id=int(customer_a.id),
+        status=OrderStatus.NEGOTIATION,
+        title="Order A",
+    )
+    order_b = Order(
+        tenant_id=int(tenant_b.id),
+        storefront_id=int(storefront_b.id),
+        customer_id=int(customer_b.id),
+        status=OrderStatus.NEGOTIATION,
+        title="Order B",
+    )
+    inconsistent_order = Order(
+        tenant_id=1,
+        storefront_id=1,
+        customer_id=int(customer_b.id),
+        status=OrderStatus.NEGOTIATION,
+        title="Inconsistent cross-tenant order",
+    )
+    db.add_all(
+        [
+            legacy_lead,
+            lead_a,
+            lead_b,
+            legacy_order,
+            order_a,
+            order_b,
+            inconsistent_order,
+        ]
+    )
+    await db.commit()
+
+    headers_a = _headers(owner_a)
+    headers_b = _headers(owner_b)
+
+    leads_a = await async_client.get("/api/manager/leads", headers=headers_a)
+    leads_b = await async_client.get("/api/manager/leads", headers=headers_b)
+    assert leads_a.status_code == 200
+    assert leads_b.status_code == 200
+    assert {item["id"] for item in leads_a.json()["items"]} == {
+        legacy_lead.id,
+        lead_a.id,
+    }
+    assert {item["id"] for item in leads_b.json()["items"]} == {lead_b.id}
+
+    orders_a = await async_client.get(
+        "/api/manager/orders?segment=all",
+        headers=headers_a,
+    )
+    orders_b = await async_client.get(
+        "/api/manager/orders?segment=all",
+        headers=headers_b,
+    )
+    assert orders_a.status_code == 200
+    assert orders_b.status_code == 200
+    assert {item["id"] for item in orders_a.json()["items"]} == {
+        legacy_order.id,
+        order_a.id,
+    }
+    assert {item["id"] for item in orders_b.json()["items"]} == {order_b.id}
+    for headers in (headers_a, headers_b):
+        inconsistent_detail = await async_client.get(
+            f"/api/manager/orders/{inconsistent_order.id}",
+            headers=headers,
+        )
+        assert inconsistent_detail.status_code == 404
+
+    lead_cross_tenant_responses = (
+        await async_client.patch(
+            f"/api/manager/leads/{lead_b.id}",
+            headers=headers_a,
+            json={"name": "Cross-tenant lead write"},
+        ),
+        await async_client.post(
+            f"/api/manager/leads/{lead_b.id}/mark-lost",
+            headers=headers_a,
+            json={"status": "lost"},
+        ),
+        await async_client.post(
+            f"/api/manager/leads/{lead_b.id}/qualify",
+            headers=headers_a,
+            json={},
+        ),
+    )
+    assert [response.status_code for response in lead_cross_tenant_responses] == [
+        404,
+        404,
+        404,
+    ]
+
+    order_detail = await async_client.get(
+        f"/api/manager/orders/{order_b.id}",
+        headers=headers_a,
+    )
+    order_patch = await async_client.patch(
+        f"/api/manager/orders/{order_b.id}",
+        headers=headers_a,
+        json={"comment": "Cross-tenant order write"},
+    )
+    order_export = await async_client.post(
+        "/api/manager/orders/export",
+        headers=headers_a,
+        json={"order_ids": [order_b.id]},
+    )
+    order_delete = await async_client.delete(
+        f"/api/manager/orders/{order_b.id}",
+        headers=headers_a,
+    )
+    assert order_detail.status_code == 404
+    assert order_patch.status_code == 404
+    assert order_export.status_code == 400
+    assert order_delete.status_code == 400
+
+    await db.refresh(lead_b)
+    await db.refresh(order_b)
+    assert lead_b.name == "Lead B"
+    assert str(lead_b.status) == "new"
+    assert lead_b.converted_order_id is None
+    assert order_b.comment is None
+    assert order_b.title == "Order B"
+
+
+@pytest.mark.asyncio
+async def test_order_children_and_equipment_reject_foreign_tenant_ids(
+    async_client: AsyncClient,
+    db,
+):
+    tenant_b, storefront_b = await _create_tenant(db, slug="children-b")
+    owner_a = await _create_staff(
+        db,
+        tenant_id=1,
+        username="children-owner-a",
+    )
+    owner_b = await _create_staff(
+        db,
+        tenant_id=int(tenant_b.id),
+        username="children-owner-b",
+    )
+    customer_b = Customer(
+        tenant_id=int(tenant_b.id),
+        name="Children customer B",
+        phone="+375290000021",
+        type=CustomerType.individual,
+    )
+    db.add(customer_b)
+    await db.flush()
+    order_b = Order(
+        tenant_id=int(tenant_b.id),
+        storefront_id=int(storefront_b.id),
+        customer_id=int(customer_b.id),
+        status=OrderStatus.NEGOTIATION,
+        title="Children order B",
+    )
+    db.add(order_b)
+    await db.flush()
+    stage_b = OrderWorkStage(
+        order_id=int(order_b.id),
+        name="Foreign tenant stage",
+    )
+    payment_b = Payment(
+        order_id=int(order_b.id),
+        amount=100,
+    )
+    document_b = OrderDocument(
+        order_id=int(order_b.id),
+        doc_type="invoice",
+        number="B-1",
+        google_file_id="foreign-document",
+        google_edit_url="https://example.invalid/foreign-document",
+    )
+    equipment_b = CustomerEquipment(
+        customer_id=int(customer_b.id),
+        source_order_id=int(order_b.id),
+        display_name="Foreign tenant equipment",
+        equipment_type="split",
+    )
+    db.add_all([stage_b, payment_b, document_b, equipment_b])
+    await db.commit()
+
+    headers_a = _headers(owner_a)
+    headers_b = _headers(owner_b)
+
+    equipment_a = await async_client.get(
+        "/api/manager/equipment",
+        headers=headers_a,
+    )
+    equipment_b_list = await async_client.get(
+        "/api/manager/equipment",
+        headers=headers_b,
+    )
+    assert equipment_a.status_code == 200
+    assert equipment_b_list.status_code == 200
+    assert equipment_a.json()["items"] == []
+    assert {item["id"] for item in equipment_b_list.json()["items"]} == {
+        equipment_b.id,
+    }
+
+    foreign_responses = (
+        await async_client.patch(
+            f"/api/manager/orders/work-stages/{stage_b.id}/cancel",
+            headers=headers_a,
+        ),
+        await async_client.delete(
+            f"/api/manager/orders/{order_b.id}/payments/{payment_b.id}",
+            headers=headers_a,
+        ),
+        await async_client.get(
+            f"/api/manager/orders/{order_b.id}/documents",
+            headers=headers_a,
+        ),
+        await async_client.delete(
+            f"/api/manager/docs/{document_b.id}",
+            headers=headers_a,
+        ),
+        await async_client.get(
+            f"/api/manager/orders/{order_b.id}/attachments",
+            headers=headers_a,
+        ),
+        await async_client.get(
+            f"/api/manager/orders/{order_b.id}/equipment-links",
+            headers=headers_a,
+        ),
+        await async_client.get(
+            f"/api/manager/equipment/{equipment_b.id}",
+            headers=headers_a,
+        ),
+        await async_client.patch(
+            f"/api/manager/equipment/{equipment_b.id}",
+            headers=headers_a,
+            json={"notes": "Cross-tenant equipment write"},
+        ),
+        await async_client.get(
+            f"/api/manager/equipment/{equipment_b.id}/history",
+            headers=headers_a,
+        ),
+        await async_client.get(
+            f"/api/manager/equipment/{equipment_b.id}/attachments",
+            headers=headers_a,
+        ),
+        await async_client.get(
+            "/api/manager/docs/templates/contract",
+            params={"order_id": order_b.id},
+            headers=headers_a,
+        ),
+        await async_client.get(
+            "/api/manager/docs/templates/contract",
+            params={"customer_id": customer_b.id},
+            headers=headers_a,
+        ),
+    )
+    assert [response.status_code for response in foreign_responses] == [
+        404,
+        404,
+        404,
+        404,
+        404,
+        404,
+        404,
+        404,
+        404,
+        404,
+        404,
+        404,
+    ]
+
+    owned_order_templates = await async_client.get(
+        "/api/manager/docs/templates/contract",
+        params={"order_id": order_b.id},
+        headers=headers_b,
+    )
+    owned_customer_templates = await async_client.get(
+        "/api/manager/docs/templates/contract",
+        params={"customer_id": customer_b.id},
+        headers=headers_b,
+    )
+    missing_context_templates = await async_client.get(
+        "/api/manager/docs/templates/contract",
+        headers=headers_b,
+    )
+    global_templates = await async_client.get(
+        "/api/manager/docs/document-templates",
+        headers=headers_b,
+    )
+    global_template_files = await async_client.get(
+        "/api/manager/docs/document-template-files",
+        headers=headers_b,
+    )
+    assert owned_order_templates.status_code == 200
+    assert owned_customer_templates.status_code == 200
+    assert missing_context_templates.status_code == 403
+    assert global_templates.status_code == 403
+    assert global_template_files.status_code == 403
+
+    await db.refresh(stage_b)
+    await db.refresh(payment_b)
+    await db.refresh(document_b)
+    await db.refresh(equipment_b)
+    assert str(stage_b.status) == "planned"
+    assert payment_b.amount == 100
+    assert document_b.number == "B-1"
+    assert equipment_b.notes is None
+
+
+@pytest.mark.asyncio
+async def test_installer_directory_and_updates_are_tenant_scoped(
+    async_client: AsyncClient,
+    db,
+):
+    tenant_b, _ = await _create_tenant(db, slug="installer-b")
+    owner_a = await _create_staff(
+        db,
+        tenant_id=1,
+        username="installer-owner-a",
+    )
+    owner_b = await _create_staff(
+        db,
+        tenant_id=int(tenant_b.id),
+        username="installer-owner-b",
+    )
+    legacy_installer = Installer(
+        name="Legacy standalone installer",
+        is_active=True,
+    )
+    installer_b = Installer(
+        name="Tenant B legacy identity",
+        is_active=True,
+    )
+    db.add_all([legacy_installer, installer_b])
+    await db.flush()
+    staff_b = StaffUser(
+        display_name="Tenant B installer",
+        status="active",
+        primary_role="installer",
+        roles=["installer"],
+        username="tenant-b-installer",
+        legacy_installer_id=int(installer_b.id),
+    )
+    db.add(staff_b)
+    await db.flush()
+    db.add(
+        TenantMembership(
+            tenant_id=int(tenant_b.id),
+            staff_user_id=int(staff_b.id),
+            role="installer",
+            status="active",
+        )
+    )
+    await db.commit()
+
+    headers_a = _headers(owner_a)
+    headers_b = _headers(owner_b)
+    list_a = await async_client.get(
+        "/api/manager/installers",
+        headers=headers_a,
+    )
+    list_b = await async_client.get(
+        "/api/manager/installers",
+        headers=headers_b,
+    )
+    assert list_a.status_code == 200
+    assert list_b.status_code == 200
+    assert {item["id"] for item in list_a.json()["items"]} == {
+        legacy_installer.id,
+    }
+    assert {item["id"] for item in list_b.json()["items"]} == {installer_b.id}
+
+    search_a = await async_client.get(
+        "/api/manager/installers/search",
+        params={"q": "Tenant B"},
+        headers=headers_a,
+    )
+    search_b = await async_client.get(
+        "/api/manager/installers/search",
+        params={"q": "Tenant B"},
+        headers=headers_b,
+    )
+    assert search_a.status_code == 200
+    assert search_a.json()["items"] == []
+    assert [item["id"] for item in search_b.json()["items"]] == [installer_b.id]
+
+    foreign_update = await async_client.put(
+        f"/api/manager/installers/{installer_b.id}",
+        headers=headers_a,
+        json={"name": "Cross-tenant installer write"},
+    )
+    assert foreign_update.status_code == 404
+    await db.refresh(installer_b)
+    await db.refresh(staff_b)
+    assert installer_b.name == "Tenant B legacy identity"
+    assert staff_b.display_name == "Tenant B installer"
+
+
+@pytest.mark.asyncio
+async def test_dashboard_is_tenant_scoped_and_global_mail_is_system_only(
+    async_client: AsyncClient,
+    db,
+):
+    tenant_b, storefront_b = await _create_tenant(db, slug="dashboard-b")
+    owner_a = await _create_staff(
+        db,
+        tenant_id=1,
+        username="dashboard-owner-a",
+    )
+    owner_b = await _create_staff(
+        db,
+        tenant_id=int(tenant_b.id),
+        username="dashboard-owner-b",
+    )
+    legacy_customer = Customer(
+        name="Legacy dashboard customer",
+        phone="+375290000031",
+        type=CustomerType.individual,
+    )
+    customer_a = Customer(
+        tenant_id=1,
+        name="Dashboard customer A",
+        phone="+375290000032",
+        type=CustomerType.individual,
+    )
+    customer_b = Customer(
+        tenant_id=int(tenant_b.id),
+        name="Dashboard customer B",
+        phone="+375290000033",
+        type=CustomerType.individual,
+    )
+    db.add_all([legacy_customer, customer_a, customer_b])
+    await db.flush()
+    followup_at = datetime.now() + timedelta(days=1)
+    legacy_order = Order(
+        customer_id=int(legacy_customer.id),
+        status=OrderStatus.NEW_LEAD,
+        title="Legacy dashboard order",
+        next_followup_date=followup_at,
+        installation_date=followup_at,
+    )
+    order_a = Order(
+        tenant_id=1,
+        storefront_id=1,
+        customer_id=int(customer_a.id),
+        status=OrderStatus.NEW_LEAD,
+        title="Dashboard order A",
+        next_followup_date=followup_at,
+        installation_date=followup_at,
+    )
+    order_b = Order(
+        tenant_id=int(tenant_b.id),
+        storefront_id=int(storefront_b.id),
+        customer_id=int(customer_b.id),
+        status=OrderStatus.NEW_LEAD,
+        title="Dashboard order B",
+        next_followup_date=followup_at,
+        installation_date=followup_at,
+    )
+    inconsistent_order = Order(
+        tenant_id=1,
+        storefront_id=1,
+        customer_id=int(customer_b.id),
+        status=OrderStatus.NEW_LEAD,
+        title="Inconsistent dashboard order",
+        next_followup_date=followup_at,
+        installation_date=followup_at,
+    )
+    db.add_all([legacy_order, order_a, order_b, inconsistent_order])
+    await db.commit()
+
+    headers_a = _headers(owner_a)
+    headers_b = _headers(owner_b)
+    dashboard_a = await async_client.get(
+        "/api/manager/dashboard/stats",
+        headers=headers_a,
+    )
+    dashboard_b = await async_client.get(
+        "/api/manager/dashboard/stats",
+        headers=headers_b,
+    )
+    assert dashboard_a.status_code == 200
+    assert dashboard_b.status_code == 200
+    assert dashboard_a.json()["new_leads_count"] == 2
+    assert dashboard_b.json()["new_leads_count"] == 1
+    assert {
+        item["order_id"] for item in dashboard_a.json()["upcoming_touchpoints"]
+    } == {legacy_order.id, order_a.id}
+    assert {
+        item["order_id"] for item in dashboard_b.json()["upcoming_touchpoints"]
+    } == {order_b.id}
+
+    counter_a = await async_client.get(
+        "/api/manager/leads/counter",
+        headers=headers_a,
+    )
+    counter_b = await async_client.get(
+        "/api/manager/leads/counter",
+        headers=headers_b,
+    )
+    inbox_a = await async_client.get(
+        "/api/manager/leads/inbox",
+        headers=headers_a,
+    )
+    inbox_b = await async_client.get(
+        "/api/manager/leads/inbox",
+        headers=headers_b,
+    )
+    assert counter_a.json()["count"] == 2
+    assert counter_b.json()["count"] == 1
+    assert {item["id"] for item in inbox_a.json()["items"]} == {
+        legacy_order.id,
+        order_a.id,
+    }
+    assert {item["id"] for item in inbox_b.json()["items"]} == {order_b.id}
+
+    calendar_params = {
+        "start": (datetime.now() - timedelta(days=1)).isoformat(),
+        "end": (datetime.now() + timedelta(days=2)).isoformat(),
+    }
+    calendar_a = await async_client.get(
+        "/api/manager/calendar/events",
+        params=calendar_params,
+        headers=headers_a,
+    )
+    calendar_b = await async_client.get(
+        "/api/manager/calendar/events",
+        params=calendar_params,
+        headers=headers_b,
+    )
+    assert {item["order_id"] for item in calendar_a.json()} == {
+        legacy_order.id,
+        order_a.id,
+    }
+    assert {item["order_id"] for item in calendar_b.json()} == {order_b.id}
+
+    system_mail = await async_client.get(
+        "/api/manager/mail/bank-receipts",
+        headers=headers_a,
+    )
+    foreign_mail = await async_client.get(
+        "/api/manager/mail/bank-receipts",
+        headers=headers_b,
+    )
+    assert system_mail.status_code == 200
+    assert foreign_mail.status_code == 403
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_bot_order_attachment_service.py
+++ b/tests/unit/test_bot_order_attachment_service.py
@@ -6,9 +6,23 @@ from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 from sqlmodel import SQLModel, select
 
-from models import Customer, Order, OrderAttachmentLink, OrderInstaller, OrderStatus, OrderWorkStage, ServiceAttachment, StaffUser
+from models import (
+    Customer,
+    Order,
+    OrderAttachmentLink,
+    OrderInstaller,
+    OrderStatus,
+    OrderWorkStage,
+    ServiceAttachment,
+    StaffUser,
+    TenantMembership,
+)
 from services.bot_order_attachment_service import BotOrderAttachmentService
 from services.private_attachment_storage_service import StoredPrivateObject
+
+from models.tenancy import TenantScope
+
+TEST_TENANT_SCOPE = TenantScope(tenant_id=1, storefront_id=1, is_system=True)
 
 
 class FakePrivateAttachmentStorage:
@@ -76,6 +90,7 @@ async def test_stores_file_id_in_order_meta_and_comment(sqlite_order_attachment_
         telegram_user_id=777,
         telegram_chat_id=100,
         telegram_message_id=55,
+        tenant_scope=TEST_TENANT_SCOPE,
     )
 
     assert result is not None
@@ -124,6 +139,7 @@ async def test_stores_attachment_content_in_private_history(
         telegram_chat_id=100,
         telegram_message_id=55,
         content=b"image-content",
+        tenant_scope=TEST_TENANT_SCOPE,
     )
 
     assert result is not None
@@ -159,8 +175,8 @@ async def test_does_not_duplicate_same_file(sqlite_order_attachment_session):
         "telegram_chat_id": 100,
         "telegram_message_id": 55,
     }
-    first = await BotOrderAttachmentService.attach_to_order(sqlite_order_attachment_session, int(order.id), **kwargs)
-    second = await BotOrderAttachmentService.attach_to_order(sqlite_order_attachment_session, int(order.id), **kwargs)
+    first = await BotOrderAttachmentService.attach_to_order(sqlite_order_attachment_session, int(order.id), **kwargs, tenant_scope=TEST_TENANT_SCOPE)
+    second = await BotOrderAttachmentService.attach_to_order(sqlite_order_attachment_session, int(order.id), **kwargs, tenant_scope=TEST_TENANT_SCOPE)
 
     assert first["already_attached"] is False
     assert second["already_attached"] is True
@@ -212,6 +228,7 @@ async def test_updates_existing_attachment_with_stored_content(
         telegram_chat_id=100,
         telegram_message_id=55,
         content=b"image-content",
+        tenant_scope=TEST_TENANT_SCOPE,
     )
 
     assert result is not None
@@ -236,7 +253,7 @@ async def test_lists_recent_active_orders(sqlite_order_attachment_session):
     sqlite_order_attachment_session.add(closed)
     await sqlite_order_attachment_session.commit()
 
-    orders = await BotOrderAttachmentService.list_recent_orders(sqlite_order_attachment_session)
+    orders = await BotOrderAttachmentService.list_recent_orders(sqlite_order_attachment_session, tenant_scope=TEST_TENANT_SCOPE)
 
     assert [item["id"] for item in orders] == [active.id]
 
@@ -257,18 +274,34 @@ async def test_executor_can_attach_only_assigned_order(sqlite_order_attachment_s
     sqlite_order_attachment_session.add(assigned)
     sqlite_order_attachment_session.add(other)
     await sqlite_order_attachment_session.flush()
-    sqlite_order_attachment_session.add(OrderWorkStage(order_id=assigned.id, installer_id=10, name="Монтаж"))
+    sqlite_order_attachment_session.add_all(
+        [
+            TenantMembership(
+                tenant_id=TEST_TENANT_SCOPE.tenant_id,
+                staff_user_id=int(staff.id or 0),
+                role="installer",
+                status="active",
+            ),
+            OrderWorkStage(
+                order_id=assigned.id,
+                installer_id=10,
+                name="Монтаж",
+            ),
+        ]
+    )
     await sqlite_order_attachment_session.commit()
 
     assert await BotOrderAttachmentService.can_attach_to_order(
         sqlite_order_attachment_session,
         int(assigned.id),
         telegram_user_id=777,
+        tenant_scope=TEST_TENANT_SCOPE,
     )
     assert not await BotOrderAttachmentService.can_attach_to_order(
         sqlite_order_attachment_session,
         int(other.id),
         telegram_user_id=777,
+        tenant_scope=TEST_TENANT_SCOPE,
     )
 
 
@@ -286,21 +319,36 @@ async def test_executor_can_attach_legacy_installer_order(sqlite_order_attachmen
     sqlite_order_attachment_session.add(staff)
     sqlite_order_attachment_session.add(order)
     await sqlite_order_attachment_session.flush()
-    sqlite_order_attachment_session.add(OrderInstaller(order_id=order.id, installer_id=10))
+    sqlite_order_attachment_session.add_all(
+        [
+            TenantMembership(
+                tenant_id=TEST_TENANT_SCOPE.tenant_id,
+                staff_user_id=int(staff.id or 0),
+                role="installer",
+                status="active",
+            ),
+            OrderInstaller(order_id=order.id, installer_id=10),
+        ]
+    )
     await sqlite_order_attachment_session.commit()
 
     assert await BotOrderAttachmentService.can_attach_to_order(
         sqlite_order_attachment_session,
         int(order.id),
         telegram_user_id=777,
+        tenant_scope=TEST_TENANT_SCOPE,
     )
 
 
 @pytest.mark.asyncio
-async def test_manager_can_attach_any_order(sqlite_order_attachment_session):
+async def test_manager_can_attach_any_existing_order(sqlite_order_attachment_session):
+    order = Order(title="Менеджерский заказ")
+    sqlite_order_attachment_session.add(order)
+    await sqlite_order_attachment_session.commit()
     assert await BotOrderAttachmentService.can_attach_to_order(
         sqlite_order_attachment_session,
-        999,
+        int(order.id),
         telegram_user_id=None,
         can_attach_any=True,
+        tenant_scope=TEST_TENANT_SCOPE,
     )

--- a/tests/unit/test_bot_repair_nameplate_service.py
+++ b/tests/unit/test_bot_repair_nameplate_service.py
@@ -20,6 +20,7 @@ from models import (
     Product,
     ServiceAttachment,
     StaffUser,
+    TenantMembership,
 )
 from services.bot_order_attachment_service import BotOrderAttachmentService
 from services.bot_defect_act_service import BotDefectActService
@@ -28,6 +29,10 @@ from services.bot_warranty_nameplate_service import BotWarrantyNameplateService
 from services.customer_requisites_recognition_service import CustomerRequisitesRecognitionService
 from services.defect_act_ai_service import DefectActAIService
 from services.private_attachment_storage_service import StoredPrivateObject
+
+from models.tenancy import TenantScope
+
+TEST_TENANT_SCOPE = TenantScope(tenant_id=1, storefront_id=1, is_system=True)
 
 
 class FakePrivateAttachmentStorage:
@@ -185,6 +190,7 @@ async def test_lists_active_repair_orders_for_manager(sqlite_repair_nameplate_se
         sqlite_repair_nameplate_session,
         telegram_user_id=777,
         can_attach_any=True,
+        tenant_scope=TEST_TENANT_SCOPE,
     )
 
     assert {item["id"] for item in orders} == {
@@ -212,14 +218,29 @@ async def test_executor_sees_only_assigned_repair_orders(sqlite_repair_nameplate
     sqlite_repair_nameplate_session.add(legacy_assigned)
     sqlite_repair_nameplate_session.add(other)
     await sqlite_repair_nameplate_session.flush()
-    sqlite_repair_nameplate_session.add(OrderWorkStage(order_id=assigned.id, installer_id=10, name="Диагностика"))
-    sqlite_repair_nameplate_session.add(OrderInstaller(order_id=legacy_assigned.id, installer_id=10))
+    sqlite_repair_nameplate_session.add_all(
+        [
+            TenantMembership(
+                tenant_id=TEST_TENANT_SCOPE.tenant_id,
+                staff_user_id=int(staff.id or 0),
+                role="installer",
+                status="active",
+            ),
+            OrderWorkStage(
+                order_id=assigned.id,
+                installer_id=10,
+                name="Диагностика",
+            ),
+            OrderInstaller(order_id=legacy_assigned.id, installer_id=10),
+        ]
+    )
     await sqlite_repair_nameplate_session.commit()
 
     orders = await BotRepairNameplateService.list_repair_orders(
         sqlite_repair_nameplate_session,
         telegram_user_id=777,
         can_attach_any=False,
+        tenant_scope=TEST_TENANT_SCOPE,
     )
 
     assert {item["id"] for item in orders} == {assigned.id, legacy_assigned.id}
@@ -262,6 +283,7 @@ async def test_apply_to_order_merges_without_overwriting_existing_repair_meta(sq
         telegram_chat_id=100,
         telegram_message_id=55,
         can_attach_any=True,
+        tenant_scope=TEST_TENANT_SCOPE,
     )
 
     assert result is not None
@@ -313,6 +335,7 @@ async def test_apply_to_order_stores_repair_nameplate_content(
         telegram_message_id=55,
         can_attach_any=True,
         file_content=b"nameplate-content",
+        tenant_scope=TEST_TENANT_SCOPE,
     )
 
     assert result is not None
@@ -376,6 +399,7 @@ async def test_apply_to_order_preserves_new_attachment_when_order_already_has_te
         telegram_message_id=56,
         can_attach_any=True,
         file_content=b"second-nameplate-content",
+        tenant_scope=TEST_TENANT_SCOPE,
     )
 
     assert result is not None
@@ -436,6 +460,7 @@ async def test_apply_to_order_updates_existing_repair_nameplate_attachment_url(
         telegram_message_id=56,
         can_attach_any=True,
         file_content=b"updated-nameplate-content",
+        tenant_scope=TEST_TENANT_SCOPE,
     )
 
     assert result is not None
@@ -469,6 +494,7 @@ async def test_apply_to_order_accepts_negotiation_repair_order(sqlite_repair_nam
         telegram_chat_id=100,
         telegram_message_id=55,
         can_attach_any=True,
+        tenant_scope=TEST_TENANT_SCOPE,
     )
 
     assert result is not None
@@ -495,6 +521,7 @@ async def test_apply_to_order_rejects_non_repair_order(sqlite_repair_nameplate_s
         telegram_chat_id=100,
         telegram_message_id=55,
         can_attach_any=True,
+        tenant_scope=TEST_TENANT_SCOPE,
     )
 
     assert result is None
@@ -531,6 +558,7 @@ async def test_build_diagnostic_comment_draft_uses_ai_and_previews_changes(sqlit
         sqlite_repair_nameplate_session,
         order_id=int(order.id),
         comment="подключили шланги, утечку устранили, компрессор не качает",
+        tenant_scope=TEST_TENANT_SCOPE,
     )
 
     assert draft is not None
@@ -555,6 +583,7 @@ async def test_build_diagnostic_preset_draft_is_deterministic_and_compact(sqlite
         sqlite_repair_nameplate_session,
         order_id=int(order.id),
         fault_type="compressor_short_circuit",
+        tenant_scope=TEST_TENANT_SCOPE,
     )
 
     assert draft is not None
@@ -604,6 +633,7 @@ async def test_apply_diagnostic_comment_updates_repair_meta_and_keeps_history(sq
         telegram_chat_id=100,
         telegram_message_id=55,
         can_attach_any=True,
+        tenant_scope=TEST_TENANT_SCOPE,
     )
 
     assert result is not None
@@ -644,6 +674,7 @@ async def test_warranty_nameplate_lists_today_installations_first(sqlite_repair_
         telegram_user_id=777,
         can_attach_any=True,
         now=datetime(2026, 6, 18, 10, 0, 0),
+        tenant_scope=TEST_TENANT_SCOPE,
     )
 
     assert result["scope"] == "today"
@@ -666,6 +697,7 @@ async def test_warranty_nameplate_falls_back_to_execution_installations(sqlite_r
         telegram_user_id=777,
         can_attach_any=True,
         now=datetime(2026, 6, 18, 10, 0, 0),
+        tenant_scope=TEST_TENANT_SCOPE,
     )
 
     assert result["scope"] == "execution"
@@ -719,6 +751,7 @@ async def test_warranty_nameplate_creates_order_equipment_and_updates_selected_c
         telegram_chat_id=100,
         telegram_message_id=55,
         can_attach_any=True,
+        tenant_scope=TEST_TENANT_SCOPE,
     )
 
     assert result is not None

--- a/tests/unit/test_bot_staff_notification_outbox.py
+++ b/tests/unit/test_bot_staff_notification_outbox.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta, timezone
 
 import pytest
+from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 from sqlmodel import select
@@ -16,6 +17,7 @@ from models import (
     OrderStageStatus,
     OrderWorkStage,
     StaffUser,
+    TenantMembership,
 )
 from services.bot_staff_notification_api_service import (
     BotStaffNotificationApiService,
@@ -26,6 +28,10 @@ from services.staff_task_notification_event_service import (
     StaffTaskNotificationEventService,
 )
 
+from models.tenancy import TenantScope
+
+TEST_TENANT_SCOPE = TenantScope(tenant_id=1, storefront_id=1, is_system=True)
+
 
 @pytest.fixture
 async def staff_outbox_session(tmp_path):
@@ -33,6 +39,7 @@ async def staff_outbox_session(tmp_path):
     tables = (
         Installer.__table__,
         StaffUser.__table__,
+        TenantMembership.__table__,
         Customer.__table__,
         Order.__table__,
         OrderWorkStage.__table__,
@@ -74,8 +81,66 @@ async def _seed_task(session: AsyncSession) -> OrderWorkStage:
         installer_id=10,
     )
     session.add_all([installer, staff, customer, order, stage])
+    session.add(
+        TenantMembership(
+            tenant_id=TEST_TENANT_SCOPE.tenant_id,
+            staff_user_id=int(staff.id or 0),
+            role="installer",
+            status="active",
+        )
+    )
     await session.commit()
     return stage
+
+
+@pytest.mark.asyncio
+async def test_assignment_event_rejects_foreign_order_scope(
+    staff_outbox_session,
+):
+    stage = await _seed_task(staff_outbox_session)
+    foreign_scope = TenantScope(tenant_id=2, storefront_id=2, is_system=False)
+    await staff_outbox_session.execute(
+        update(Order)
+        .where(Order.id == int(stage.order_id))
+        .values(
+            tenant_id=foreign_scope.tenant_id,
+            storefront_id=foreign_scope.storefront_id,
+        )
+    )
+    await staff_outbox_session.execute(
+        update(Customer)
+        .where(Customer.id == 30)
+        .values(tenant_id=foreign_scope.tenant_id)
+    )
+    staff_outbox_session.add(
+        TenantMembership(
+            tenant_id=foreign_scope.tenant_id,
+            staff_user_id=20,
+            role="installer",
+            status="active",
+        )
+    )
+    await staff_outbox_session.commit()
+
+    rejected = await StaffTaskNotificationEventService.enqueue_assigned(
+        staff_outbox_session,
+        stage=stage,
+        previous_installer_id=None,
+        tenant_scope=TEST_TENANT_SCOPE,
+    )
+    events_after_rejection = (
+        await staff_outbox_session.execute(select(IntegrationOutboxEvent))
+    ).scalars().all()
+    accepted = await StaffTaskNotificationEventService.enqueue_assigned(
+        staff_outbox_session,
+        stage=stage,
+        previous_installer_id=None,
+        tenant_scope=foreign_scope,
+    )
+
+    assert rejected is False
+    assert events_after_rejection == []
+    assert accepted is True
 
 
 @pytest.mark.asyncio
@@ -94,11 +159,13 @@ async def test_assignment_event_claim_and_ack_use_database_clock(
         staff_outbox_session,
         stage=stage,
         previous_installer_id=None,
+        tenant_scope=TEST_TENANT_SCOPE,
     )
     duplicate = await StaffTaskNotificationEventService.enqueue_assigned(
         staff_outbox_session,
         stage=stage,
         previous_installer_id=None,
+        tenant_scope=TEST_TENANT_SCOPE,
     )
     await staff_outbox_session.commit()
 
@@ -139,6 +206,7 @@ async def test_claim_cancels_delivery_when_assignment_is_stale(staff_outbox_sess
         staff_outbox_session,
         stage=stage,
         previous_installer_id=None,
+        tenant_scope=TEST_TENANT_SCOPE,
     )
     await staff_outbox_session.commit()
     stage.installer_id = None
@@ -168,6 +236,7 @@ async def test_nack_schedules_retry_and_next_claim_increments_attempt(
         staff_outbox_session,
         stage=stage,
         previous_installer_id=None,
+        tenant_scope=TEST_TENANT_SCOPE,
     )
     await staff_outbox_session.commit()
     first = await BotStaffNotificationApiService.claim(
@@ -210,6 +279,7 @@ async def test_transport_nack_is_terminal_ambiguous_after_remote_handoff(
         staff_outbox_session,
         stage=stage,
         previous_installer_id=None,
+        tenant_scope=TEST_TENANT_SCOPE,
     )
     await staff_outbox_session.commit()
     claim = await BotStaffNotificationApiService.claim(
@@ -249,6 +319,7 @@ async def test_claim_handoff_expiry_is_terminal_and_never_claimed_again(
         staff_outbox_session,
         stage=stage,
         previous_installer_id=None,
+        tenant_scope=TEST_TENANT_SCOPE,
     )
     await staff_outbox_session.commit()
     first = await BotStaffNotificationApiService.claim(
@@ -296,6 +367,7 @@ async def test_old_api_null_boundary_handoff_is_conservatively_terminal(
         staff_outbox_session,
         stage=stage,
         previous_installer_id=None,
+        tenant_scope=TEST_TENANT_SCOPE,
     )
     await staff_outbox_session.commit()
     now = await CommunicationDeliveryService.database_now(
@@ -357,12 +429,14 @@ async def test_departure_reminder_scan_is_idempotent(staff_outbox_session):
         now=now,
         offset_minutes=120,
         scan_window_minutes=10,
+        tenant_scope=TEST_TENANT_SCOPE,
     )
     second = await StaffTaskNotificationEventService.enqueue_departure_reminders(
         staff_outbox_session,
         now=now,
         offset_minutes=120,
         scan_window_minutes=10,
+        tenant_scope=TEST_TENANT_SCOPE,
     )
 
     assert first == 1

--- a/tests/unit/test_bot_task_mutation_service.py
+++ b/tests/unit/test_bot_task_mutation_service.py
@@ -4,9 +4,17 @@ from unittest.mock import AsyncMock
 import pytest
 
 from models import OrderStageStatus
+from models.tenancy import TenantScope
 from services.bot_task_mutation_service import (
     BotTaskMutationConflictError,
     BotTaskMutationService,
+)
+
+
+TEST_TENANT_SCOPE = TenantScope(
+    tenant_id=1,
+    storefront_id=1,
+    is_system=True,
 )
 
 
@@ -66,19 +74,25 @@ async def test_task_status_mutation_is_locked_idempotent_and_notifies_once(monke
         telegram_id=777,
         stage_id=10,
         status=OrderStageStatus.IN_PROGRESS,
+        tenant_scope=TEST_TENANT_SCOPE,
     )
     repeated = await BotTaskMutationService.update_stage_status(
         session,
         telegram_id=777,
         stage_id=10,
         status=OrderStageStatus.IN_PROGRESS,
+        tenant_scope=TEST_TENANT_SCOPE,
     )
 
     assert first.changed is True
     assert repeated.changed is False
     assert stage.status == OrderStageStatus.IN_PROGRESS
     assert session.commit_count == 1
-    notify.assert_awaited_once_with(session, 10)
+    notify.assert_awaited_once_with(
+        session,
+        10,
+        tenant_scope=TEST_TENANT_SCOPE,
+    )
     assert len(session.statements) == 2
     assert all(statement._for_update_arg is not None for statement in session.statements)
 
@@ -103,6 +117,7 @@ async def test_completed_task_cannot_be_reopened_by_stale_accept(monkeypatch):
             telegram_id=777,
             stage_id=10,
             status=OrderStageStatus.IN_PROGRESS,
+            tenant_scope=TEST_TENANT_SCOPE,
         )
 
     assert stage.status == OrderStageStatus.COMPLETED
@@ -128,12 +143,14 @@ async def test_task_report_mutation_is_normalized_and_idempotent(monkeypatch):
         telegram_id=777,
         stage_id=10,
         report="  Монтаж завершен  ",
+        tenant_scope=TEST_TENANT_SCOPE,
     )
     repeated = await BotTaskMutationService.save_stage_report(
         session,
         telegram_id=777,
         stage_id=10,
         report="Монтаж завершен",
+        tenant_scope=TEST_TENANT_SCOPE,
     )
 
     assert first.changed is True

--- a/tests/unit/test_bot_work_services.py
+++ b/tests/unit/test_bot_work_services.py
@@ -251,6 +251,15 @@ async def test_task_list_merges_stages_and_distinct_legacy_orders(sqlite_staff_s
     customer = Customer(name="Клиент", phone="+375291234567")
     sqlite_staff_session.add(staff)
     sqlite_staff_session.add(customer)
+    await sqlite_staff_session.flush()
+    sqlite_staff_session.add(
+        TenantMembership(
+            tenant_id=TEST_TENANT_SCOPE.tenant_id,
+            staff_user_id=int(staff.id or 0),
+            role="installer",
+            status="active",
+        )
+    )
     await sqlite_staff_session.commit()
     await sqlite_staff_session.refresh(customer)
 
@@ -326,7 +335,11 @@ async def test_task_list_merges_stages_and_distinct_legacy_orders(sqlite_staff_s
     )
     await sqlite_staff_session.commit()
 
-    tasks = await BotTaskService.list_my_tasks(sqlite_staff_session, 12345)
+    tasks = await BotTaskService.list_my_tasks(
+        sqlite_staff_session,
+        12345,
+        tenant_scope=TEST_TENANT_SCOPE,
+    )
 
     assert [task["title"] for task in tasks] == [
         "Ближайший монтаж",
@@ -343,7 +356,12 @@ async def test_task_list_merges_stages_and_distinct_legacy_orders(sqlite_staff_s
         for task in tasks
     )
 
-    limited = await BotTaskService.list_my_tasks(sqlite_staff_session, 12345, limit=2)
+    limited = await BotTaskService.list_my_tasks(
+        sqlite_staff_session,
+        12345,
+        limit=2,
+        tenant_scope=TEST_TENANT_SCOPE,
+    )
     assert [task["title"] for task in limited] == ["Ближайший монтаж", "Пусконаладка"]
 
     reference_time = datetime.now()
@@ -353,6 +371,7 @@ async def test_task_list_merges_stages_and_distinct_legacy_orders(sqlite_staff_s
         date_from=reference_time + timedelta(days=1, hours=12),
         date_to=reference_time + timedelta(days=2, hours=12),
         statuses=["planned"],
+        tenant_scope=TEST_TENANT_SCOPE,
     )
     assert [task["title"] for task in today] == ["Ближайший монтаж", "Пусконаладка"]
 
@@ -419,6 +438,7 @@ async def test_task_read_service_reuses_authorized_installer_mapping(monkeypatch
         session,
         telegram_id=777,
         limit=10,
+        tenant_scope=TEST_TENANT_SCOPE,
     )
 
     assert tasks == []
@@ -430,6 +450,7 @@ async def test_task_read_service_reuses_authorized_installer_mapping(monkeypatch
         date_from=None,
         date_to=None,
         statuses=None,
+        tenant_scope=TEST_TENANT_SCOPE,
     )
 
 
@@ -1411,17 +1432,26 @@ async def test_quick_order_create_uses_order_service_and_stage_for_dated_work(mo
         }
         return {"lead": {"id": lead_id, "status": "qualified"}, "customer_id": 5, "order_id": 42}
 
-    async def fake_update_order(session, order_id, payload):
-        calls["update"] = {"order_id": order_id, "payload": payload}
+    async def fake_update_order(session, order_id, payload, *, tenant_scope):
+        calls["update"] = {
+            "order_id": order_id,
+            "payload": payload,
+            "tenant_scope": tenant_scope,
+        }
         return {"id": order_id, "status": "new_lead"}
 
-    async def fake_add_order_stage(session, order_id, payload):
+    async def fake_add_order_stage(session, order_id, payload, *, tenant_scope):
         calls["stage_order_id"] = order_id
         calls["stage_payload"] = payload
+        calls["stage_tenant_scope"] = tenant_scope
         return {"id": order_id, "work_stages": [{"name": payload.name}]}
 
-    async def fake_notify(session, order_id, *, source_label):
-        calls["notify"] = {"order_id": order_id, "source_label": source_label}
+    async def fake_notify(session, order_id, *, source_label, tenant_scope):
+        calls["notify"] = {
+            "order_id": order_id,
+            "source_label": source_label,
+            "tenant_scope": tenant_scope,
+        }
         return 1
 
     monkeypatch.setattr("services.bot_quick_order_service.LeadService.create_lead", fake_create_lead)
@@ -1464,9 +1494,15 @@ async def test_quick_order_create_uses_order_service_and_stage_for_dated_work(mo
     assert calls["update"]["order_id"] == 42
     assert calls["update"]["payload"].title == "Монтаж"
     assert calls["update"]["payload"].service_type == "install_only"
+    assert calls["update"]["tenant_scope"] == TEST_TENANT_SCOPE
     assert calls["stage_order_id"] == 42
     assert calls["stage_payload"].name == "Монтаж"
-    assert calls["notify"] == {"order_id": 42, "source_label": "Telegram-бот"}
+    assert calls["stage_tenant_scope"] == TEST_TENANT_SCOPE
+    assert calls["notify"] == {
+        "order_id": 42,
+        "source_label": "Telegram-бот",
+        "tenant_scope": TEST_TENANT_SCOPE,
+    }
 
 
 @pytest.mark.asyncio
@@ -1486,15 +1522,23 @@ async def test_quick_order_create_notifies_admins_for_maintenance_without_stage(
         }
         return {"lead": {"id": lead_id, "status": "qualified"}, "customer_id": 5, "order_id": 43}
 
-    async def fake_update_order(session, order_id, payload):
-        calls["update"] = {"order_id": order_id, "payload": payload}
+    async def fake_update_order(session, order_id, payload, *, tenant_scope):
+        calls["update"] = {
+            "order_id": order_id,
+            "payload": payload,
+            "tenant_scope": tenant_scope,
+        }
         return {"id": order_id, "status": payload.status}
 
-    async def fake_add_order_stage(session, order_id, payload):
+    async def fake_add_order_stage(session, order_id, payload, *, tenant_scope):
         raise AssertionError("maintenance quick orders should use order installation_date, not a work stage")
 
-    async def fake_notify(session, order_id, *, source_label):
-        calls["notify"] = {"order_id": order_id, "source_label": source_label}
+    async def fake_notify(session, order_id, *, source_label, tenant_scope):
+        calls["notify"] = {
+            "order_id": order_id,
+            "source_label": source_label,
+            "tenant_scope": tenant_scope,
+        }
         return 1
 
     monkeypatch.setattr("services.bot_quick_order_service.LeadService.create_lead", fake_create_lead)
@@ -1535,7 +1579,12 @@ async def test_quick_order_create_notifies_admins_for_maintenance_without_stage(
     assert calls["update"]["payload"].service_type == "maintenance"
     assert calls["update"]["payload"].status == "negotiation"
     assert calls["update"]["payload"].installation_date.isoformat() == "2026-06-15T14:00:00"
-    assert calls["notify"] == {"order_id": 43, "source_label": "Telegram-бот"}
+    assert calls["update"]["tenant_scope"] == TEST_TENANT_SCOPE
+    assert calls["notify"] == {
+        "order_id": 43,
+        "source_label": "Telegram-бот",
+        "tenant_scope": TEST_TENANT_SCOPE,
+    }
 
 
 @pytest.mark.asyncio
@@ -1580,7 +1629,12 @@ async def test_quick_order_create_persists_lead_funnel_and_calendar_stage(db, mo
     assert stage.order_id == order["id"]
     assert stage.name == "Монтаж"
     assert stage.start_time.isoformat() == "2026-06-15T14:00:00"
-    notify.assert_awaited_once_with(db, order["id"], source_label="Telegram-бот")
+    notify.assert_awaited_once_with(
+        db,
+        order["id"],
+        source_label="Telegram-бот",
+        tenant_scope=TEST_TENANT_SCOPE,
+    )
 
 
 @pytest.mark.asyncio
@@ -1595,12 +1649,17 @@ async def test_quick_order_retry_after_partial_failure_reuses_lead_and_order(db,
     original_add_order_stage = OrderService.add_order_stage
     stage_attempts = 0
 
-    async def flaky_add_order_stage(session, order_id, payload):
+    async def flaky_add_order_stage(session, order_id, payload, *, tenant_scope):
         nonlocal stage_attempts
         stage_attempts += 1
         if stage_attempts == 1:
             raise RuntimeError("stage failed")
-        return await original_add_order_stage(session, order_id, payload)
+        return await original_add_order_stage(
+            session,
+            order_id,
+            payload,
+            tenant_scope=tenant_scope,
+        )
 
     monkeypatch.setattr("services.bot_quick_order_service.OrderService.add_order_stage", flaky_add_order_stage)
 

--- a/tests/unit/test_installation_estimate_lead_service.py
+++ b/tests/unit/test_installation_estimate_lead_service.py
@@ -24,6 +24,10 @@ from services.private_attachment_storage_service import StoredPrivateObject
 from services.order_service import OrderService
 from services.service_attachment_service import ServiceAttachmentService
 
+from models.tenancy import TenantScope
+
+TEST_TENANT_SCOPE = TenantScope(tenant_id=1, storefront_id=1, is_system=True)
+
 
 def _png_bytes() -> bytes:
     output = io.BytesIO()
@@ -171,10 +175,11 @@ async def test_installation_estimate_is_atomic_private_and_idempotent(
     manager_attachments = await ServiceAttachmentService.list_order_attachments(
         installation_estimate_session,
         order_id=created.order_id,
+        tenant_scope=TEST_TENANT_SCOPE,
     )
     assert manager_attachments is not None
     assert manager_attachments["total"] == 1
-    inbox = await OrderService.get_leads_inbox(installation_estimate_session)
+    inbox = await OrderService.get_leads_inbox(installation_estimate_session, tenant_scope=TEST_TENANT_SCOPE)
     assert inbox.items[0].attachment_count == 1
     assert (
         await installation_estimate_session.scalar(

--- a/tests/unit/test_installer_compatibility_service.py
+++ b/tests/unit/test_installer_compatibility_service.py
@@ -6,10 +6,32 @@ from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 from sqlmodel import SQLModel
 
-from models import Installer, Order, OrderInstaller, StaffUser
+from models import Installer, Order, OrderInstaller, StaffUser, TenantMembership
 from schemas import ManagerOrderUpdatePayload
 from services.installer_service import ManagerInstallerService
 from services.order_service import OrderService
+
+from models.tenancy import TenantScope
+
+TEST_TENANT_SCOPE = TenantScope(tenant_id=1, storefront_id=1, is_system=True)
+
+
+async def _add_tenant_staff(
+    session: AsyncSession,
+    staff_user: StaffUser,
+    *,
+    membership_status: str = "active",
+) -> None:
+    session.add(staff_user)
+    await session.flush()
+    session.add(
+        TenantMembership(
+            tenant_id=TEST_TENANT_SCOPE.tenant_id,
+            staff_user_id=int(staff_user.id or 0),
+            role="installer",
+            status=membership_status,
+        )
+    )
 
 
 @pytest.fixture
@@ -34,7 +56,8 @@ async def test_installer_search_uses_staff_user_status_and_keeps_orphan_legacy_f
     sqlite_installer_session.add_all([active, blocked, inactive, orphan])
     await sqlite_installer_session.flush()
 
-    sqlite_installer_session.add(
+    await _add_tenant_staff(
+        sqlite_installer_session,
         StaffUser(
             display_name="Active Staff",
             status="active",
@@ -42,33 +65,37 @@ async def test_installer_search_uses_staff_user_status_and_keeps_orphan_legacy_f
             legacy_installer_id=active.id,
         )
     )
-    sqlite_installer_session.add(
+    await _add_tenant_staff(
+        sqlite_installer_session,
         StaffUser(
             display_name="Blocked Staff",
             status="blocked",
             roles=["installer"],
             legacy_installer_id=blocked.id,
-        )
+        ),
+        membership_status="suspended",
     )
-    sqlite_installer_session.add(
+    await _add_tenant_staff(
+        sqlite_installer_session,
         StaffUser(
             display_name="Inactive Staff",
             status="inactive",
             roles=["installer"],
             legacy_installer_id=inactive.id,
-        )
+        ),
+        membership_status="disabled",
     )
     await sqlite_installer_session.commit()
 
-    result = await ManagerInstallerService.search(sqlite_installer_session, q="Staff", limit=10)
+    result = await ManagerInstallerService.search(sqlite_installer_session, q="Staff", limit=10, tenant_scope=TEST_TENANT_SCOPE)
 
     assert [item.name for item in result.items] == ["Active Staff"]
 
-    fallback_result = await ManagerInstallerService.search(sqlite_installer_session, q="Orphan", limit=10)
+    fallback_result = await ManagerInstallerService.search(sqlite_installer_session, q="Orphan", limit=10, tenant_scope=TEST_TENANT_SCOPE)
 
     assert [item.name for item in fallback_result.items] == ["Orphan Legacy"]
 
-    legacy_name_result = await ManagerInstallerService.search(sqlite_installer_session, q="Active Legacy", limit=10)
+    legacy_name_result = await ManagerInstallerService.search(sqlite_installer_session, q="Active Legacy", limit=10, tenant_scope=TEST_TENANT_SCOPE)
 
     assert [item.name for item in legacy_name_result.items] == ["Active Staff"]
 
@@ -78,17 +105,19 @@ async def test_installer_list_keeps_historical_blocked_staff_visible(sqlite_inst
     installer = Installer(name="Legacy Name", is_active=True)
     sqlite_installer_session.add(installer)
     await sqlite_installer_session.flush()
-    sqlite_installer_session.add(
+    await _add_tenant_staff(
+        sqlite_installer_session,
         StaffUser(
             display_name="Blocked Historical",
             status="blocked",
             roles=["installer"],
             legacy_installer_id=installer.id,
-        )
+        ),
+        membership_status="suspended",
     )
     await sqlite_installer_session.commit()
 
-    result = await ManagerInstallerService.get_all(sqlite_installer_session)
+    result = await ManagerInstallerService.get_all(sqlite_installer_session, tenant_scope=TEST_TENANT_SCOPE)
 
     assert len(result.items) == 1
     assert result.items[0].name == "Blocked Historical"
@@ -102,7 +131,8 @@ async def test_new_order_assignment_rejects_blocked_staff_user(sqlite_installer_
     sqlite_installer_session.add(installer)
     sqlite_installer_session.add(order)
     await sqlite_installer_session.flush()
-    sqlite_installer_session.add(
+    await _add_tenant_staff(
+        sqlite_installer_session,
         StaffUser(
             display_name="Blocked Installer",
             status="blocked",
@@ -117,6 +147,7 @@ async def test_new_order_assignment_rejects_blocked_staff_user(sqlite_installer_
             sqlite_installer_session,
             order.id,
             [{"installer_id": installer.id, "agreed_pay": 100}],
+            tenant_scope=TEST_TENANT_SCOPE,
         )
 
 
@@ -130,7 +161,8 @@ async def test_new_order_assignment_notification_uses_active_staff_telegram_id(
     sqlite_installer_session.add(installer)
     sqlite_installer_session.add(order)
     await sqlite_installer_session.flush()
-    sqlite_installer_session.add(
+    await _add_tenant_staff(
+        sqlite_installer_session,
         StaffUser(
             display_name="Active Staff",
             status="active",
@@ -148,6 +180,7 @@ async def test_new_order_assignment_notification_uses_active_staff_telegram_id(
         sqlite_installer_session,
         order.id,
         [{"installer_id": installer.id, "agreed_pay": 100}],
+        tenant_scope=TEST_TENANT_SCOPE,
     )
 
     notify_mock.assert_awaited_once()
@@ -161,7 +194,8 @@ async def test_existing_historical_blocked_assignment_can_still_update(sqlite_in
     sqlite_installer_session.add(installer)
     sqlite_installer_session.add(order)
     await sqlite_installer_session.flush()
-    sqlite_installer_session.add(
+    await _add_tenant_staff(
+        sqlite_installer_session,
         StaffUser(
             display_name="Historical Installer",
             status="blocked",
@@ -182,6 +216,7 @@ async def test_existing_historical_blocked_assignment_can_still_update(sqlite_in
         sqlite_installer_session,
         order.id,
         [{"installer_id": installer.id, "agreed_pay": 125}],
+        tenant_scope=TEST_TENANT_SCOPE,
     )
 
     link = await sqlite_installer_session.get(OrderInstaller, (order.id, installer.id))
@@ -196,7 +231,8 @@ async def test_new_manager_measurer_assignment_rejects_blocked_staff_user(sqlite
     sqlite_installer_session.add(installer)
     sqlite_installer_session.add(order)
     await sqlite_installer_session.flush()
-    sqlite_installer_session.add(
+    await _add_tenant_staff(
+        sqlite_installer_session,
         StaffUser(
             display_name="Blocked Measurer",
             status="blocked",
@@ -211,6 +247,7 @@ async def test_new_manager_measurer_assignment_rejects_blocked_staff_user(sqlite
             sqlite_installer_session,
             order.id,
             ManagerOrderUpdatePayload(measurer_id=installer.id),
+            tenant_scope=TEST_TENANT_SCOPE,
         )
 
 
@@ -222,7 +259,8 @@ async def test_unchanged_historical_blocked_measurer_can_still_save(sqlite_insta
     sqlite_installer_session.add(order)
     await sqlite_installer_session.flush()
     order.measurer_id = installer.id
-    sqlite_installer_session.add(
+    await _add_tenant_staff(
+        sqlite_installer_session,
         StaffUser(
             display_name="Historical Measurer",
             status="blocked",
@@ -236,6 +274,7 @@ async def test_unchanged_historical_blocked_measurer_can_still_save(sqlite_insta
         sqlite_installer_session,
         order.id,
         ManagerOrderUpdatePayload(measurer_id=installer.id, comment="after"),
+        tenant_scope=TEST_TENANT_SCOPE,
     )
 
     assert data is not None

--- a/tests/unit/test_internal_bot_api.py
+++ b/tests/unit/test_internal_bot_api.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from unittest.mock import AsyncMock
 
+import pytest
 from httpx import ASGITransport, AsyncClient
 
 from core.config import settings
@@ -36,6 +37,15 @@ TEST_TENANT_SCOPE = TenantScope(
     storefront_id=1,
     is_system=True,
 )
+
+
+@pytest.fixture(autouse=True)
+def _system_tenant_scope_override():
+    app.dependency_overrides[get_system_tenant_scope] = lambda: TEST_TENANT_SCOPE
+    try:
+        yield
+    finally:
+        app.dependency_overrides.pop(get_system_tenant_scope, None)
 
 
 async def _request(
@@ -411,11 +421,13 @@ async def test_internal_bot_task_list_returns_stable_projection(monkeypatch):
         date_from,
         date_to,
         statuses,
+        tenant_scope,
     ):
         assert (telegram_id, limit) == (123456, 10)
         assert date_from is None
         assert date_to is None
         assert statuses == []
+        assert tenant_scope == TEST_TENANT_SCOPE
         return [
             {
                 "kind": "stage",
@@ -478,6 +490,7 @@ async def test_internal_bot_task_list_forwards_today_filters(monkeypatch):
         assert kwargs["date_from"] == datetime(2026, 7, 20, 0, 0)
         assert kwargs["date_to"] == datetime(2026, 7, 20, 23, 59, 59)
         assert kwargs["statuses"] == ["planned", "in_progress"]
+        assert kwargs["tenant_scope"] == TEST_TENANT_SCOPE
         return []
 
     async def fake_session():
@@ -550,6 +563,7 @@ async def test_internal_bot_task_status_mutation_uses_authorized_service(monkeyp
             "telegram_id": 123456,
             "stage_id": 7,
             "status": OrderStageStatus.COMPLETED,
+            "tenant_scope": TEST_TENANT_SCOPE,
         }
         return BotTaskStatusMutationResult(
             stage_id=7,
@@ -624,6 +638,7 @@ async def test_internal_bot_task_report_normalizes_and_saves(monkeypatch):
             "telegram_id": 123456,
             "stage_id": 7,
             "report": "Работа выполнена",
+            "tenant_scope": TEST_TENANT_SCOPE,
         }
         return BotTaskReportMutationResult(stage_id=7, changed=False)
 

--- a/tests/unit/test_lead_service.py
+++ b/tests/unit/test_lead_service.py
@@ -8,6 +8,10 @@ from schemas import LeadCreatePayload, LeadLossPayload, LeadQualifyPayload, Lead
 from services.lead_service import LeadService
 from services.tenant_scope_service import TenantScope
 
+from models.tenancy import TenantScope
+
+TEST_TENANT_SCOPE = TenantScope(tenant_id=1, storefront_id=1, is_system=True)
+
 
 @pytest.mark.asyncio
 async def test_create_lead_with_inn_sets_b2b(db, tenant_scope):
@@ -198,6 +202,7 @@ async def test_update_lead_rejects_terminal_status_shortcut(db, tenant_scope):
             db,
             lead_id=lead_data["id"],
             payload=LeadUpdatePayload(status="qualified"),
+            tenant_scope=TEST_TENANT_SCOPE,
         )
 
     lead = await db.get(Lead, lead_data["id"])
@@ -223,6 +228,7 @@ async def test_mark_lost_rejects_non_loss_status(db, tenant_scope):
             db,
             lead_id=lead_data["id"],
             payload=LeadLossPayload(status="qualified"),
+            tenant_scope=TEST_TENANT_SCOPE,
         )
 
     lead = await db.get(Lead, lead_data["id"])
@@ -335,6 +341,7 @@ async def test_mark_lost_and_archive_old_leads(db, tenant_scope):
         db,
         lead_id=created["id"],
         payload=LeadLossPayload(status="lost", loss_reason="no_product"),
+        tenant_scope=TEST_TENANT_SCOPE,
     )
     assert updated is not None
     assert updated["status"] == "lost"
@@ -353,6 +360,6 @@ async def test_mark_lost_and_archive_old_leads(db, tenant_scope):
     assert refreshed is not None
     assert refreshed.archived_at is not None
 
-    listed = await LeadService.list_leads(db, page=1, limit=20)
+    listed = await LeadService.list_leads(db, page=1, limit=20, tenant_scope=TEST_TENANT_SCOPE)
     ids = [item["id"] for item in listed["items"]]
     assert created["id"] not in ids

--- a/tests/unit/test_mail_services.py
+++ b/tests/unit/test_mail_services.py
@@ -683,7 +683,7 @@ async def test_delete_order_payment_detaches_group_bank_receipt(sqlite_session):
     ).scalars().all()
     assert len(payments) == 2
 
-    await OrderService.delete_payment(sqlite_session, payments[0].order_id, payments[0].id)
+    await OrderService.delete_payment(sqlite_session, payments[0].order_id, payments[0].id, tenant_scope=TEST_TENANT_SCOPE)
 
     refreshed_receipt = await sqlite_session.get(BankReceipt, receipt.id)
     assert refreshed_receipt.status == "requires_review"
@@ -1122,7 +1122,7 @@ async def test_order_detail_payment_includes_bank_receipt(sqlite_session):
     await sqlite_session.commit()
     sqlite_session.expunge(order)
 
-    detail = await OrderService.get_order_detail_for_manager(sqlite_session, order.id)
+    detail = await OrderService.get_order_detail_for_manager(sqlite_session, order.id, tenant_scope=TEST_TENANT_SCOPE)
 
     assert detail is not None
     assert detail["payments"][0]["bank_receipt_id"] == receipt.id
@@ -1240,6 +1240,7 @@ async def test_bank_receipt_import_notification_counts_confirmed_admins(sqlite_s
         sent_count = await NotificationService.notify_admins_bank_receipts_imported(
             sqlite_session,
             [receipt.id, matched.id],
+            tenant_scope=TEST_TENANT_SCOPE,
         )
 
     assert sent_count == 1
@@ -1284,6 +1285,7 @@ async def test_email_lead_import_notification_counts_confirmed_admins(sqlite_ses
         sent_count = await NotificationService.notify_admins_email_leads_imported(
             sqlite_session,
             [order.id],
+            tenant_scope=TEST_TENANT_SCOPE,
         )
 
     assert sent_count == 1

--- a/tests/unit/test_manager_document_template_files_api.py
+++ b/tests/unit/test_manager_document_template_files_api.py
@@ -2,7 +2,8 @@ import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
-from core.security import get_current_username
+from core.security import require_system_manager_tenant_scope
+from models.tenancy import TenantScope
 from routers.manager_docs import (
     DOCUMENT_TEMPLATE_FILES_UNAVAILABLE,
     DOCUMENT_TEMPLATE_FILES_UNAVAILABLE_MESSAGE,
@@ -37,7 +38,9 @@ async def test_document_template_files_maps_google_failures_to_controlled_502(
     )
     app = FastAPI()
     app.include_router(manager_docs_router)
-    app.dependency_overrides[get_current_username] = lambda: "admin"
+    app.dependency_overrides[require_system_manager_tenant_scope] = lambda: (
+        TenantScope(tenant_id=1, storefront_id=1, is_system=True)
+    )
 
     async with AsyncClient(
         transport=ASGITransport(app=app),

--- a/tests/unit/test_manager_mail_notifications.py
+++ b/tests/unit/test_manager_mail_notifications.py
@@ -1,5 +1,6 @@
 import pytest
 
+from models.tenancy import TenantScope
 from routers.manager_mail import import_manager_bank_receipts
 from services.bank_receipt_service import BankReceiptImportResult
 from services.mail_imap_service import MailImapService
@@ -9,6 +10,7 @@ from services.notification_service import NotificationService
 @pytest.mark.asyncio
 async def test_manual_bank_import_notifies_only_created_receipts(monkeypatch):
     session = object()
+    tenant_scope = TenantScope(tenant_id=1, storefront_id=1, is_system=True)
     notification_calls = []
 
     async def fake_import(received_session, *, limit):
@@ -22,17 +24,21 @@ async def test_manual_bank_import_notifies_only_created_receipts(monkeypatch):
             created_receipt_ids=[10],
         )
 
-    async def fake_notify(received_session, receipt_ids):
-        notification_calls.append((received_session, receipt_ids))
+    async def fake_notify(received_session, receipt_ids, *, tenant_scope):
+        notification_calls.append((received_session, receipt_ids, tenant_scope))
         return 1
 
     monkeypatch.setattr(MailImapService, "import_bank_receipts", fake_import)
     monkeypatch.setattr(NotificationService, "notify_admins_bank_receipts_imported", fake_notify)
 
-    response = await import_manager_bank_receipts(limit=2, session=session)
+    response = await import_manager_bank_receipts(
+        limit=2,
+        session=session,
+        tenant_scope=tenant_scope,
+    )
 
     assert response.processed == 2
     assert response.created == 1
     assert response.duplicates == 1
     assert response.receipt_ids == [10, 11]
-    assert notification_calls == [(session, [10])]
+    assert notification_calls == [(session, [10], tenant_scope)]

--- a/tests/unit/test_migrate_service_attachments.py
+++ b/tests/unit/test_migrate_service_attachments.py
@@ -19,6 +19,7 @@ from models import (
     OrderWorkStage,
     ServiceAttachment,
 )
+from models.tenancy import TenantScope
 from services.service_attachment_presenter import legacy_attachment_source_key
 from services.private_attachment_storage_service import StoredPrivateObject
 from scripts.migrate_service_attachments import (
@@ -34,6 +35,13 @@ from scripts.migrate_service_attachments import (
     migrate_attachments,
     migrate_equipment_links,
     migrate_legacy_coverages,
+)
+
+
+TEST_TENANT_SCOPE = TenantScope(
+    tenant_id=1,
+    storefront_id=1,
+    is_system=True,
 )
 
 
@@ -297,6 +305,7 @@ async def test_private_copy_rejects_corrupt_storage_readback(migration_session, 
         order_id=17,
         stats=stats,
         storage=CorruptReadbackStorage(),
+        tenant_scope=TEST_TENANT_SCOPE,
     )
 
     assert stats.attachments_verified == 1
@@ -374,9 +383,17 @@ async def test_execute_uses_advisory_lock_and_fails_closed_on_partial_result(mon
     async def no_op_migration(session, **kwargs):
         return None
 
+    async def resolve_tenant_scope(session):
+        return TEST_TENANT_SCOPE
+
     monkeypatch.setattr(orchestrator, "engine", FakeEngine())
     monkeypatch.setattr(orchestrator, "async_session_maker", lambda: SessionContext())
     monkeypatch.setattr(orchestrator, "get_private_attachment_storage", lambda: FakeStorage())
+    monkeypatch.setattr(
+        orchestrator.SystemTenantScopeResolver,
+        "resolve",
+        resolve_tenant_scope,
+    )
     monkeypatch.setattr(orchestrator, "migrate_attachments", partial_attachment_migration)
     monkeypatch.setattr(orchestrator, "migrate_equipment_links", no_op_migration)
     monkeypatch.setattr(orchestrator, "migrate_legacy_coverages", no_op_migration)

--- a/tests/unit/test_notification_service.py
+++ b/tests/unit/test_notification_service.py
@@ -7,6 +7,10 @@ import pytest
 from core.config import settings
 from services.notification_service import NotificationService
 
+from models.tenancy import TenantScope
+
+TEST_TENANT_SCOPE = TenantScope(tenant_id=1, storefront_id=1, is_system=True)
+
 
 class _DummyResult:
     def __init__(self, order):
@@ -14,6 +18,15 @@ class _DummyResult:
 
     def scalar_one_or_none(self):
         return self._order
+
+    def scalars(self):
+        return self
+
+    def first(self):
+        return self._order
+
+    def all(self):
+        return []
 
 
 class _DummySession:
@@ -40,6 +53,7 @@ async def test_notify_admins_new_order_skips_when_no_admins(monkeypatch):
         customer_name="User",
         customer_username="user",
         customer_phone="+123",
+        tenant_scope=TEST_TENANT_SCOPE,
     )
 
     send_mock.assert_not_called()
@@ -61,6 +75,7 @@ async def test_notify_admins_new_order_warns_for_missing_order(monkeypatch, capl
             customer_name="User",
             customer_username="user",
             customer_phone="+123",
+            tenant_scope=TEST_TENANT_SCOPE,
         )
 
     assert "NOTIFY_NEW_ORDER_SKIPPED missing_order_id=404" in caplog.text
@@ -98,6 +113,7 @@ async def test_notify_admins_new_order_sends_to_admins(monkeypatch):
         customer_name="Ivan <script>",
         customer_username="ivan&co",
         customer_phone="<+375291234567>",
+        tenant_scope=TEST_TENANT_SCOPE,
     )
 
     assert send_mock.await_count == 3
@@ -133,6 +149,7 @@ async def test_notify_admins_staff_order_created_counts_only_confirmed_delivery(
             session=session,
             order_id=88,
             source_label="Telegram-бот",
+            tenant_scope=TEST_TENANT_SCOPE,
         )
 
     assert sent == 1
@@ -172,7 +189,7 @@ async def test_notify_admins_work_stage_status_changed_counts_only_confirmed_del
     monkeypatch.setattr("services.notification_service.BotService.send_rich_message", send_mock)
 
     with caplog.at_level("WARNING"):
-        sent = await NotificationService.notify_admins_work_stage_status_changed(session, stage_id=5)
+        sent = await NotificationService.notify_admins_work_stage_status_changed(session, stage_id=5, tenant_scope=TEST_TENANT_SCOPE)
 
     assert sent == 1
     rich_text = send_mock.await_args_list[0].args[1]

--- a/tests/unit/test_order_service_leads_inbox.py
+++ b/tests/unit/test_order_service_leads_inbox.py
@@ -6,6 +6,10 @@ from models import Customer, CustomerType, LeadSource, Order, OrderStatus
 from schemas import ManagerOrderUpdatePayload
 from services.order_service import OrderService
 
+from models.tenancy import TenantScope
+
+TEST_TENANT_SCOPE = TenantScope(tenant_id=1, storefront_id=1, is_system=True)
+
 
 @pytest.mark.asyncio
 async def test_leads_inbox_is_paginated(db):
@@ -24,7 +28,7 @@ async def test_leads_inbox_is_paginated(db):
         )
     await db.commit()
 
-    response = await OrderService.get_leads_inbox(db, scope="active", page=1, limit=2)
+    response = await OrderService.get_leads_inbox(db, scope="active", page=1, limit=2, tenant_scope=TEST_TENANT_SCOPE)
 
     assert response.total == 3
     assert response.meta.total == 3
@@ -51,7 +55,7 @@ async def test_leads_inbox_uses_email_date_for_email_source(db):
     )
     await db.commit()
 
-    response = await OrderService.get_leads_inbox(db, scope="active", page=1, limit=10)
+    response = await OrderService.get_leads_inbox(db, scope="active", page=1, limit=10, tenant_scope=TEST_TENANT_SCOPE)
 
     assert response.items[0].email == "client@example.com"
     assert response.items[0].created_at == datetime(2026, 5, 27, 21, 40)
@@ -74,7 +78,7 @@ async def test_leads_inbox_extracts_legacy_email_date_from_comment(db):
     )
     await db.commit()
 
-    response = await OrderService.get_leads_inbox(db, scope="active", page=1, limit=10)
+    response = await OrderService.get_leads_inbox(db, scope="active", page=1, limit=10, tenant_scope=TEST_TENANT_SCOPE)
 
     assert response.items[0].source_created_at == datetime(2026, 5, 11, 12, 33)
 
@@ -94,7 +98,7 @@ async def test_leads_inbox_ignores_invalid_no_answer_at(db):
     )
     await db.commit()
 
-    response = await OrderService.get_leads_inbox(db, scope="active", page=1, limit=10)
+    response = await OrderService.get_leads_inbox(db, scope="active", page=1, limit=10, tenant_scope=TEST_TENANT_SCOPE)
 
     assert response.items[0].no_answer_at is None
 
@@ -115,7 +119,7 @@ async def test_leads_inbox_keeps_unknown_customer_type_and_task_essence_null(db)
     )
     await db.commit()
 
-    response = await OrderService.get_leads_inbox(db, scope="active", page=1, limit=10)
+    response = await OrderService.get_leads_inbox(db, scope="active", page=1, limit=10, tenant_scope=TEST_TENANT_SCOPE)
 
     assert response.items[0].customer_id == customer.id
     assert response.items[0].customer_type is None
@@ -148,7 +152,7 @@ async def test_leads_inbox_returns_known_type_and_task_when_stored(db):
     )
     await db.commit()
 
-    response = await OrderService.get_leads_inbox(db, scope="active", page=1, limit=10)
+    response = await OrderService.get_leads_inbox(db, scope="active", page=1, limit=10, tenant_scope=TEST_TENANT_SCOPE)
     item = response.items[0]
 
     assert item.customer_type == "company"
@@ -177,7 +181,7 @@ async def test_leads_inbox_returns_confirmed_individual_customer_type(db):
     )
     await db.commit()
 
-    response = await OrderService.get_leads_inbox(db, scope="active", page=1, limit=10)
+    response = await OrderService.get_leads_inbox(db, scope="active", page=1, limit=10, tenant_scope=TEST_TENANT_SCOPE)
 
     assert response.items[0].customer_type == "individual"
 
@@ -203,9 +207,10 @@ async def test_linking_existing_individual_marks_lead_customer_type_known(db):
         db,
         int(order.id),
         ManagerOrderUpdatePayload(customer_id=int(existing_customer.id)),
+        tenant_scope=TEST_TENANT_SCOPE,
     )
 
-    response = await OrderService.get_leads_inbox(db, scope="active", page=1, limit=10)
+    response = await OrderService.get_leads_inbox(db, scope="active", page=1, limit=10, tenant_scope=TEST_TENANT_SCOPE)
 
     assert response.items[0].customer_id == existing_customer.id
     assert response.items[0].customer_type == "individual"

--- a/tests/unit/test_order_service_manager.py
+++ b/tests/unit/test_order_service_manager.py
@@ -30,6 +30,10 @@ from services.staff_task_notification_event_service import (
     StaffTaskNotificationEventService,
 )
 
+from models.tenancy import TenantScope
+
+TEST_TENANT_SCOPE = TenantScope(tenant_id=1, storefront_id=1, is_system=True)
+
 
 @pytest.fixture
 async def sqlite_order_session(tmp_path: Path):
@@ -105,20 +109,20 @@ async def test_service_lists_cancels_and_deletes_stale_work_stages(sqlite_order_
     for stage in (stale_stage, unscheduled_stage, upcoming_stage, completed_stage):
         await sqlite_order_session.refresh(stage)
 
-    result = await OrderService.list_stale_order_stages(sqlite_order_session, older_than_days=7)
+    result = await OrderService.list_stale_order_stages(sqlite_order_session, older_than_days=7, tenant_scope=TEST_TENANT_SCOPE)
     names = {item["name"] for item in result["items"]}
 
     assert result["total"] == 2
     assert names == {"Старый выезд", "Без даты"}
     assert result["items"][0]["customer_name"] == "Иван"
 
-    canceled = await OrderService.cancel_order_stage_direct(sqlite_order_session, stale_stage.id)
+    canceled = await OrderService.cancel_order_stage_direct(sqlite_order_session, stale_stage.id, tenant_scope=TEST_TENANT_SCOPE)
     assert canceled["status"] == "canceled"
 
-    after_cancel = await OrderService.list_stale_order_stages(sqlite_order_session, older_than_days=7)
+    after_cancel = await OrderService.list_stale_order_stages(sqlite_order_session, older_than_days=7, tenant_scope=TEST_TENANT_SCOPE)
     assert {item["name"] for item in after_cancel["items"]} == {"Без даты"}
 
-    deleted = await OrderService.delete_order_stage_direct(sqlite_order_session, unscheduled_stage.id)
+    deleted = await OrderService.delete_order_stage_direct(sqlite_order_session, unscheduled_stage.id, tenant_scope=TEST_TENANT_SCOPE)
     assert deleted == {"ok": True, "id": unscheduled_stage.id}
     assert await sqlite_order_session.get(OrderWorkStage, unscheduled_stage.id) is None
 
@@ -139,6 +143,7 @@ async def test_service_validates_work_stage_status_and_order(sqlite_order_sessio
         sqlite_order_session,
         int(order.id),
         OrderWorkStageCreatePayload(name="Монтаж", status="in_progress"),
+        tenant_scope=TEST_TENANT_SCOPE,
     )
     assert created["work_stages"][0]["status"] == "in_progress"
 
@@ -151,6 +156,7 @@ async def test_service_validates_work_stage_status_and_order(sqlite_order_sessio
             int(order.id),
             int(stage.id),
             OrderWorkStageUpdatePayload(status="waiting_for_magic"),
+            tenant_scope=TEST_TENANT_SCOPE,
         )
 
     with pytest.raises(ValueError, match="Order not found"):
@@ -158,6 +164,7 @@ async def test_service_validates_work_stage_status_and_order(sqlite_order_sessio
             sqlite_order_session,
             999999,
             OrderWorkStageCreatePayload(name="Невозможный заказ"),
+            tenant_scope=TEST_TENANT_SCOPE,
         )
 
 
@@ -215,11 +222,13 @@ async def test_order_stage_mutations_enqueue_staff_notifications(
             installer_id=int(installer.id),
             start_time=start_time,
         ),
+        tenant_scope=TEST_TENANT_SCOPE,
     )
     stage = (await sqlite_order_session.execute(select(OrderWorkStage))).scalar_one()
     ensure_assignable.assert_awaited_once_with(
         sqlite_order_session,
         int(installer.id),
+        tenant_scope=TEST_TENANT_SCOPE,
     )
     assigned.assert_awaited_once()
 
@@ -228,6 +237,7 @@ async def test_order_stage_mutations_enqueue_staff_notifications(
         int(order.id),
         int(stage.id),
         OrderWorkStageUpdatePayload(start_time=start_time + timedelta(hours=1)),
+        tenant_scope=TEST_TENANT_SCOPE,
     )
     rescheduled.assert_awaited_once()
 
@@ -236,6 +246,7 @@ async def test_order_stage_mutations_enqueue_staff_notifications(
         int(order.id),
         int(stage.id),
         OrderWorkStageUpdatePayload(status="canceled"),
+        tenant_scope=TEST_TENANT_SCOPE,
     )
     canceled.assert_awaited_once()
 
@@ -296,6 +307,7 @@ async def test_calendar_completed_stages_keep_their_own_titles(sqlite_order_sess
         sqlite_order_session,
         event_time - timedelta(hours=1),
         event_time + timedelta(hours=3),
+        tenant_scope=TEST_TENANT_SCOPE,
     )
     by_id = {event.id: event for event in events}
 
@@ -432,15 +444,15 @@ async def test_service_get_orders_for_manager_segment_and_search(db):
     db.add(Order(customer_id=c2.id, status=OrderStatus.NEGOTIATION, comment="note 2"))
     await db.commit()
 
-    b2c = await OrderService.get_orders_for_manager(db, "b2c", page=1, limit=20)
+    b2c = await OrderService.get_orders_for_manager(db, "b2c", page=1, limit=20, tenant_scope=TEST_TENANT_SCOPE)
     assert len(b2c["items"]) == 1
     assert b2c["items"][0]["customer"]["name"] == "Alice"
 
-    b2b = await OrderService.get_orders_for_manager(db, "b2b", page=1, limit=20, search="999000111")
+    b2b = await OrderService.get_orders_for_manager(db, "b2b", page=1, limit=20, search="999000111", tenant_scope=TEST_TENANT_SCOPE)
     assert len(b2b["items"]) == 1
     assert b2b["items"][0]["customer"]["name"] == "Acme LLC"
 
-    all_orders = await OrderService.get_orders_for_manager(db, "all", page=1, limit=20)
+    all_orders = await OrderService.get_orders_for_manager(db, "all", page=1, limit=20, tenant_scope=TEST_TENANT_SCOPE)
     assert {item["customer"]["name"] for item in all_orders["items"]} == {"Alice", "Acme LLC"}
 
 
@@ -461,12 +473,12 @@ async def test_service_get_orders_for_manager_title_and_labels(db):
     )
     await db.commit()
 
-    by_title = await OrderService.get_orders_for_manager(db, "b2c", page=1, limit=20, search="Дубровно")
+    by_title = await OrderService.get_orders_for_manager(db, "b2c", page=1, limit=20, search="Дубровно", tenant_scope=TEST_TENANT_SCOPE)
     assert len(by_title["items"]) == 1
     assert by_title["items"][0]["title"] == "Монтаж магазина в Дубровно"
     assert by_title["items"][0]["manager_labels"] == ["срочно", "уточнить оплату"]
 
-    by_label = await OrderService.get_orders_for_manager(db, "b2c", page=1, limit=20, search="оплату")
+    by_label = await OrderService.get_orders_for_manager(db, "b2c", page=1, limit=20, search="оплату", tenant_scope=TEST_TENANT_SCOPE)
     assert len(by_label["items"]) == 1
 
 
@@ -475,14 +487,14 @@ async def test_service_get_orders_for_manager_b2c_includes_legacy_without_custom
     db.add(Order(customer_id=None, status=OrderStatus.NEGOTIATION, comment="legacy"))
     await db.commit()
 
-    b2c = await OrderService.get_orders_for_manager(db, "b2c", page=1, limit=20)
+    b2c = await OrderService.get_orders_for_manager(db, "b2c", page=1, limit=20, tenant_scope=TEST_TENANT_SCOPE)
     assert len(b2c["items"]) == 1
     assert b2c["items"][0]["customer"] is None
 
-    b2b = await OrderService.get_orders_for_manager(db, "b2b", page=1, limit=20)
+    b2b = await OrderService.get_orders_for_manager(db, "b2b", page=1, limit=20, tenant_scope=TEST_TENANT_SCOPE)
     assert len(b2b["items"]) == 0
 
-    all_orders = await OrderService.get_orders_for_manager(db, "all", page=1, limit=20)
+    all_orders = await OrderService.get_orders_for_manager(db, "all", page=1, limit=20, tenant_scope=TEST_TENANT_SCOPE)
     assert len(all_orders["items"]) == 1
     assert all_orders["items"][0]["customer"] is None
 
@@ -511,6 +523,7 @@ async def test_service_auto_execution_on_payment_moves_order_to_work(db):
         db,
         int(order.id),
         PaymentCreatePayload(amount=500, type="postpayment"),
+        tenant_scope=TEST_TENANT_SCOPE,
     )
     await db.refresh(order)
 
@@ -543,6 +556,7 @@ async def test_service_auto_close_on_payment_closes_execution_order(db):
         db,
         int(order.id),
         PaymentCreatePayload(amount=420, type="postpayment"),
+        tenant_scope=TEST_TENANT_SCOPE,
     )
     await db.refresh(order)
 
@@ -577,6 +591,7 @@ async def test_service_auto_close_on_payment_waits_for_payment_execution_status(
         db,
         int(order.id),
         PaymentCreatePayload(amount=420, type="postpayment"),
+        tenant_scope=TEST_TENANT_SCOPE,
     )
     await db.refresh(order)
 
@@ -598,7 +613,7 @@ async def test_service_get_orders_for_manager_overdue_filter(db):
     db.add(Order(customer_id=customer.id, status=OrderStatus.NEGOTIATION, next_followup_date=datetime.now() + timedelta(days=1)))
     await db.commit()
 
-    result = await OrderService.get_orders_for_manager(db, "b2c", page=1, limit=20, overdue_only=True)
+    result = await OrderService.get_orders_for_manager(db, "b2c", page=1, limit=20, overdue_only=True, tenant_scope=TEST_TENANT_SCOPE)
     assert len(result["items"]) == 1
 
 
@@ -626,7 +641,7 @@ async def test_service_update_order_for_manager_line_sync(db):
         services=[{"service_id": service.id, "title": "Srv", "quantity": 1, "price": 200}],
     )
 
-    data = await OrderService.update_order_for_manager(db, order.id, payload)
+    data = await OrderService.update_order_for_manager(db, order.id, payload, tenant_scope=TEST_TENANT_SCOPE)
     assert data is not None
     assert data["status"] == "negotiation"
     assert len(data["product_lines"]) == 1
@@ -652,7 +667,7 @@ async def test_service_update_order_for_manager_title_and_labels(db):
         manager_labels=[" срочно ", "Срочно", "", "ждём оплату"],
     )
 
-    data = await OrderService.update_order_for_manager(db, order.id, payload)
+    data = await OrderService.update_order_for_manager(db, order.id, payload, tenant_scope=TEST_TENANT_SCOPE)
     assert data is not None
     assert data["title"] == "Монтаж магазина"
     assert data["manager_labels"] == ["срочно", "ждём оплату"]
@@ -661,6 +676,7 @@ async def test_service_update_order_for_manager_title_and_labels(db):
         db,
         order.id,
         ManagerOrderUpdatePayload(title="", manager_labels=[]),
+        tenant_scope=TEST_TENANT_SCOPE,
     )
     assert cleared is not None
     assert cleared["title"] is None
@@ -692,6 +708,7 @@ async def test_service_non_repair_update_has_no_repair_side_effects(db):
         db,
         order.id,
         ManagerOrderUpdatePayload(comment="Обычная заявка без ремонта"),
+        tenant_scope=TEST_TENANT_SCOPE,
     )
 
     assert data is not None
@@ -713,13 +730,14 @@ async def test_service_update_order_for_manager_validation(db):
     await db.refresh(order)
 
     with pytest.raises(ValueError):
-        await OrderService.update_order_for_manager(db, order.id, ManagerOrderUpdatePayload(status="bad_status"))
+        await OrderService.update_order_for_manager(db, order.id, ManagerOrderUpdatePayload(status="bad_status"), tenant_scope=TEST_TENANT_SCOPE)
 
     with pytest.raises(ValueError, match="Invalid negotiation_status"):
         await OrderService.update_order_for_manager(
             db,
             order.id,
             ManagerOrderUpdatePayload(negotiation_status="waiting_for_magic"),
+            tenant_scope=TEST_TENANT_SCOPE,
         )
 
     with pytest.raises(ValueError):
@@ -727,6 +745,7 @@ async def test_service_update_order_for_manager_validation(db):
             db,
             order.id,
             ManagerOrderUpdatePayload(products=[{"product_id": 1, "quantity": 1, "price": -1}]),
+            tenant_scope=TEST_TENANT_SCOPE,
         )
 
     with pytest.raises(ValueError, match="Product not found"):
@@ -734,6 +753,7 @@ async def test_service_update_order_for_manager_validation(db):
             db,
             order.id,
             ManagerOrderUpdatePayload(products=[{"product_id": 999999, "quantity": 1, "price": 100}]),
+            tenant_scope=TEST_TENANT_SCOPE,
         )
 
     product = Product(title="Validation Product", slug="validation-product", price=100)
@@ -749,6 +769,7 @@ async def test_service_update_order_for_manager_validation(db):
             db,
             order.id,
             ManagerOrderUpdatePayload(products=[{"product_id": product.id, "quantity": 1, "price": 100, "cost": -1}]),
+            tenant_scope=TEST_TENANT_SCOPE,
         )
 
     with pytest.raises(ValueError, match="Service not found"):
@@ -756,6 +777,7 @@ async def test_service_update_order_for_manager_validation(db):
             db,
             order.id,
             ManagerOrderUpdatePayload(services=[{"service_id": 999999, "title": "Bad", "quantity": 1, "price": 100}]),
+            tenant_scope=TEST_TENANT_SCOPE,
         )
 
     with pytest.raises(ValueError, match="Service cost cannot be negative"):
@@ -765,6 +787,7 @@ async def test_service_update_order_for_manager_validation(db):
             ManagerOrderUpdatePayload(
                 services=[{"service_id": service.id, "title": service.title, "quantity": 1, "price": 100, "cost": -1}]
             ),
+            tenant_scope=TEST_TENANT_SCOPE,
         )
 
 
@@ -784,6 +807,7 @@ async def test_service_update_order_lost_archives_customer_in_same_flow(db):
         db,
         order.id,
         ManagerOrderUpdatePayload(status="closed", closing_result="lost"),
+        tenant_scope=TEST_TENANT_SCOPE,
     )
 
     assert updated is not None
@@ -845,7 +869,7 @@ async def test_service_delete_order_cleans_proposals_and_detaches_audit_rows(sql
     db.add(email)
     await db.commit()
 
-    assert await OrderService.delete_order(db, order.id) is True
+    assert await OrderService.delete_order(db, order.id, tenant_scope=TEST_TENANT_SCOPE) is True
 
     assert await db.get(Order, order.id) is None
     assert (await db.execute(select(OrderProposal).where(OrderProposal.id == proposal.id))).scalar_one_or_none() is None

--- a/tests/unit/test_repair_diagnostic_service.py
+++ b/tests/unit/test_repair_diagnostic_service.py
@@ -127,7 +127,11 @@ async def test_repair_diagnostic_service_creates_repair_order_with_structured_me
 
 
 @pytest.mark.asyncio
-async def test_repair_notification_escapes_contact_fields(monkeypatch, caplog):
+async def test_repair_notification_escapes_contact_fields(
+    monkeypatch,
+    caplog,
+    tenant_scope,
+):
     payload = RepairDiagnosticLeadPayload.model_validate(
         {
             "scenario": "repair",
@@ -142,7 +146,7 @@ async def test_repair_notification_escapes_contact_fields(monkeypatch, caplog):
     )
     sent_messages = []
 
-    async def fake_recipients(_session):
+    async def fake_recipients(_session, *, tenant_scope):
         return [101, 202]
 
     async def fake_send_message(admin_id, text):
@@ -162,6 +166,7 @@ async def test_repair_notification_escapes_contact_fields(monkeypatch, caplog):
             SimpleNamespace(id=42),
             payload,
             {},
+            tenant_scope=tenant_scope,
         )
 
     sent_text = sent_messages[0][1]

--- a/tests/unit/test_service_attachment_service.py
+++ b/tests/unit/test_service_attachment_service.py
@@ -20,6 +20,10 @@ from services.private_attachment_storage_service import StoredPrivateObject
 from services.service_attachment_presenter import legacy_attachment_source_key
 from services.service_attachment_service import ServiceAttachmentService
 
+from models.tenancy import TenantScope
+
+TEST_TENANT_SCOPE = TenantScope(tenant_id=1, storefront_id=1, is_system=True)
+
 
 class FakePrivateAttachmentStorage:
     provider_name = "test_private"
@@ -94,6 +98,7 @@ async def test_private_attachment_dedupes_binary_without_merging_business_occurr
         mime_type="text/plain",
         category="document",
         storage=storage,
+        tenant_scope=TEST_TENANT_SCOPE,
     )
     second = await ServiceAttachmentService.create_and_link_order_attachment(
         attachment_session,
@@ -103,6 +108,7 @@ async def test_private_attachment_dedupes_binary_without_merging_business_occurr
         mime_type="text/plain",
         category="service",
         storage=storage,
+        tenant_scope=TEST_TENANT_SCOPE,
     )
 
     attachments = list((await attachment_session.execute(select(ServiceAttachment))).scalars().all())
@@ -122,6 +128,7 @@ async def test_private_attachment_dedupes_binary_without_merging_business_occurr
         variant="original",
         download=True,
         storage=storage,
+        tenant_scope=TEST_TENANT_SCOPE,
     )
     assert access is not None
     parsed = urlparse(access["url"])
@@ -140,6 +147,7 @@ async def test_private_attachment_dedupes_binary_without_merging_business_occurr
         attachment_session,
         attachment_id=first["id"],
         order_id=int(first_order.id),
+        tenant_scope=TEST_TENANT_SCOPE,
     )
     first_attachment = next(item for item in attachments if item.id == first["id"])
     second_attachment = next(item for item in attachments if item.id == second["id"])
@@ -155,16 +163,17 @@ async def test_private_attachment_dedupes_binary_without_merging_business_occurr
     assert second_link.archived_at is None
     assert (await ServiceAttachmentService.list_order_attachments(
         attachment_session, order_id=int(first_order.id)
-    ))["total"] == 0
+    , tenant_scope=TEST_TENANT_SCOPE))["total"] == 0
     assert (await ServiceAttachmentService.list_order_attachments(
         attachment_session, order_id=int(second_order.id)
-    ))["total"] == 1
+    , tenant_scope=TEST_TENANT_SCOPE))["total"] == 1
     assert await ServiceAttachmentService.get_access(
         attachment_session,
         attachment_id=first["id"],
         variant="original",
         download=False,
         storage=storage,
+        tenant_scope=TEST_TENANT_SCOPE,
     ) is None
 
 
@@ -187,16 +196,19 @@ async def test_telegram_occurrence_is_idempotent_but_a_new_message_keeps_its_own
         attachment_session,
         **common,
         telegram_meta={"file_id": "file-a", "chat_id": 10, "message_id": 20},
+        tenant_scope=TEST_TENANT_SCOPE,
     )
     retry = await ServiceAttachmentService.create_and_link_order_attachment(
         attachment_session,
         **common,
         telegram_meta={"file_id": "file-a", "chat_id": 10, "message_id": 20},
+        tenant_scope=TEST_TENANT_SCOPE,
     )
     second_message = await ServiceAttachmentService.create_and_link_order_attachment(
         attachment_session,
         **common,
         telegram_meta={"file_id": "file-a", "chat_id": 10, "message_id": 21},
+        tenant_scope=TEST_TENANT_SCOPE,
     )
 
     assert retry["id"] == first["id"]
@@ -235,15 +247,18 @@ async def test_identical_evidence_does_not_cross_link_equipment_between_customer
             category="nameplate",
             telegram_meta={"file_id": f"file-{message_id}", "chat_id": 10, "message_id": message_id},
             storage=storage,
+            tenant_scope=TEST_TENANT_SCOPE,
         )
 
     first_result = await ServiceAttachmentService.list_order_attachments(
         attachment_session,
         order_id=int(first_order.id),
+        tenant_scope=TEST_TENANT_SCOPE,
     )
     second_result = await ServiceAttachmentService.list_order_attachments(
         attachment_session,
         order_id=int(second_order.id),
+        tenant_scope=TEST_TENANT_SCOPE,
     )
     assert first_result is not None and first_result["items"][0]["equipment_id"] == first_equipment.id
     assert second_result is not None and second_result["items"][0]["equipment_id"] == second_equipment.id
@@ -289,11 +304,13 @@ async def test_list_order_attachments_dual_reads_normalized_and_unmigrated_legac
         category="document",
         telegram_meta={"file_id": "already-normalized"},
         storage=storage,
+        tenant_scope=TEST_TENANT_SCOPE,
     )
 
     result = await ServiceAttachmentService.list_order_attachments(
         attachment_session,
         order_id=int(order.id),
+        tenant_scope=TEST_TENANT_SCOPE,
     )
 
     assert result is not None
@@ -332,15 +349,18 @@ async def test_url_only_legacy_item_is_not_duplicated_after_private_migration(at
             }
         },
         storage=storage,
+        tenant_scope=TEST_TENANT_SCOPE,
     )
 
     result = await ServiceAttachmentService.list_order_attachments(
         attachment_session,
         order_id=int(order.id),
+        tenant_scope=TEST_TENANT_SCOPE,
     )
     count = await ServiceAttachmentService.order_attachment_count(
         attachment_session,
         order=order,
+        tenant_scope=TEST_TENANT_SCOPE,
     )
 
     assert result is not None
@@ -376,6 +396,7 @@ async def test_attachment_can_follow_an_equipment_service_history_event(attachme
         mime_type="text/plain",
         category="service",
         storage=storage,
+        tenant_scope=TEST_TENANT_SCOPE,
     )
 
     assert created["equipment_id"] == equipment.id
@@ -395,6 +416,7 @@ async def test_attachment_can_follow_an_equipment_service_history_event(attachme
         attachment_id=int(created["id"]),
         order_id=int(order.id),
         payload={"service_history_id": None},
+        tenant_scope=TEST_TENANT_SCOPE,
     )
     assert updated is not None
     assert updated["equipment_id"] == equipment.id
@@ -428,4 +450,84 @@ async def test_attachment_rejects_service_history_from_another_order(attachment_
             filename="wrong.txt",
             mime_type="text/plain",
             storage=storage,
+            tenant_scope=TEST_TENANT_SCOPE,
         )
+
+
+@pytest.mark.asyncio
+async def test_shared_cross_tenant_attachment_cannot_be_globally_mutated_or_archived(
+    attachment_session,
+):
+    storage = FakePrivateAttachmentStorage()
+    tenant_b_scope = TenantScope(tenant_id=2, storefront_id=2, is_system=False)
+    customer_a = Customer(
+        tenant_id=1,
+        name="Attachment customer A",
+        phone="+375290000011",
+    )
+    customer_b = Customer(
+        tenant_id=2,
+        name="Attachment customer B",
+        phone="+375290000012",
+    )
+    attachment_session.add_all([customer_a, customer_b])
+    await attachment_session.flush()
+    order_a = Order(
+        tenant_id=1,
+        storefront_id=1,
+        customer_id=int(customer_a.id),
+        title="Attachment order A",
+    )
+    order_b = Order(
+        tenant_id=tenant_b_scope.tenant_id,
+        storefront_id=tenant_b_scope.storefront_id,
+        customer_id=int(customer_b.id),
+        title="Attachment order B",
+    )
+    attachment_session.add_all([order_a, order_b])
+    await attachment_session.commit()
+
+    created = await ServiceAttachmentService.create_and_link_order_attachment(
+        attachment_session,
+        order_id=int(order_a.id),
+        content=b"shared attachment",
+        filename="shared.txt",
+        mime_type="text/plain",
+        storage=storage,
+        tenant_scope=TEST_TENANT_SCOPE,
+    )
+    attachment_session.add(
+        OrderAttachmentLink(
+            order_id=int(order_b.id),
+            attachment_id=int(created["id"]),
+            category="other",
+        )
+    )
+    await attachment_session.commit()
+
+    updated = await ServiceAttachmentService.update_attachment(
+        attachment_session,
+        attachment_id=int(created["id"]),
+        order_id=int(order_a.id),
+        payload={"transcript": "must not cross tenants"},
+        tenant_scope=TEST_TENANT_SCOPE,
+    )
+    archived = await ServiceAttachmentService.archive_attachment(
+        attachment_session,
+        attachment_id=int(created["id"]),
+        tenant_scope=TEST_TENANT_SCOPE,
+    )
+
+    attachment = await attachment_session.get(ServiceAttachment, int(created["id"]))
+    links = (
+        await attachment_session.execute(
+            select(OrderAttachmentLink).where(
+                OrderAttachmentLink.attachment_id == int(created["id"])
+            )
+        )
+    ).scalars().all()
+    assert updated is None
+    assert archived is False
+    assert attachment.transcript is None
+    assert attachment.archived_at is None
+    assert all(link.archived_at is None for link in links)

--- a/tests/unit/test_snapshot_pricing.py
+++ b/tests/unit/test_snapshot_pricing.py
@@ -3,6 +3,10 @@ from sqlmodel import select
 from services.order_service import OrderService
 from models import Product, OrderProductLink, OrderServiceLink, LeadSource, OrderStatus
 
+from models.tenancy import TenantScope
+
+TEST_TENANT_SCOPE = TenantScope(tenant_id=1, storefront_id=1, is_system=True)
+
 async def test_snapshot_pricing(db, tenant_scope):
     # 1. Create test product
     product = Product(id=63, title="Hero Product", slug="hero-product", price=2500, specs={"area_m2": 30})
@@ -166,7 +170,7 @@ async def test_order_detail_does_not_double_count_installation_in_product_line(d
         comment=None,
     )
 
-    detail = await OrderService.get_order_detail_for_manager(db, order.id)
+    detail = await OrderService.get_order_detail_for_manager(db, order.id, tenant_scope=TEST_TENANT_SCOPE)
 
     assert detail["total_amount"] == 4600
     assert detail["product_lines"][0]["installation_price"] == 300

--- a/tests/unit/test_staff_user_service.py
+++ b/tests/unit/test_staff_user_service.py
@@ -11,8 +11,12 @@ from sqlalchemy.orm import sessionmaker
 from sqlmodel import SQLModel
 
 from core.config import settings
-from models import Installer, StaffUser
+from models import Installer, StaffUser, TenantMembership
 from services.staff_user_service import StaffUserService
+
+from models.tenancy import TenantScope
+
+TEST_TENANT_SCOPE = TenantScope(tenant_id=1, storefront_id=1, is_system=True)
 
 
 @pytest.fixture
@@ -109,17 +113,31 @@ async def test_find_active_executors_by_role_excludes_inactive_and_blocked(sqlit
     installer = Installer(name="Active Legacy", is_active=True)
     sqlite_staff_session.add(installer)
     await sqlite_staff_session.flush()
-    sqlite_staff_session.add(
-        StaffUser(display_name="Active Installer", status="active", roles=["installer"], legacy_installer_id=installer.id)
+    active_installer = StaffUser(
+        display_name="Active Installer",
+        status="active",
+        roles=["installer"],
+        legacy_installer_id=installer.id,
     )
+    sqlite_staff_session.add(active_installer)
     sqlite_staff_session.add(StaffUser(display_name="Inactive Installer", status="inactive", roles=["installer"]))
     sqlite_staff_session.add(StaffUser(display_name="Blocked Installer", status="blocked", roles=["installer"]))
     sqlite_staff_session.add(StaffUser(display_name="Active Admin", status="active", roles=["admin"]))
+    await sqlite_staff_session.flush()
+    sqlite_staff_session.add(
+        TenantMembership(
+            tenant_id=TEST_TENANT_SCOPE.tenant_id,
+            staff_user_id=int(active_installer.id or 0),
+            role="installer",
+            status="active",
+        )
+    )
     await sqlite_staff_session.commit()
 
     users = await StaffUserService.find_active_executors_by_role(
         sqlite_staff_session,
         StaffUserService.ROLE_INSTALLER,
+        tenant_scope=TEST_TENANT_SCOPE,
     )
 
     assert [user.display_name for user in users] == ["Active Installer"]
@@ -130,16 +148,86 @@ async def test_admin_recipients_use_active_db_owner_admin_before_legacy_fallback
     monkeypatch.setattr(settings, "ADMIN_IDS", "999", raising=False)
     monkeypatch.setattr(settings, "ADMIN_ID", 0, raising=False)
 
-    sqlite_staff_session.add(StaffUser(display_name="Owner", status="active", roles=["owner"], telegram_id=101))
-    sqlite_staff_session.add(StaffUser(display_name="Admin", status="active", roles=["admin"], telegram_id=202))
-    sqlite_staff_session.add(StaffUser(display_name="Manager", status="active", roles=["manager"], telegram_id=505))
-    sqlite_staff_session.add(StaffUser(display_name="Blocked", status="blocked", roles=["admin"], telegram_id=303))
-    sqlite_staff_session.add(StaffUser(display_name="Installer", status="active", roles=["installer"], telegram_id=404))
+    staff_rows = [
+        StaffUser(display_name="Owner", status="active", roles=["owner"], telegram_id=101),
+        StaffUser(display_name="Admin", status="active", roles=["admin"], telegram_id=202),
+        StaffUser(display_name="Manager", status="active", roles=["manager"], telegram_id=505),
+        StaffUser(display_name="Blocked", status="blocked", roles=["admin"], telegram_id=303),
+        StaffUser(display_name="Installer", status="active", roles=["installer"], telegram_id=404),
+    ]
+    sqlite_staff_session.add_all(staff_rows)
+    await sqlite_staff_session.flush()
+    for staff, role in zip(
+        staff_rows,
+        ("owner", "admin", "manager", "admin", "installer"),
+        strict=True,
+    ):
+        sqlite_staff_session.add(
+            TenantMembership(
+                tenant_id=TEST_TENANT_SCOPE.tenant_id,
+                staff_user_id=int(staff.id or 0),
+                role=role,
+                status="active",
+            )
+        )
     await sqlite_staff_session.commit()
 
-    recipients = await StaffUserService.get_active_owner_admin_telegram_recipient_ids(sqlite_staff_session)
+    recipients = await StaffUserService.get_active_owner_admin_telegram_recipient_ids(sqlite_staff_session, tenant_scope=TEST_TENANT_SCOPE)
 
     assert recipients == [101, 202, 505]
+
+
+@pytest.mark.asyncio
+async def test_admin_recipients_do_not_cross_tenant_memberships(
+    sqlite_staff_session,
+    monkeypatch,
+):
+    monkeypatch.setattr(settings, "ADMIN_IDS", "999", raising=False)
+    monkeypatch.setattr(settings, "ADMIN_ID", 0, raising=False)
+    scope_b = TenantScope(tenant_id=2, storefront_id=2, is_system=False)
+    owner_a = StaffUser(
+        display_name="Owner A",
+        status="active",
+        roles=["owner"],
+        telegram_id=101,
+    )
+    owner_b = StaffUser(
+        display_name="Owner B",
+        status="active",
+        roles=["owner"],
+        telegram_id=202,
+    )
+    sqlite_staff_session.add_all([owner_a, owner_b])
+    await sqlite_staff_session.flush()
+    sqlite_staff_session.add_all(
+        [
+            TenantMembership(
+                tenant_id=TEST_TENANT_SCOPE.tenant_id,
+                staff_user_id=int(owner_a.id or 0),
+                role="owner",
+                status="active",
+            ),
+            TenantMembership(
+                tenant_id=scope_b.tenant_id,
+                staff_user_id=int(owner_b.id or 0),
+                role="owner",
+                status="active",
+            ),
+        ]
+    )
+    await sqlite_staff_session.commit()
+
+    recipients_a = await StaffUserService.get_active_owner_admin_telegram_recipient_ids(
+        sqlite_staff_session,
+        tenant_scope=TEST_TENANT_SCOPE,
+    )
+    recipients_b = await StaffUserService.get_active_owner_admin_telegram_recipient_ids(
+        sqlite_staff_session,
+        tenant_scope=scope_b,
+    )
+
+    assert recipients_a == [101]
+    assert recipients_b == [202]
 
 
 @pytest.mark.asyncio
@@ -196,10 +284,25 @@ async def test_admin_recipients_fall_back_to_legacy_admin_ids_when_db_has_none(s
     monkeypatch.setattr(settings, "ADMIN_IDS", "901,902", raising=False)
     monkeypatch.setattr(settings, "ADMIN_ID", 903, raising=False)
 
-    sqlite_staff_session.add(StaffUser(display_name="Installer", status="active", roles=["installer"], telegram_id=404))
+    installer = StaffUser(
+        display_name="Installer",
+        status="active",
+        roles=["installer"],
+        telegram_id=404,
+    )
+    sqlite_staff_session.add(installer)
+    await sqlite_staff_session.flush()
+    sqlite_staff_session.add(
+        TenantMembership(
+            tenant_id=TEST_TENANT_SCOPE.tenant_id,
+            staff_user_id=int(installer.id or 0),
+            role="installer",
+            status="active",
+        )
+    )
     await sqlite_staff_session.commit()
 
-    recipients = await StaffUserService.get_active_owner_admin_telegram_recipient_ids(sqlite_staff_session)
+    recipients = await StaffUserService.get_active_owner_admin_telegram_recipient_ids(sqlite_staff_session, tenant_scope=TEST_TENANT_SCOPE)
 
     assert recipients == [901, 902, 903]
 

--- a/tests/unit/test_website_lead_service.py
+++ b/tests/unit/test_website_lead_service.py
@@ -37,7 +37,7 @@ async def test_create_contact_lead_uses_lead_funnel_and_notifies_all_owners(
         captured["tenant_scope"] = tenant_scope
         return {"id": 33, "status": "new", "created_at": created_at}
 
-    async def fake_recipients(_session):
+    async def fake_recipients(_session, *, tenant_scope):
         return [1001, 1002]
 
     async def fake_send_message(admin_id, text):

--- a/tests/unit/test_website_order_service.py
+++ b/tests/unit/test_website_order_service.py
@@ -89,7 +89,7 @@ async def test_website_checkout_does_not_attempt_telegram_without_recipients(
     async def fake_create_from_website(**_kwargs):
         return order
 
-    async def fake_recipients(_session):
+    async def fake_recipients(_session, *, tenant_scope):
         return []
 
     async def fail_if_sent(*_args, **_kwargs):
@@ -131,7 +131,11 @@ async def test_website_checkout_does_not_attempt_telegram_without_recipients(
 
 
 @pytest.mark.asyncio
-async def test_website_order_notification_escapes_and_bounds_untrusted_fields(monkeypatch, caplog):
+async def test_website_order_notification_escapes_and_bounds_untrusted_fields(
+    monkeypatch,
+    caplog,
+    tenant_scope,
+):
     payload = OrderPayload.model_validate(
         {
             "customer": {
@@ -165,7 +169,7 @@ async def test_website_order_notification_escapes_and_bounds_untrusted_fields(mo
         async def refresh(self, *_args, **_kwargs):
             return None
 
-    async def fake_recipients(_session):
+    async def fake_recipients(_session, *, tenant_scope):
         return [101, 202]
 
     async def fake_send_message(admin_id, text):
@@ -180,7 +184,12 @@ async def test_website_order_notification_escapes_and_bounds_untrusted_fields(mo
     monkeypatch.setattr(BotService, "send_message", fake_send_message)
 
     with caplog.at_level("WARNING"):
-        await WebsiteOrderService._notify_admins(_Session(), order, payload)
+        await WebsiteOrderService._notify_admins(
+            _Session(),
+            order,
+            payload,
+            tenant_scope=tenant_scope,
+        )
 
     assert [admin_id for admin_id, _text in sent_messages] == [101, 202]
     sent_text = sent_messages[0][1]


### PR DESCRIPTION
## Summary
- add a central fail-closed tenant ownership boundary for Orders, Leads, Customers, equipment, stages and documents
- propagate server-resolved tenant scope through Manager, staff bot, notifications, attachments, installers, dashboard, calendar and transfer flows
- keep global finance, mail and document-template administration system-only until those resources have tenant provenance
- add cross-tenant negative API tests, shared-attachment mutation protection and customer-context template loading in Manager

## Validation
- 2853 pytest tests passed; 4 platform-specific tests skipped
- Manager frontend production build passed
- OpenAPI extraction and generated Manager client are clean
- Python compileall and git diff checks passed

## Rollout
This is application-layer isolation in the existing expand phase. It adds no destructive migration. Existing controlled provenance backfill and the later contract migration remain separate production steps before a second tenant is enabled.