### PR TITLE
Make order stages and payments transactional

### DIFF
--- a/docs/order-domain-refactor.md
+++ b/docs/order-domain-refactor.md
@@ -50,9 +50,9 @@ one unit. Add fault-injection tests at the final step of each command.
 
 Deliver R2 as three independently deployable slices:
 
-1. proposal create/update/select commands;
-2. work-stage and payment commands;
-3. order create/update/delete plus Lead qualification.
+1. [x] proposal create/update/select commands;
+2. [x] work-stage and payment commands;
+3. [ ] order create/update/delete plus Lead qualification.
 
 When a command participates in an explicit caller-owned unit of work, its local
 boundary is a SAVEPOINT; ordinary HTTP commands own the root transaction.

--- a/routers/manager_orders_write.py
+++ b/routers/manager_orders_write.py
@@ -45,9 +45,11 @@ from schemas import (
     ManagerStaleWorkStageItem,
 )
 from services.document_service import DocumentService, OrderDocumentsLockedError
+from services.order_payment_command_service import OrderPaymentCommandService
 from services.order_proposal_command_service import OrderProposalCommandService
 from services.order_service import OrderService
 from services.order_transfer_service import OrderTransferService
+from services.order_work_stage_command_service import OrderWorkStageCommandService
 from services.tenant_scope_service import TenantScope
 
 
@@ -89,7 +91,7 @@ async def cancel_manager_order_stage_direct(
     tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     try:
-        return await OrderService.cancel_order_stage_direct(
+        return await OrderWorkStageCommandService.cancel_order_stage_direct(
             session,
             stage_id,
             tenant_scope=tenant_scope,
@@ -115,7 +117,7 @@ async def delete_manager_order_stage_direct(
     tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     try:
-        return await OrderService.delete_order_stage_direct(
+        return await OrderWorkStageCommandService.delete_order_stage_direct(
             session,
             stage_id,
             tenant_scope=tenant_scope,
@@ -424,7 +426,7 @@ async def add_manager_order_payment(
     tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     try:
-        return await OrderService.add_payment(
+        return await OrderPaymentCommandService.add_payment(
             session,
             order_id,
             payload,
@@ -453,7 +455,7 @@ async def delete_manager_order_payment(
     tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     try:
-        return await OrderService.delete_payment(
+        return await OrderPaymentCommandService.delete_payment(
             session,
             order_id,
             payment_id,
@@ -483,7 +485,7 @@ async def create_manager_order_stage(
     tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     try:
-        return await OrderService.add_order_stage(
+        return await OrderWorkStageCommandService.add_order_stage(
             session,
             order_id,
             payload,
@@ -507,7 +509,7 @@ async def update_manager_order_stage(
     tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     try:
-        return await OrderService.update_order_stage(
+        return await OrderWorkStageCommandService.update_order_stage(
             session,
             order_id,
             stage_id,
@@ -531,7 +533,7 @@ async def delete_manager_order_stage(
     tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     try:
-        return await OrderService.delete_order_stage(
+        return await OrderWorkStageCommandService.delete_order_stage(
             session,
             order_id,
             stage_id,

--- a/services/bot_quick_order_service.py
+++ b/services/bot_quick_order_service.py
@@ -615,5 +615,9 @@ class BotQuickOrderService:
                         tenant_scope=tenant_scope,
                     ) or order
 
+        # This orchestrator is the outer command boundary. Nested Order/Lead
+        # commands deliberately use SAVEPOINTs when earlier authorization or
+        # idempotency reads have already opened the session transaction.
+        await session.commit()
         order["_bot_order_created"] = order_created
         return order

--- a/services/order_payment_command_service.py
+++ b/services/order_payment_command_service.py
@@ -1,0 +1,179 @@
+"""Transactional commands for order payments and bank-receipt reconciliation."""
+
+from typing import Any, Dict, List
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+from sqlmodel import select
+
+from models import BankReceipt, Customer, Order, Payment, PaymentCurrency, PaymentType
+from services.command_transaction import command_transaction
+from services.order_service import OrderService
+from services.tenant_entity_access_service import TenantEntityAccessService
+from services.tenant_scope_service import TenantScope
+
+
+class OrderPaymentCommandService:
+    @staticmethod
+    async def _list_payments(
+        session: AsyncSession,
+        order_id: int,
+    ) -> List[Dict[str, Any]]:
+        result = await session.execute(
+            select(Payment)
+            .where(Payment.order_id == order_id)
+            .options(selectinload(Payment.bank_receipt))
+            .order_by(Payment.date.desc())
+        )
+        return [
+            OrderService._map_payment(payment)
+            for payment in result.scalars().all()
+        ]
+
+    @staticmethod
+    async def add_payment(
+        session: AsyncSession,
+        order_id: int,
+        payload: Any,
+        *,
+        tenant_scope: TenantScope,
+    ) -> List[Dict[str, Any]]:
+        async with command_transaction(session):
+            order = await TenantEntityAccessService.get_order(
+                session,
+                order_id,
+                tenant_scope=tenant_scope,
+                for_update=True,
+            )
+            if not order:
+                raise ValueError("Order not found")
+
+            try:
+                payment_type = PaymentType(payload.type)
+            except ValueError as exc:
+                raise ValueError(f"Invalid payment type: {payload.type}") from exc
+
+            currency = OrderService._normalize_payment_currency(
+                payload.currency
+                if hasattr(payload, "currency")
+                else PaymentCurrency.BYN
+            )
+            if currency != PaymentCurrency.BYN and order.target_currency != currency:
+                raise ValueError(
+                    "Foreign-currency payment requires matching order target currency"
+                )
+
+            session.add(
+                Payment(
+                    order_id=order_id,
+                    amount=payload.amount,
+                    currency=currency,
+                    type=payment_type,
+                    comment=payload.comment,
+                )
+            )
+            await session.flush()
+            await OrderService._refresh_order_financials(session, order)
+            session.add(order)
+
+        return await OrderPaymentCommandService._list_payments(session, order_id)
+
+    @staticmethod
+    async def delete_payment(
+        session: AsyncSession,
+        order_id: int,
+        payment_id: int,
+        *,
+        tenant_scope: TenantScope,
+    ) -> List[Dict[str, Any]]:
+        async with command_transaction(session):
+            order = await TenantEntityAccessService.get_order(
+                session,
+                order_id,
+                tenant_scope=tenant_scope,
+                for_update=True,
+            )
+            if not order:
+                raise ValueError("Order not found")
+
+            payment = await session.get(Payment, payment_id)
+            if not payment or payment.order_id != order_id:
+                raise ValueError("Payment not found on this order")
+
+            bank_receipt_id = (
+                int(payment.bank_receipt_id) if payment.bank_receipt_id else None
+            )
+            affected_order_ids = {int(order_id)}
+
+            if bank_receipt_id:
+                all_linked_ids = list(
+                    (
+                        await session.execute(
+                            select(Payment.id).where(
+                                Payment.bank_receipt_id == bank_receipt_id
+                            )
+                        )
+                    ).scalars()
+                )
+                linked_payments_result = await session.execute(
+                    select(Payment)
+                    .join(Order, Order.id == Payment.order_id)
+                    .outerjoin(Customer, Customer.id == Order.customer_id)
+                    .where(
+                        Payment.bank_receipt_id == bank_receipt_id,
+                        TenantEntityAccessService.order_clause(tenant_scope),
+                        TenantEntityAccessService.order_customer_clause(
+                            tenant_scope
+                        ),
+                    )
+                )
+                linked_payments = list(linked_payments_result.scalars().all())
+                if len(linked_payments) != len(all_linked_ids):
+                    raise ValueError("Bank receipt spans a tenant boundary")
+                deleted_payment_ids = [
+                    int(item.id or 0) for item in linked_payments if item.id
+                ]
+                for linked_payment in linked_payments:
+                    if linked_payment.order_id:
+                        affected_order_ids.add(int(linked_payment.order_id))
+                    await session.delete(linked_payment)
+
+                receipt = await session.get(BankReceipt, bank_receipt_id)
+                if receipt:
+                    metadata = dict(receipt.match_meta or {})
+                    metadata.update(
+                        {
+                            "manual_status": "requires_review",
+                            "manual_reason": "payment_deleted_from_order",
+                            "previous_status": receipt.status,
+                            "previous_matched_order_id": receipt.matched_order_id,
+                            "previous_matched_payment_id": receipt.matched_payment_id,
+                            "previous_matched_payment_ids": deleted_payment_ids
+                            or None,
+                        }
+                    )
+                    receipt.status = "requires_review"
+                    receipt.matched_order_id = None
+                    receipt.matched_payment_id = None
+                    receipt.match_meta = metadata
+                    session.add(receipt)
+            else:
+                await session.delete(payment)
+            await session.flush()
+
+            for affected_order_id in affected_order_ids:
+                affected_order = await TenantEntityAccessService.get_order(
+                    session,
+                    affected_order_id,
+                    tenant_scope=tenant_scope,
+                )
+                if not affected_order:
+                    continue
+                await OrderService._refresh_order_financials(
+                    session,
+                    affected_order,
+                )
+                affected_order.is_paid = affected_order.balance_due <= 0.01
+                session.add(affected_order)
+
+        return await OrderPaymentCommandService._list_payments(session, order_id)

--- a/services/order_service.py
+++ b/services/order_service.py
@@ -1851,47 +1851,13 @@ class OrderService:
         *,
         tenant_scope: TenantScope,
     ):
-        from models import OrderWorkStage
-        from services.staff_task_notification_event_service import (
-            StaffTaskNotificationEventService,
-        )
-        order = await TenantEntityAccessService.get_order(
+        """Compatibility delegate to the transactional work-stage command."""
+        from services.order_work_stage_command_service import OrderWorkStageCommandService
+
+        return await OrderWorkStageCommandService.add_order_stage(
             session,
             order_id,
-            tenant_scope=tenant_scope,
-            for_update=True,
-        )
-        if not order:
-            raise ValueError("Order not found")
-        if payload.installer_id is not None:
-            await OrderService._ensure_assignable_legacy_executor(
-                session,
-                int(payload.installer_id),
-                tenant_scope=tenant_scope,
-            )
-        stage = OrderWorkStage(
-            order_id=order_id,
-            name=payload.name,
-            status=OrderService._normalize_order_stage_status(payload.status),
-            start_time=OrderService._normalize_naive_datetime(payload.start_time),
-            end_time=OrderService._normalize_naive_datetime(payload.end_time),
-            installer_id=payload.installer_id,
-            manager_comment=payload.manager_comment,
-            installer_report=payload.installer_report
-        )
-        session.add(stage)
-        await session.flush()
-        if stage.installer_id is not None:
-            await StaffTaskNotificationEventService.enqueue_assigned(
-                session,
-                stage=stage,
-                previous_installer_id=None,
-                tenant_scope=tenant_scope,
-            )
-        await session.commit()
-        return await OrderService.get_order_detail_for_manager(
-            session,
-            order_id,
+            payload,
             tenant_scope=tenant_scope,
         )
 
@@ -1972,41 +1938,14 @@ class OrderService:
         *,
         tenant_scope: TenantScope,
     ) -> Dict[str, Any]:
-        from services.staff_task_notification_event_service import (
-            StaffTaskNotificationEventService,
-        )
-        stage = await TenantEntityAccessService.get_order_stage(
+        """Compatibility delegate to the transactional work-stage command."""
+        from services.order_work_stage_command_service import OrderWorkStageCommandService
+
+        return await OrderWorkStageCommandService.cancel_order_stage_direct(
             session,
             stage_id,
             tenant_scope=tenant_scope,
-            for_update=True,
         )
-        if not stage:
-            raise ValueError("Stage not found")
-        previous_status = stage.status
-        stage.status = OrderStageStatus.CANCELED
-        session.add(stage)
-        if previous_status != OrderStageStatus.CANCELED:
-            await StaffTaskNotificationEventService.enqueue_canceled(
-                session,
-                stage=stage,
-                previous_status=previous_status,
-                tenant_scope=tenant_scope,
-            )
-        await session.commit()
-        await session.refresh(stage)
-        stage = await TenantEntityAccessService.get_order_stage(
-            session,
-            stage_id,
-            tenant_scope=tenant_scope,
-            options=(
-                selectinload(OrderWorkStage.order).selectinload(Order.customer),
-                selectinload(OrderWorkStage.installer),
-            ),
-        )
-        if stage is None:
-            raise ValueError("Stage not found")
-        return OrderService._map_stale_order_stage(stage)
 
     @staticmethod
     async def delete_order_stage_direct(
@@ -2015,17 +1954,14 @@ class OrderService:
         *,
         tenant_scope: TenantScope,
     ) -> Dict[str, Any]:
-        stage = await TenantEntityAccessService.get_order_stage(
+        """Compatibility delegate to the transactional work-stage command."""
+        from services.order_work_stage_command_service import OrderWorkStageCommandService
+
+        return await OrderWorkStageCommandService.delete_order_stage_direct(
             session,
             stage_id,
             tenant_scope=tenant_scope,
-            for_update=True,
         )
-        if not stage:
-            raise ValueError("Stage not found")
-        await session.delete(stage)
-        await session.commit()
-        return {"ok": True, "id": stage_id}
 
     @staticmethod
     async def update_order_stage(
@@ -2036,100 +1972,14 @@ class OrderService:
         *,
         tenant_scope: TenantScope,
     ):
-        from models import OrderWorkStage, Order, OrderStatus, OrderStageStatus
-        from services.staff_task_notification_event_service import (
-            StaffTaskNotificationEventService,
-        )
-        stage = await TenantEntityAccessService.get_order_stage(
-            session,
-            stage_id,
-            tenant_scope=tenant_scope,
-            order_id=order_id,
-            for_update=True,
-        )
-        if not stage:
-            raise ValueError("Stage not found")
-        previous_installer_id = stage.installer_id
-        previous_start_time = stage.start_time
-        previous_end_time = stage.end_time
-        previous_status = stage.status
-        update_data = payload.model_dump(exclude_unset=True)
-        next_installer_id = update_data.get("installer_id", stage.installer_id)
-        if next_installer_id is not None and next_installer_id != stage.installer_id:
-            await OrderService._ensure_assignable_legacy_executor(
-                session,
-                int(next_installer_id),
-                tenant_scope=tenant_scope,
-            )
-        for key, value in update_data.items():
-            if key in ("start_time", "end_time"):
-                value = OrderService._normalize_naive_datetime(value)
-            elif key == "status":
-                value = OrderService._normalize_order_stage_status(value)
-            setattr(stage, key, value)
-            
-        session.add(stage)
-        await session.flush()
+        """Compatibility delegate to the transactional work-stage command."""
+        from services.order_work_stage_command_service import OrderWorkStageCommandService
 
-        if (
-            stage.status == OrderStageStatus.CANCELED
-            and previous_status != OrderStageStatus.CANCELED
-        ):
-            await StaffTaskNotificationEventService.enqueue_canceled(
-                session,
-                stage=stage,
-                previous_status=previous_status,
-                tenant_scope=tenant_scope,
-            )
-        elif stage.installer_id != previous_installer_id and stage.installer_id is not None:
-            await StaffTaskNotificationEventService.enqueue_assigned(
-                session,
-                stage=stage,
-                previous_installer_id=previous_installer_id,
-                tenant_scope=tenant_scope,
-            )
-        elif stage.installer_id is not None:
-            changed_fields = []
-            previous_values = []
-            if stage.start_time != previous_start_time:
-                changed_fields.append("start_time")
-                previous_values.extend([previous_start_time, stage.start_time])
-            if stage.end_time != previous_end_time:
-                changed_fields.append("end_time")
-                previous_values.extend([previous_end_time, stage.end_time])
-            if changed_fields:
-                await StaffTaskNotificationEventService.enqueue_rescheduled(
-                    session,
-                    stage=stage,
-                    change_fields=changed_fields,
-                    previous_values=previous_values,
-                    tenant_scope=tenant_scope,
-                )
-        
-        # Auto-pause logic
-        order = await TenantEntityAccessService.get_order(
+        return await OrderWorkStageCommandService.update_order_stage(
             session,
             order_id,
-            tenant_scope=tenant_scope,
-        )
-        if order:
-            await session.refresh(order, ['work_stages'])
-            all_completed = True
-            for st in order.work_stages:
-                if st.status != OrderStageStatus.COMPLETED and st.status != OrderStageStatus.CANCELED:
-                    all_completed = False
-                    break
-            
-            # If all are completed/canceled and balance > 0 and not closed
-            if all_completed and order.work_stages and order.balance_due > 0 and order.status != OrderStatus.CLOSED:
-                order.is_on_hold = True
-                order.on_hold_reason = "Все запланированные этапы завершены, ожидается оплата или следующий этап"
-                session.add(order)
-                
-        await session.commit()
-        return await OrderService.get_order_detail_for_manager(
-            session,
-            order_id,
+            stage_id,
+            payload,
             tenant_scope=tenant_scope,
         )
 
@@ -2141,21 +1991,13 @@ class OrderService:
         *,
         tenant_scope: TenantScope,
     ):
-        from models import OrderWorkStage
-        stage = await TenantEntityAccessService.get_order_stage(
-            session,
-            stage_id,
-            tenant_scope=tenant_scope,
-            order_id=order_id,
-            for_update=True,
-        )
-        if not stage:
-            raise ValueError("Stage not found")
-        await session.delete(stage)
-        await session.commit()
-        return await OrderService.get_order_detail_for_manager(
+        """Compatibility delegate to the transactional work-stage command."""
+        from services.order_work_stage_command_service import OrderWorkStageCommandService
+
+        return await OrderWorkStageCommandService.delete_order_stage(
             session,
             order_id,
+            stage_id,
             tenant_scope=tenant_scope,
         )
 
@@ -2932,41 +2774,15 @@ class OrderService:
         *,
         tenant_scope: TenantScope,
     ):
-        from models import Payment, PaymentType
-        order = await TenantEntityAccessService.get_order(
+        """Compatibility delegate to the transactional payment command."""
+        from services.order_payment_command_service import OrderPaymentCommandService
+
+        return await OrderPaymentCommandService.add_payment(
             session,
             order_id,
+            payload,
             tenant_scope=tenant_scope,
-            for_update=True,
         )
-        if not order:
-            raise ValueError("Order not found")
-        
-        try:
-            ptype = PaymentType(payload.type)
-        except ValueError:
-            raise ValueError(f"Invalid payment type: {payload.type}")
-            
-        currency = OrderService._normalize_payment_currency(payload.currency if hasattr(payload, "currency") else PaymentCurrency.BYN)
-        if currency != PaymentCurrency.BYN and order.target_currency != currency:
-            raise ValueError("Foreign-currency payment requires matching order target currency")
-
-        new_payment = Payment(
-            order_id=order_id,
-            amount=payload.amount,
-            currency=currency,
-            type=ptype,
-            comment=payload.comment,
-        )
-        session.add(new_payment)
-        await session.flush()
-
-        await OrderService._refresh_order_financials(session, order)
-        session.add(order)
-        await session.commit()
-        
-        # Return payments mapped exactly as in get_order_detail_for_manager.
-        return [OrderService._map_payment(p) for p in sorted(order.payments, key=lambda d: d.date, reverse=True)]
 
     @staticmethod
     async def delete_payment(
@@ -2976,96 +2792,15 @@ class OrderService:
         *,
         tenant_scope: TenantScope,
     ):
-        from models import BankReceipt, Payment
-        order = await TenantEntityAccessService.get_order(
+        """Compatibility delegate to the transactional payment command."""
+        from services.order_payment_command_service import OrderPaymentCommandService
+
+        return await OrderPaymentCommandService.delete_payment(
             session,
             order_id,
+            payment_id,
             tenant_scope=tenant_scope,
-            for_update=True,
         )
-        if not order:
-            raise ValueError("Order not found")
-            
-        payment = await session.get(Payment, payment_id)
-        if not payment or payment.order_id != order_id:
-            raise ValueError("Payment not found on this order")
-
-        bank_receipt_id = int(payment.bank_receipt_id) if payment.bank_receipt_id else None
-        affected_order_ids = {int(order_id)}
-
-        if bank_receipt_id:
-            all_linked_ids = list(
-                (
-                    await session.execute(
-                        select(Payment.id).where(
-                            Payment.bank_receipt_id == bank_receipt_id
-                        )
-                    )
-                ).scalars()
-            )
-            linked_payments_result = await session.execute(
-                select(Payment)
-                .join(Order, Order.id == Payment.order_id)
-                .outerjoin(Customer, Customer.id == Order.customer_id)
-                .where(
-                    Payment.bank_receipt_id == bank_receipt_id,
-                    TenantEntityAccessService.order_clause(tenant_scope),
-                    TenantEntityAccessService.order_customer_clause(
-                        tenant_scope
-                    ),
-                )
-            )
-            linked_payments = list(linked_payments_result.scalars().all())
-            if len(linked_payments) != len(all_linked_ids):
-                raise ValueError("Bank receipt spans a tenant boundary")
-            deleted_payment_ids = [int(item.id or 0) for item in linked_payments if item.id]
-            for linked_payment in linked_payments:
-                if linked_payment.order_id:
-                    affected_order_ids.add(int(linked_payment.order_id))
-                await session.delete(linked_payment)
-
-            receipt = await session.get(BankReceipt, bank_receipt_id)
-            if receipt:
-                meta = dict(receipt.match_meta or {})
-                meta.update(
-                    {
-                        "manual_status": "requires_review",
-                        "manual_reason": "payment_deleted_from_order",
-                        "previous_status": receipt.status,
-                        "previous_matched_order_id": receipt.matched_order_id,
-                        "previous_matched_payment_id": receipt.matched_payment_id,
-                        "previous_matched_payment_ids": deleted_payment_ids or None,
-                    }
-                )
-                receipt.status = "requires_review"
-                receipt.matched_order_id = None
-                receipt.matched_payment_id = None
-                receipt.match_meta = meta
-                session.add(receipt)
-        else:
-            await session.delete(payment)
-        await session.flush()
-
-        for affected_order_id in affected_order_ids:
-            affected_order = await TenantEntityAccessService.get_order(
-                session,
-                affected_order_id,
-                tenant_scope=tenant_scope,
-            )
-            if not affected_order:
-                continue
-            await OrderService._refresh_order_financials(session, affected_order)
-            affected_order.is_paid = affected_order.balance_due <= 0.01
-            session.add(affected_order)
-        await session.commit()
-
-        current_payments_result = await session.execute(
-            select(Payment)
-            .where(Payment.order_id == order_id)
-            .options(selectinload(Payment.bank_receipt))
-            .order_by(Payment.date.desc())
-        )
-        return [OrderService._map_payment(p) for p in current_payments_result.scalars().all()]
 
     # -----------------------------------------------------------------
     # Leads Inbox (Order-based triage)

--- a/services/order_work_stage_command_service.py
+++ b/services/order_work_stage_command_service.py
@@ -1,0 +1,290 @@
+"""Transactional commands for order work stages and their outbox events."""
+
+from typing import Any, Dict
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from models import Order, OrderStageStatus, OrderStatus, OrderWorkStage
+from services.command_transaction import command_transaction
+from services.order_projection_service import OrderProjectionService
+from services.order_service import OrderService
+from services.tenant_entity_access_service import TenantEntityAccessService
+from services.tenant_scope_service import TenantScope
+
+
+class OrderWorkStageCommandService:
+    @staticmethod
+    async def _project_committed_order(
+        session: AsyncSession,
+        order_id: int,
+        *,
+        tenant_scope: TenantScope,
+    ) -> Dict[str, Any]:
+        data = await OrderProjectionService.get_order_detail_for_manager(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+        )
+        if data is None:
+            raise RuntimeError("Committed order is no longer visible in its tenant scope")
+        return data
+
+    @staticmethod
+    async def add_order_stage(
+        session: AsyncSession,
+        order_id: int,
+        payload: Any,
+        *,
+        tenant_scope: TenantScope,
+    ) -> Dict[str, Any]:
+        from services.staff_task_notification_event_service import (
+            StaffTaskNotificationEventService,
+        )
+
+        async with command_transaction(session):
+            order = await TenantEntityAccessService.get_order(
+                session,
+                order_id,
+                tenant_scope=tenant_scope,
+                for_update=True,
+            )
+            if not order:
+                raise ValueError("Order not found")
+            if payload.installer_id is not None:
+                await OrderService._ensure_assignable_legacy_executor(
+                    session,
+                    int(payload.installer_id),
+                    tenant_scope=tenant_scope,
+                )
+            stage = OrderWorkStage(
+                order_id=order_id,
+                name=payload.name,
+                status=OrderService._normalize_order_stage_status(payload.status),
+                start_time=OrderService._normalize_naive_datetime(payload.start_time),
+                end_time=OrderService._normalize_naive_datetime(payload.end_time),
+                installer_id=payload.installer_id,
+                manager_comment=payload.manager_comment,
+                installer_report=payload.installer_report,
+            )
+            session.add(stage)
+            await session.flush()
+            if stage.installer_id is not None:
+                await StaffTaskNotificationEventService.enqueue_assigned(
+                    session,
+                    stage=stage,
+                    previous_installer_id=None,
+                    tenant_scope=tenant_scope,
+                )
+
+        return await OrderWorkStageCommandService._project_committed_order(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+        )
+
+    @staticmethod
+    async def cancel_order_stage_direct(
+        session: AsyncSession,
+        stage_id: int,
+        *,
+        tenant_scope: TenantScope,
+    ) -> Dict[str, Any]:
+        from services.staff_task_notification_event_service import (
+            StaffTaskNotificationEventService,
+        )
+
+        async with command_transaction(session):
+            stage = await TenantEntityAccessService.get_order_stage(
+                session,
+                stage_id,
+                tenant_scope=tenant_scope,
+                for_update=True,
+            )
+            if not stage:
+                raise ValueError("Stage not found")
+            previous_status = stage.status
+            stage.status = OrderStageStatus.CANCELED
+            session.add(stage)
+            if previous_status != OrderStageStatus.CANCELED:
+                await StaffTaskNotificationEventService.enqueue_canceled(
+                    session,
+                    stage=stage,
+                    previous_status=previous_status,
+                    tenant_scope=tenant_scope,
+                )
+
+        stage = await TenantEntityAccessService.get_order_stage(
+            session,
+            stage_id,
+            tenant_scope=tenant_scope,
+            options=(
+                selectinload(OrderWorkStage.order).selectinload(Order.customer),
+                selectinload(OrderWorkStage.installer),
+            ),
+        )
+        if stage is None:
+            raise ValueError("Stage not found")
+        return OrderService._map_stale_order_stage(stage)
+
+    @staticmethod
+    async def delete_order_stage_direct(
+        session: AsyncSession,
+        stage_id: int,
+        *,
+        tenant_scope: TenantScope,
+    ) -> Dict[str, Any]:
+        async with command_transaction(session):
+            stage = await TenantEntityAccessService.get_order_stage(
+                session,
+                stage_id,
+                tenant_scope=tenant_scope,
+                for_update=True,
+            )
+            if not stage:
+                raise ValueError("Stage not found")
+            await session.delete(stage)
+        return {"ok": True, "id": stage_id}
+
+    @staticmethod
+    async def update_order_stage(
+        session: AsyncSession,
+        order_id: int,
+        stage_id: int,
+        payload: Any,
+        *,
+        tenant_scope: TenantScope,
+    ) -> Dict[str, Any]:
+        from services.staff_task_notification_event_service import (
+            StaffTaskNotificationEventService,
+        )
+
+        async with command_transaction(session):
+            stage = await TenantEntityAccessService.get_order_stage(
+                session,
+                stage_id,
+                tenant_scope=tenant_scope,
+                order_id=order_id,
+                for_update=True,
+            )
+            if not stage:
+                raise ValueError("Stage not found")
+            previous_installer_id = stage.installer_id
+            previous_start_time = stage.start_time
+            previous_end_time = stage.end_time
+            previous_status = stage.status
+            update_data = payload.model_dump(exclude_unset=True)
+            next_installer_id = update_data.get("installer_id", stage.installer_id)
+            if (
+                next_installer_id is not None
+                and next_installer_id != stage.installer_id
+            ):
+                await OrderService._ensure_assignable_legacy_executor(
+                    session,
+                    int(next_installer_id),
+                    tenant_scope=tenant_scope,
+                )
+            for key, value in update_data.items():
+                if key in ("start_time", "end_time"):
+                    value = OrderService._normalize_naive_datetime(value)
+                elif key == "status":
+                    value = OrderService._normalize_order_stage_status(value)
+                setattr(stage, key, value)
+
+            session.add(stage)
+            await session.flush()
+
+            if (
+                stage.status == OrderStageStatus.CANCELED
+                and previous_status != OrderStageStatus.CANCELED
+            ):
+                await StaffTaskNotificationEventService.enqueue_canceled(
+                    session,
+                    stage=stage,
+                    previous_status=previous_status,
+                    tenant_scope=tenant_scope,
+                )
+            elif (
+                stage.installer_id != previous_installer_id
+                and stage.installer_id is not None
+            ):
+                await StaffTaskNotificationEventService.enqueue_assigned(
+                    session,
+                    stage=stage,
+                    previous_installer_id=previous_installer_id,
+                    tenant_scope=tenant_scope,
+                )
+            elif stage.installer_id is not None:
+                changed_fields = []
+                previous_values = []
+                if stage.start_time != previous_start_time:
+                    changed_fields.append("start_time")
+                    previous_values.extend([previous_start_time, stage.start_time])
+                if stage.end_time != previous_end_time:
+                    changed_fields.append("end_time")
+                    previous_values.extend([previous_end_time, stage.end_time])
+                if changed_fields:
+                    await StaffTaskNotificationEventService.enqueue_rescheduled(
+                        session,
+                        stage=stage,
+                        change_fields=changed_fields,
+                        previous_values=previous_values,
+                        tenant_scope=tenant_scope,
+                    )
+
+            order = await TenantEntityAccessService.get_order(
+                session,
+                order_id,
+                tenant_scope=tenant_scope,
+            )
+            if order:
+                await session.refresh(order, attribute_names=["work_stages"])
+                all_completed = all(
+                    item.status
+                    in (OrderStageStatus.COMPLETED, OrderStageStatus.CANCELED)
+                    for item in order.work_stages
+                )
+                if (
+                    all_completed
+                    and order.work_stages
+                    and order.balance_due > 0
+                    and order.status != OrderStatus.CLOSED
+                ):
+                    order.is_on_hold = True
+                    order.on_hold_reason = (
+                        "Все запланированные этапы завершены, ожидается оплата "
+                        "или следующий этап"
+                    )
+                    session.add(order)
+
+        return await OrderWorkStageCommandService._project_committed_order(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+        )
+
+    @staticmethod
+    async def delete_order_stage(
+        session: AsyncSession,
+        order_id: int,
+        stage_id: int,
+        *,
+        tenant_scope: TenantScope,
+    ) -> Dict[str, Any]:
+        async with command_transaction(session):
+            stage = await TenantEntityAccessService.get_order_stage(
+                session,
+                stage_id,
+                tenant_scope=tenant_scope,
+                order_id=order_id,
+                for_update=True,
+            )
+            if not stage:
+                raise ValueError("Stage not found")
+            await session.delete(stage)
+
+        return await OrderWorkStageCommandService._project_committed_order(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+        )

--- a/tests/unit/test_bot_work_services.py
+++ b/tests/unit/test_bot_work_services.py
@@ -97,8 +97,14 @@ class _NoRowsResult:
 
 
 class _NoExistingQuickOrderSession:
+    def __init__(self):
+        self.commit_count = 0
+
     async def execute(self, *args, **kwargs):
         return _NoRowsResult()
+
+    async def commit(self):
+        self.commit_count += 1
 
 
 def test_quick_order_fallback_parses_service_phone_address_and_date():
@@ -1476,8 +1482,9 @@ async def test_quick_order_create_uses_order_service_and_stage_for_dated_work(mo
         fake_notify,
     )
 
+    session = _NoExistingQuickOrderSession()
     order = await BotQuickOrderService.create_order_from_draft(
-        _NoExistingQuickOrderSession(),
+        session,
         {
             "name": "Иван",
             "phone": "+375291234567",
@@ -1504,6 +1511,7 @@ async def test_quick_order_create_uses_order_service_and_stage_for_dated_work(mo
     assert calls["stage_order_id"] == 42
     assert calls["stage_payload"].name == "Монтаж"
     assert calls["stage_tenant_scope"] == TEST_TENANT_SCOPE
+    assert session.commit_count == 1
     assert calls["notify"] == {
         "order_id": 42,
         "source_label": "Telegram-бот",
@@ -1563,8 +1571,9 @@ async def test_quick_order_create_notifies_admins_for_maintenance_without_stage(
         fake_notify,
     )
 
+    session = _NoExistingQuickOrderSession()
     order = await BotQuickOrderService.create_order_from_draft(
-        _NoExistingQuickOrderSession(),
+        session,
         {
             "name": "Иван",
             "phone": "+375291234567",
@@ -1591,6 +1600,7 @@ async def test_quick_order_create_notifies_admins_for_maintenance_without_stage(
         "source_label": "Telegram-бот",
         "tenant_scope": TEST_TENANT_SCOPE,
     }
+    assert session.commit_count == 1
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_order_stage_payment_command_service.py
+++ b/tests/unit/test_order_stage_payment_command_service.py
@@ -1,0 +1,290 @@
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import SQLModel, select
+
+from models import (
+    Customer,
+    Installer,
+    Order,
+    OrderStageStatus,
+    OrderStatus,
+    OrderWorkStage,
+    Payment,
+)
+from models.tenancy import TenantScope
+from schemas import (
+    OrderWorkStageCreatePayload,
+    OrderWorkStageUpdatePayload,
+    PaymentCreatePayload,
+)
+from services.order_payment_command_service import OrderPaymentCommandService
+from services.order_service import OrderService
+from services.order_work_stage_command_service import OrderWorkStageCommandService
+from services.staff_task_notification_event_service import (
+    StaffTaskNotificationEventService,
+)
+
+
+TEST_TENANT_SCOPE = TenantScope(tenant_id=1, storefront_id=1, is_system=True)
+
+
+@pytest.fixture
+async def command_session(tmp_path: Path):
+    engine = create_async_engine(
+        f"sqlite+aiosqlite:///{tmp_path / 'order_stage_payment_commands.db'}",
+        echo=False,
+    )
+    async with engine.begin() as connection:
+        await connection.run_sync(SQLModel.metadata.create_all)
+
+    session_factory = sessionmaker(
+        bind=engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+    async with session_factory() as session:
+        yield session
+
+    await engine.dispose()
+
+
+async def _create_order(
+    session: AsyncSession,
+    *,
+    with_installer: bool = False,
+) -> tuple[int, int | None]:
+    customer = Customer(
+        tenant_id=TEST_TENANT_SCOPE.tenant_id,
+        name="Command transaction customer",
+        phone="+375290000002",
+    )
+    session.add(customer)
+    installer = Installer(name="Command transaction installer", is_active=True)
+    if with_installer:
+        session.add(installer)
+    await session.flush()
+    order = Order(
+        tenant_id=TEST_TENANT_SCOPE.tenant_id,
+        storefront_id=TEST_TENANT_SCOPE.storefront_id,
+        customer_id=customer.id,
+        status=OrderStatus.EXECUTION,
+    )
+    session.add(order)
+    await session.commit()
+    return int(order.id), int(installer.id) if with_installer else None
+
+
+async def _create_stage(
+    session: AsyncSession,
+    order_id: int,
+    *,
+    installer_id: int | None = None,
+) -> int:
+    stage = OrderWorkStage(
+        order_id=order_id,
+        name="Исходный этап",
+        status=OrderStageStatus.PLANNED,
+        installer_id=installer_id,
+    )
+    session.add(stage)
+    await session.commit()
+    return int(stage.id)
+
+
+async def _fail_financial_refresh(
+    _session: AsyncSession,
+    _order: Order,
+) -> None:
+    raise RuntimeError("injected final-step failure")
+
+
+@pytest.mark.asyncio
+async def test_add_stage_rolls_back_stage_when_outbox_enqueue_fails(
+    command_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    order_id, installer_id = await _create_order(
+        command_session,
+        with_installer=True,
+    )
+    monkeypatch.setattr(
+        StaffTaskNotificationEventService,
+        "enqueue_assigned",
+        AsyncMock(side_effect=RuntimeError("injected final-step failure")),
+    )
+
+    with pytest.raises(RuntimeError, match="injected final-step failure"):
+        await OrderWorkStageCommandService.add_order_stage(
+            command_session,
+            order_id,
+            OrderWorkStageCreatePayload(
+                name="Новый этап",
+                installer_id=installer_id,
+            ),
+            tenant_scope=TEST_TENANT_SCOPE,
+        )
+
+    stages = list(
+        (
+            await command_session.execute(
+                select(OrderWorkStage).where(OrderWorkStage.order_id == order_id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert stages == []
+
+
+@pytest.mark.asyncio
+async def test_cancel_stage_rolls_back_status_when_outbox_enqueue_fails(
+    command_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    order_id, _ = await _create_order(command_session)
+    stage_id = await _create_stage(command_session, order_id)
+    monkeypatch.setattr(
+        StaffTaskNotificationEventService,
+        "enqueue_canceled",
+        AsyncMock(side_effect=RuntimeError("injected final-step failure")),
+    )
+
+    with pytest.raises(RuntimeError, match="injected final-step failure"):
+        await OrderWorkStageCommandService.cancel_order_stage_direct(
+            command_session,
+            stage_id,
+            tenant_scope=TEST_TENANT_SCOPE,
+        )
+
+    stored = await command_session.get(OrderWorkStage, stage_id)
+    assert stored is not None
+    assert stored.status == OrderStageStatus.PLANNED
+
+
+@pytest.mark.asyncio
+async def test_update_stage_rolls_back_fields_when_outbox_enqueue_fails(
+    command_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    order_id, _ = await _create_order(command_session)
+    stage_id = await _create_stage(command_session, order_id)
+    monkeypatch.setattr(
+        StaffTaskNotificationEventService,
+        "enqueue_canceled",
+        AsyncMock(side_effect=RuntimeError("injected final-step failure")),
+    )
+
+    with pytest.raises(RuntimeError, match="injected final-step failure"):
+        await OrderWorkStageCommandService.update_order_stage(
+            command_session,
+            order_id,
+            stage_id,
+            OrderWorkStageUpdatePayload(
+                name="Не должно сохраниться",
+                status="canceled",
+            ),
+            tenant_scope=TEST_TENANT_SCOPE,
+        )
+
+    stored = await command_session.get(OrderWorkStage, stage_id)
+    assert stored is not None
+    assert stored.name == "Исходный этап"
+    assert stored.status == OrderStageStatus.PLANNED
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("direct", [False, True])
+async def test_delete_stage_rolls_back_deletion_on_final_failure(
+    command_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    direct: bool,
+):
+    order_id, _ = await _create_order(command_session)
+    stage_id = await _create_stage(command_session, order_id)
+    original_delete = AsyncSession.delete
+
+    async def delete_then_fail(session: AsyncSession, instance: object) -> None:
+        await original_delete(session, instance)
+        raise RuntimeError("injected final-step failure")
+
+    monkeypatch.setattr(AsyncSession, "delete", delete_then_fail)
+
+    with pytest.raises(RuntimeError, match="injected final-step failure"):
+        if direct:
+            await OrderWorkStageCommandService.delete_order_stage_direct(
+                command_session,
+                stage_id,
+                tenant_scope=TEST_TENANT_SCOPE,
+            )
+        else:
+            await OrderWorkStageCommandService.delete_order_stage(
+                command_session,
+                order_id,
+                stage_id,
+                tenant_scope=TEST_TENANT_SCOPE,
+            )
+
+    assert await command_session.get(OrderWorkStage, stage_id) is not None
+
+
+@pytest.mark.asyncio
+async def test_add_payment_rolls_back_flushed_payment_on_final_failure(
+    command_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    order_id, _ = await _create_order(command_session)
+    monkeypatch.setattr(
+        OrderService,
+        "_refresh_order_financials",
+        _fail_financial_refresh,
+    )
+
+    with pytest.raises(RuntimeError, match="injected final-step failure"):
+        await OrderPaymentCommandService.add_payment(
+            command_session,
+            order_id,
+            PaymentCreatePayload(amount=100, type="prepayment"),
+            tenant_scope=TEST_TENANT_SCOPE,
+        )
+
+    payments = list(
+        (
+            await command_session.execute(
+                select(Payment).where(Payment.order_id == order_id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert payments == []
+
+
+@pytest.mark.asyncio
+async def test_delete_payment_rolls_back_deletion_on_final_failure(
+    command_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    order_id, _ = await _create_order(command_session)
+    payment = Payment(order_id=order_id, amount=100)
+    command_session.add(payment)
+    await command_session.commit()
+    payment_id = int(payment.id)
+    monkeypatch.setattr(
+        OrderService,
+        "_refresh_order_financials",
+        _fail_financial_refresh,
+    )
+
+    with pytest.raises(RuntimeError, match="injected final-step failure"):
+        await OrderPaymentCommandService.delete_payment(
+            command_session,
+            order_id,
+            payment_id,
+            tenant_scope=TEST_TENANT_SCOPE,
+        )
+
+    assert await command_session.get(Payment, payment_id) is not None


### PR DESCRIPTION
## Что изменено
- этапы работ вынесены из крупного OrderService в отдельный command service
- платежи вынесены в отдельный command service
- создание, изменение, отмена и удаление этапов, а также создание и удаление платежей выполняются атомарно вместе с перерасчётом и outbox-событиями
- Manager write routes вызывают новые команды напрямую; совместимые делегаты сохранены
- добавлены семь fault-injection тестов полного rollback

## Проверка
- 26 existing Manager Orders unit tests passed до rebase
- 7 rollback tests passed после rebase
- 18 focused stage/payment unit and integration tests passed после rebase
- 66 Manager Orders and tenant-isolation integration tests passed на исходном патче
- OpenAPI and generated Manager client unchanged

## Риск
Низкий: HTTP-контракт и DTO не меняются; изменения ограничены внутренними транзакционными границами.