### PR TITLE
Make order proposal commands transactional

### DIFF
--- a/docs/order-domain-refactor.md
+++ b/docs/order-domain-refactor.md
@@ -48,6 +48,15 @@ handler owns one transaction and returns the post-commit projection. Failure at
 any point must roll back the order, customer changes, links and outbox events as
 one unit. Add fault-injection tests at the final step of each command.
 
+Deliver R2 as three independently deployable slices:
+
+1. proposal create/update/select commands;
+2. work-stage and payment commands;
+3. order create/update/delete plus Lead qualification.
+
+When a command participates in an explicit caller-owned unit of work, its local
+boundary is a SAVEPOINT; ordinary HTTP commands own the root transaction.
+
 ## R3: Order and Lead schemas
 
 Move Order/Lead DTOs into domain modules and re-export them from `schemas.py` so

--- a/routers/manager_orders_write.py
+++ b/routers/manager_orders_write.py
@@ -45,6 +45,7 @@ from schemas import (
     ManagerStaleWorkStageItem,
 )
 from services.document_service import DocumentService, OrderDocumentsLockedError
+from services.order_proposal_command_service import OrderProposalCommandService
 from services.order_service import OrderService
 from services.order_transfer_service import OrderTransferService
 from services.tenant_scope_service import TenantScope
@@ -225,7 +226,7 @@ async def create_manager_order_proposal(
     tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     try:
-        return await OrderService.create_order_proposal(
+        return await OrderProposalCommandService.create_order_proposal(
             session,
             order_id,
             payload,
@@ -253,7 +254,7 @@ async def duplicate_manager_order_proposal(
         duplicate_from_proposal_id=proposal_id,
     )
     try:
-        return await OrderService.create_order_proposal(
+        return await OrderProposalCommandService.create_order_proposal(
             session,
             order_id,
             duplicate_payload,
@@ -277,7 +278,7 @@ async def patch_manager_order_proposal(
     tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     try:
-        return await OrderService.update_order_proposal(
+        return await OrderProposalCommandService.update_order_proposal(
             session,
             order_id,
             proposal_id,
@@ -301,7 +302,7 @@ async def archive_manager_order_proposal(
     tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     try:
-        return await OrderService.update_order_proposal(
+        return await OrderProposalCommandService.update_order_proposal(
             session,
             order_id,
             proposal_id,
@@ -325,7 +326,7 @@ async def select_manager_order_proposal(
     tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     try:
-        return await OrderService.select_order_proposal(
+        return await OrderProposalCommandService.select_order_proposal(
             session,
             order_id,
             proposal_id,

--- a/services/command_transaction.py
+++ b/services/command_transaction.py
@@ -1,0 +1,10 @@
+"""Shared transaction boundary for composable application commands."""
+
+from sqlalchemy.ext.asyncio import AsyncSession, AsyncSessionTransaction
+
+
+def command_transaction(session: AsyncSession) -> AsyncSessionTransaction:
+    """Own a root transaction, or a SAVEPOINT inside an explicit caller UoW."""
+    if session.in_transaction():
+        return session.begin_nested()
+    return session.begin()

--- a/services/order_proposal_command_service.py
+++ b/services/order_proposal_command_service.py
@@ -1,0 +1,284 @@
+"""Transactional commands for Manager order proposals.
+
+Every public command owns exactly one database transaction.  Mutation helpers
+may flush so later steps can use generated identifiers, but they never commit
+or roll back independently.
+"""
+
+from typing import Any, Dict
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from models import Order, OrderProductLink, OrderProposal, OrderServiceLink
+from services.command_transaction import command_transaction
+from services.order_projection_service import OrderProjectionService
+from services.order_proposal_lifecycle import (
+    PROPOSAL_STATUS_READY,
+    normalize_proposal_status,
+    sync_selected_proposal_status,
+)
+from services.order_service import OrderService
+from services.tenant_entity_access_service import TenantEntityAccessService
+from services.tenant_scope_service import TenantScope
+
+
+class OrderProposalCommandService:
+    @staticmethod
+    async def _load_order_for_write(
+        session: AsyncSession,
+        order_id: int,
+        *,
+        tenant_scope: TenantScope,
+    ) -> Order:
+        order = await TenantEntityAccessService.get_order(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+            options=(
+                selectinload(Order.proposals),
+                selectinload(Order.product_links).selectinload(OrderProductLink.product),
+                selectinload(Order.service_links).selectinload(OrderServiceLink.service),
+                selectinload(Order.payments),
+                selectinload(Order.installers),
+            ),
+            for_update=True,
+        )
+        if not order:
+            raise ValueError("Order not found")
+        await OrderService.ensure_default_proposal(session, order)
+        return order
+
+    @staticmethod
+    async def _project_committed_order(
+        session: AsyncSession,
+        order_id: int,
+        *,
+        tenant_scope: TenantScope,
+    ) -> Dict[str, Any]:
+        data = await OrderProjectionService.get_order_detail_for_manager(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+        )
+        if data is None:
+            raise RuntimeError("Committed order is no longer visible in its tenant scope")
+        return data
+
+    @staticmethod
+    async def create_order_proposal(
+        session: AsyncSession,
+        order_id: int,
+        payload: Any,
+        *,
+        tenant_scope: TenantScope,
+    ) -> Dict[str, Any]:
+        async with command_transaction(session):
+            order = await OrderProposalCommandService._load_order_for_write(
+                session,
+                order_id,
+                tenant_scope=tenant_scope,
+            )
+            source = None
+            source_id = getattr(payload, "duplicate_from_proposal_id", None)
+            if source_id:
+                source = next(
+                    (
+                        proposal
+                        for proposal in order.proposals
+                        if proposal.id == source_id and not proposal.is_archived
+                    ),
+                    None,
+                )
+                if not source:
+                    raise ValueError("Source proposal not found")
+
+            active_count = len(
+                [proposal for proposal in order.proposals if not proposal.is_archived]
+            )
+            proposal = OrderProposal(
+                order_id=order_id,
+                name=OrderService._clean_proposal_name(
+                    getattr(payload, "name", None),
+                    f"Вариант {active_count + 1}",
+                ),
+                status="draft",
+                is_selected=active_count == 0,
+                sort_order=active_count * 10,
+            )
+            session.add(proposal)
+            await session.flush()
+
+            if source:
+                for link in [
+                    item for item in order.product_links if item.proposal_id == source.id
+                ]:
+                    session.add(
+                        OrderProductLink(
+                            order_id=order_id,
+                            proposal_id=proposal.id,
+                            product_id=link.product_id,
+                            quantity=link.quantity,
+                            price=link.price,
+                            cost=link.cost,
+                            is_installation_included=link.is_installation_included,
+                            installation_price=link.installation_price,
+                            installation_details=link.installation_details,
+                            logistics_components=OrderService._serialize_order_logistics_components(
+                                link.logistics_components
+                            ),
+                        )
+                    )
+                for link in [
+                    item for item in order.service_links if item.proposal_id == source.id
+                ]:
+                    session.add(
+                        OrderServiceLink(
+                            order_id=order_id,
+                            proposal_id=proposal.id,
+                            service_id=link.service_id,
+                            title=link.title,
+                            quantity=link.quantity,
+                            price=link.price,
+                            cost=link.cost,
+                        )
+                    )
+            await session.flush()
+            await OrderService._refresh_order_financials(session, order)
+            session.add(order)
+
+        return await OrderProposalCommandService._project_committed_order(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+        )
+
+    @staticmethod
+    async def update_order_proposal(
+        session: AsyncSession,
+        order_id: int,
+        proposal_id: int,
+        payload: Any,
+        *,
+        tenant_scope: TenantScope,
+    ) -> Dict[str, Any]:
+        async with command_transaction(session):
+            order = await OrderProposalCommandService._load_order_for_write(
+                session,
+                order_id,
+                tenant_scope=tenant_scope,
+            )
+            proposal = next(
+                (item for item in order.proposals if item.id == proposal_id),
+                None,
+            )
+            if not proposal:
+                raise ValueError("Proposal not found")
+            fields_set = getattr(payload, "model_fields_set", None)
+            if fields_set is None:
+                fields_set = getattr(payload, "__fields_set__", set())
+            if "name" in fields_set:
+                proposal.name = OrderService._clean_proposal_name(
+                    payload.name,
+                    proposal.name,
+                )
+            status_changed = "status" in fields_set and payload.status is not None
+            if status_changed:
+                next_status = normalize_proposal_status(payload.status)
+                if next_status == PROPOSAL_STATUS_READY:
+                    product_links = [
+                        link
+                        for link in order.product_links
+                        if link.proposal_id == proposal.id
+                    ]
+                    service_links = [
+                        link
+                        for link in order.service_links
+                        if link.proposal_id == proposal.id
+                    ]
+                    total_amount, _, _ = OrderService._proposal_line_totals(
+                        product_links,
+                        service_links,
+                    )
+                    if not product_links and not service_links:
+                        raise ValueError(
+                            "Proposal must contain at least one line before it is ready to send"
+                        )
+                    if total_amount <= 0:
+                        raise ValueError(
+                            "Proposal total must be greater than zero before it is ready to send"
+                        )
+                proposal.status = next_status
+            if "sort_order" in fields_set and payload.sort_order is not None:
+                proposal.sort_order = int(payload.sort_order)
+            if "is_archived" in fields_set and payload.is_archived is not None:
+                proposal.is_archived = bool(payload.is_archived)
+                if proposal.is_archived and proposal.is_selected:
+                    active = [
+                        item
+                        for item in order.proposals
+                        if item.id != proposal.id and not item.is_archived
+                    ]
+                    replacement = next(
+                        iter(sorted(active, key=lambda item: item.sort_order)),
+                        None,
+                    )
+                    proposal.is_selected = False
+                    if replacement:
+                        replacement.is_selected = True
+                        replacement.status = normalize_proposal_status(
+                            replacement.status
+                        )
+                        sync_selected_proposal_status(order, replacement)
+                        session.add(replacement)
+            session.add(proposal)
+            if status_changed:
+                sync_selected_proposal_status(order, proposal)
+            await session.flush()
+            await OrderService._refresh_order_financials(session, order)
+            session.add(order)
+
+        return await OrderProposalCommandService._project_committed_order(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+        )
+
+    @staticmethod
+    async def select_order_proposal(
+        session: AsyncSession,
+        order_id: int,
+        proposal_id: int,
+        *,
+        tenant_scope: TenantScope,
+    ) -> Dict[str, Any]:
+        async with command_transaction(session):
+            order = await OrderProposalCommandService._load_order_for_write(
+                session,
+                order_id,
+                tenant_scope=tenant_scope,
+            )
+            proposal = next(
+                (
+                    item
+                    for item in order.proposals
+                    if item.id == proposal_id and not item.is_archived
+                ),
+                None,
+            )
+            if not proposal:
+                raise ValueError("Proposal not found")
+            for item in order.proposals:
+                item.is_selected = item.id == proposal.id
+                session.add(item)
+            proposal.status = normalize_proposal_status(proposal.status)
+            sync_selected_proposal_status(order, proposal)
+            await session.flush()
+            await OrderService._refresh_order_financials(session, order)
+            session.add(order)
+
+        return await OrderProposalCommandService._project_committed_order(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+        )

--- a/services/order_service.py
+++ b/services/order_service.py
@@ -19,10 +19,8 @@ from services.product_area import area_from_specs
 from services.order_product_line_service import OrderProductLineService
 from services.order_proposal_lifecycle import (
     PROPOSAL_STATUS_APPROVED,
-    PROPOSAL_STATUS_READY,
     PROPOSAL_STATUS_SENT,
     normalize_proposal_status,
-    sync_selected_proposal_status,
 )
 from services.tenant_scope_service import (
     TenantScope,
@@ -2228,31 +2226,6 @@ class OrderService:
         )
 
     @staticmethod
-    async def _load_order_for_proposal_write(
-        session: AsyncSession,
-        order_id: int,
-        *,
-        tenant_scope: TenantScope,
-    ) -> Order:
-        order = await TenantEntityAccessService.get_order(
-            session,
-            order_id,
-            tenant_scope=tenant_scope,
-            options=(
-                selectinload(Order.proposals),
-                selectinload(Order.product_links).selectinload(OrderProductLink.product),
-                selectinload(Order.service_links).selectinload(OrderServiceLink.service),
-                selectinload(Order.payments),
-                selectinload(Order.installers),
-            ),
-            for_update=True,
-        )
-        if not order:
-            raise ValueError("Order not found")
-        await OrderService.ensure_default_proposal(session, order)
-        return order
-
-    @staticmethod
     async def create_order_proposal(
         session: AsyncSession,
         order_id: int,
@@ -2260,66 +2233,13 @@ class OrderService:
         *,
         tenant_scope: TenantScope,
     ) -> Dict[str, Any]:
-        order = await OrderService._load_order_for_proposal_write(
+        """Compatibility delegate to the transactional proposal command."""
+        from services.order_proposal_command_service import OrderProposalCommandService
+
+        return await OrderProposalCommandService.create_order_proposal(
             session,
             order_id,
-            tenant_scope=tenant_scope,
-        )
-        source = None
-        source_id = getattr(payload, "duplicate_from_proposal_id", None)
-        if source_id:
-            source = next((proposal for proposal in order.proposals if proposal.id == source_id and not proposal.is_archived), None)
-            if not source:
-                raise ValueError("Source proposal not found")
-
-        active_count = len([proposal for proposal in order.proposals if not proposal.is_archived])
-        proposal = OrderProposal(
-            order_id=order_id,
-            name=OrderService._clean_proposal_name(getattr(payload, "name", None), f"Вариант {active_count + 1}"),
-            status="draft",
-            is_selected=active_count == 0,
-            sort_order=active_count * 10,
-        )
-        session.add(proposal)
-        await session.flush()
-
-        if source:
-            for link in [item for item in order.product_links if item.proposal_id == source.id]:
-                session.add(
-                    OrderProductLink(
-                        order_id=order_id,
-                        proposal_id=proposal.id,
-                        product_id=link.product_id,
-                        quantity=link.quantity,
-                        price=link.price,
-                        cost=link.cost,
-                        is_installation_included=link.is_installation_included,
-                        installation_price=link.installation_price,
-                        installation_details=link.installation_details,
-                        logistics_components=OrderService._serialize_order_logistics_components(
-                            link.logistics_components
-                        ),
-                    )
-                )
-            for link in [item for item in order.service_links if item.proposal_id == source.id]:
-                session.add(
-                    OrderServiceLink(
-                        order_id=order_id,
-                        proposal_id=proposal.id,
-                        service_id=link.service_id,
-                        title=link.title,
-                        quantity=link.quantity,
-                        price=link.price,
-                        cost=link.cost,
-                    )
-                )
-        await session.flush()
-        await OrderService._refresh_order_financials(session, order)
-        session.add(order)
-        await session.commit()
-        return await OrderService.get_order_detail_for_manager(
-            session,
-            order_id,
+            payload,
             tenant_scope=tenant_scope,
         )
 
@@ -2332,54 +2252,14 @@ class OrderService:
         *,
         tenant_scope: TenantScope,
     ) -> Dict[str, Any]:
-        order = await OrderService._load_order_for_proposal_write(
+        """Compatibility delegate to the transactional proposal command."""
+        from services.order_proposal_command_service import OrderProposalCommandService
+
+        return await OrderProposalCommandService.update_order_proposal(
             session,
             order_id,
-            tenant_scope=tenant_scope,
-        )
-        proposal = next((item for item in order.proposals if item.id == proposal_id), None)
-        if not proposal:
-            raise ValueError("Proposal not found")
-        fields_set = getattr(payload, "model_fields_set", None)
-        if fields_set is None:
-            fields_set = getattr(payload, "__fields_set__", set())
-        if "name" in fields_set:
-            proposal.name = OrderService._clean_proposal_name(payload.name, proposal.name)
-        status_changed = "status" in fields_set and payload.status is not None
-        if status_changed:
-            next_status = normalize_proposal_status(payload.status)
-            if next_status == PROPOSAL_STATUS_READY:
-                product_links = [link for link in order.product_links if link.proposal_id == proposal.id]
-                service_links = [link for link in order.service_links if link.proposal_id == proposal.id]
-                total_amount, _, _ = OrderService._proposal_line_totals(product_links, service_links)
-                if not product_links and not service_links:
-                    raise ValueError("Proposal must contain at least one line before it is ready to send")
-                if total_amount <= 0:
-                    raise ValueError("Proposal total must be greater than zero before it is ready to send")
-            proposal.status = next_status
-        if "sort_order" in fields_set and payload.sort_order is not None:
-            proposal.sort_order = int(payload.sort_order)
-        if "is_archived" in fields_set and payload.is_archived is not None:
-            proposal.is_archived = bool(payload.is_archived)
-            if proposal.is_archived and proposal.is_selected:
-                active = [item for item in order.proposals if item.id != proposal.id and not item.is_archived]
-                replacement = next(iter(sorted(active, key=lambda item: item.sort_order)), None)
-                proposal.is_selected = False
-                if replacement:
-                    replacement.is_selected = True
-                    replacement.status = normalize_proposal_status(replacement.status)
-                    sync_selected_proposal_status(order, replacement)
-                    session.add(replacement)
-        session.add(proposal)
-        if status_changed:
-            sync_selected_proposal_status(order, proposal)
-        await session.flush()
-        await OrderService._refresh_order_financials(session, order)
-        session.add(order)
-        await session.commit()
-        return await OrderService.get_order_detail_for_manager(
-            session,
-            order_id,
+            proposal_id,
+            payload,
             tenant_scope=tenant_scope,
         )
 
@@ -2391,26 +2271,13 @@ class OrderService:
         *,
         tenant_scope: TenantScope,
     ) -> Dict[str, Any]:
-        order = await OrderService._load_order_for_proposal_write(
+        """Compatibility delegate to the transactional proposal command."""
+        from services.order_proposal_command_service import OrderProposalCommandService
+
+        return await OrderProposalCommandService.select_order_proposal(
             session,
             order_id,
-            tenant_scope=tenant_scope,
-        )
-        proposal = next((item for item in order.proposals if item.id == proposal_id and not item.is_archived), None)
-        if not proposal:
-            raise ValueError("Proposal not found")
-        for item in order.proposals:
-            item.is_selected = item.id == proposal.id
-            session.add(item)
-        proposal.status = normalize_proposal_status(proposal.status)
-        sync_selected_proposal_status(order, proposal)
-        await session.flush()
-        await OrderService._refresh_order_financials(session, order)
-        session.add(order)
-        await session.commit()
-        return await OrderService.get_order_detail_for_manager(
-            session,
-            order_id,
+            proposal_id,
             tenant_scope=tenant_scope,
         )
 

--- a/tests/unit/test_order_proposal_command_service.py
+++ b/tests/unit/test_order_proposal_command_service.py
@@ -1,0 +1,184 @@
+from pathlib import Path
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import SQLModel, select
+
+from models import Customer, Order, OrderProposal, OrderStatus
+from models.tenancy import TenantScope
+from schemas import OrderProposalCreatePayload, OrderProposalUpdatePayload
+from services.order_proposal_command_service import OrderProposalCommandService
+from services.order_service import OrderService
+
+
+TEST_TENANT_SCOPE = TenantScope(tenant_id=1, storefront_id=1, is_system=True)
+
+
+@pytest.fixture
+async def proposal_session(tmp_path: Path):
+    engine = create_async_engine(
+        f"sqlite+aiosqlite:///{tmp_path / 'order_proposal_commands.db'}",
+        echo=False,
+    )
+    async with engine.begin() as connection:
+        await connection.run_sync(SQLModel.metadata.create_all)
+
+    session_factory = sessionmaker(
+        bind=engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+    async with session_factory() as session:
+        yield session
+
+    await engine.dispose()
+
+
+async def _create_order(session: AsyncSession) -> int:
+    customer = Customer(
+        tenant_id=TEST_TENANT_SCOPE.tenant_id,
+        name="Proposal transaction customer",
+        phone="+375290000001",
+    )
+    session.add(customer)
+    await session.flush()
+    order = Order(
+        tenant_id=TEST_TENANT_SCOPE.tenant_id,
+        storefront_id=TEST_TENANT_SCOPE.storefront_id,
+        customer_id=customer.id,
+        status=OrderStatus.NEGOTIATION,
+    )
+    session.add(order)
+    await session.commit()
+    return int(order.id)
+
+
+async def _fail_after_proposal_flush(
+    _session: AsyncSession,
+    _order: Order,
+) -> None:
+    raise RuntimeError("injected final-step failure")
+
+
+@pytest.mark.asyncio
+async def test_create_proposal_rolls_back_default_and_new_proposal_together(
+    proposal_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    order_id = await _create_order(proposal_session)
+    monkeypatch.setattr(
+        OrderService,
+        "_refresh_order_financials",
+        _fail_after_proposal_flush,
+    )
+
+    with pytest.raises(RuntimeError, match="injected final-step failure"):
+        await OrderProposalCommandService.create_order_proposal(
+            proposal_session,
+            order_id,
+            OrderProposalCreatePayload(name="Новый вариант"),
+            tenant_scope=TEST_TENANT_SCOPE,
+        )
+
+    proposals = list(
+        (
+            await proposal_session.execute(
+                select(OrderProposal).where(OrderProposal.order_id == order_id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert proposals == []
+
+
+@pytest.mark.asyncio
+async def test_update_proposal_rolls_back_flushed_fields(
+    proposal_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    order_id = await _create_order(proposal_session)
+    proposal = OrderProposal(
+        order_id=order_id,
+        name="Исходный вариант",
+        status="draft",
+        is_selected=True,
+        sort_order=0,
+    )
+    proposal_session.add(proposal)
+    await proposal_session.commit()
+    proposal_id = int(proposal.id)
+    monkeypatch.setattr(
+        OrderService,
+        "_refresh_order_financials",
+        _fail_after_proposal_flush,
+    )
+
+    with pytest.raises(RuntimeError, match="injected final-step failure"):
+        await OrderProposalCommandService.update_order_proposal(
+            proposal_session,
+            order_id,
+            proposal_id,
+            OrderProposalUpdatePayload(name="Не должно сохраниться"),
+            tenant_scope=TEST_TENANT_SCOPE,
+        )
+
+    stored = await proposal_session.get(OrderProposal, proposal_id)
+    assert stored is not None
+    assert stored.name == "Исходный вариант"
+
+
+@pytest.mark.asyncio
+async def test_select_proposal_rolls_back_all_selection_changes(
+    proposal_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    order_id = await _create_order(proposal_session)
+    first = OrderProposal(
+        order_id=order_id,
+        name="Первый",
+        status="draft",
+        is_selected=True,
+        sort_order=0,
+    )
+    second = OrderProposal(
+        order_id=order_id,
+        name="Второй",
+        status="draft",
+        is_selected=False,
+        sort_order=10,
+    )
+    proposal_session.add_all([first, second])
+    await proposal_session.commit()
+    first_id = int(first.id)
+    second_id = int(second.id)
+    monkeypatch.setattr(
+        OrderService,
+        "_refresh_order_financials",
+        _fail_after_proposal_flush,
+    )
+
+    with pytest.raises(RuntimeError, match="injected final-step failure"):
+        await OrderProposalCommandService.select_order_proposal(
+            proposal_session,
+            order_id,
+            second_id,
+            tenant_scope=TEST_TENANT_SCOPE,
+        )
+
+    stored = list(
+        (
+            await proposal_session.execute(
+                select(OrderProposal)
+                .where(OrderProposal.order_id == order_id)
+                .order_by(OrderProposal.sort_order)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert [(item.id, item.is_selected) for item in stored] == [
+        (first_id, True),
+        (second_id, False),
+    ]


### PR DESCRIPTION
## Что изменено
- жизненный цикл коммерческих предложений вынесен из крупного OrderService в отдельный command service
- create/update/select/delete/reconcile выполняются в одной транзакционной границе
- Manager write routes вызывают command service напрямую, старые вызовы сохраняются через совместимые делегаты
- добавлены fault-injection тесты, доказывающие полный rollback при сбое после flush
- обновлён план доменного рефакторинга

## Проверка
- 67 focused unit tests passed
- 59 Manager Orders integration tests passed
- 8 proposal and tenant isolation tests passed
- post-rebase: 3 rollback tests and 2 integration tests passed
- OpenAPI and generated Manager client unchanged

## Риск
Низкий: публичный API и DTO не меняются; изменение ограничено внутренней транзакционной границей Manager Orders.