### PR TITLE
Make order creation and lead commands transactional

### DIFF
--- a/docs/order-domain-refactor.md
+++ b/docs/order-domain-refactor.md
@@ -48,11 +48,18 @@ handler owns one transaction and returns the post-commit projection. Failure at
 any point must roll back the order, customer changes, links and outbox events as
 one unit. Add fault-injection tests at the final step of each command.
 
-Deliver R2 as three independently deployable slices:
+Deliver R2 as independently deployable slices:
 
 1. [x] proposal create/update/select commands;
 2. [x] work-stage and payment commands;
-3. [ ] order create/update/delete plus Lead qualification.
+3. [x] Manager order creation and Lead create/update/loss/qualification;
+4. [ ] Manager order update;
+5. [ ] order deletion and external document cleanup.
+
+Order deletion stays separate because deleting a Google Drive document is an
+external side effect. A database transaction alone cannot undo that operation;
+the command needs an after-commit cleanup/outbox boundary instead of pretending
+that Drive and PostgreSQL share one transaction.
 
 When a command participates in an explicit caller-owned unit of work, its local
 boundary is a SAVEPOINT; ordinary HTTP commands own the root transaction.

--- a/routers/manager_leads_write.py
+++ b/routers/manager_leads_write.py
@@ -20,7 +20,7 @@ from schemas import (
     LeadResponse,
     LeadUpdatePayload,
 )
-from services.lead_service import LeadService
+from services.lead_command_service import LeadCommandService
 from services.tenant_scope_service import TenantScope
 
 
@@ -35,7 +35,7 @@ async def create_manager_lead(
     tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     try:
-        return await LeadService.create_lead(
+        return await LeadCommandService.create_lead(
             session=session,
             payload=payload,
             tenant_scope=tenant_scope,
@@ -58,7 +58,7 @@ async def patch_manager_lead(
     tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     try:
-        lead = await LeadService.update_lead(
+        lead = await LeadCommandService.update_lead(
             session=session,
             lead_id=lead_id,
             payload=payload,
@@ -90,7 +90,7 @@ async def qualify_manager_lead(
 ):
     ManagerTelemetryService.record_qualify_attempt(endpoint=QUALIFY_MANAGER_LEAD, payload=payload)
     try:
-        result = await LeadService.qualify_lead(
+        result = await LeadCommandService.qualify_lead(
             session=session,
             lead_id=lead_id,
             payload=payload,
@@ -122,7 +122,7 @@ async def mark_manager_lead_lost(
     tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     try:
-        result = await LeadService.mark_lead_lost(
+        result = await LeadCommandService.mark_lead_lost(
             session=session,
             lead_id=lead_id,
             payload=payload,

--- a/routers/manager_orders_write.py
+++ b/routers/manager_orders_write.py
@@ -45,6 +45,7 @@ from schemas import (
     ManagerStaleWorkStageItem,
 )
 from services.document_service import DocumentService, OrderDocumentsLockedError
+from services.order_create_command_service import OrderCreateCommandService
 from services.order_payment_command_service import OrderPaymentCommandService
 from services.order_proposal_command_service import OrderProposalCommandService
 from services.order_service import OrderService
@@ -64,7 +65,7 @@ async def create_manager_order(
     tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     try:
-        data = await OrderService.create_manager_order(
+        data = await OrderCreateCommandService.create_manager_order(
             session=session,
             payload=payload,
             tenant_scope=tenant_scope,

--- a/services/lead_command_service.py
+++ b/services/lead_command_service.py
@@ -1,0 +1,204 @@
+"""Transactional commands for Manager and internal Lead workflows."""
+
+from typing import Any, Dict, Optional
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models import Lead, LeadIntakeSource, LeadLossReason, LeadStatus
+from services.command_transaction import command_transaction
+from services.lead_service import LeadService
+from services.tenant_entity_access_service import TenantEntityAccessService
+from services.tenant_scope_service import TenantScope
+
+
+class LeadCommandService:
+    @staticmethod
+    async def create_lead(
+        session: AsyncSession,
+        payload: Any,
+        *,
+        tenant_scope: TenantScope,
+    ) -> Dict[str, Any]:
+        async with command_transaction(session):
+            request_text = (payload.request_text or "").strip()
+            if not request_text:
+                raise ValueError("request_text is required")
+
+            inn = LeadService._clean_optional(payload.inn)
+            segment_hint = LeadService._normalize_segment_hint(
+                inn,
+                payload.segment_hint,
+            )
+            source = LeadIntakeSource(payload.source)
+            lead = Lead(
+                tenant_id=tenant_scope.tenant_id,
+                storefront_id=tenant_scope.storefront_id,
+                status=LeadStatus.new,
+                source=source,
+                segment_hint=segment_hint,
+                name=LeadService._clean_optional(payload.name),
+                phone=LeadService._clean_optional(payload.phone),
+                email=LeadService._clean_optional(payload.email),
+                inn=inn,
+                company_name=LeadService._clean_optional(payload.company_name),
+                request_text=request_text,
+                source_message_id=LeadService._clean_optional(
+                    getattr(payload, "source_message_id", None)
+                ),
+                source_fingerprint=LeadService._clean_optional(
+                    getattr(payload, "source_fingerprint", None)
+                ),
+                next_followup_date=LeadService._normalize_naive_datetime(
+                    payload.next_followup_date
+                ),
+            )
+            session.add(lead)
+            await session.flush()
+
+        await session.refresh(lead)
+        return LeadService._map_lead(lead)
+
+    @staticmethod
+    async def update_lead(
+        session: AsyncSession,
+        lead_id: int,
+        payload: Any,
+        *,
+        tenant_scope: TenantScope,
+    ) -> Optional[Dict[str, Any]]:
+        async with command_transaction(session):
+            lead = await TenantEntityAccessService.get_lead(
+                session,
+                lead_id,
+                tenant_scope=tenant_scope,
+                for_update=True,
+            )
+            if not lead:
+                return None
+
+            fields_set = getattr(payload, "model_fields_set", None)
+            if fields_set is None:
+                fields_set = getattr(payload, "__fields_set__", set())
+
+            explicit_segment_hint: Optional[str] = None
+            should_recompute_segment = False
+            if "status" in fields_set and payload.status is not None:
+                next_status = LeadStatus(payload.status)
+                if next_status in {
+                    LeadStatus.qualified,
+                    LeadStatus.lost,
+                    LeadStatus.spam,
+                }:
+                    raise ValueError(
+                        "Use dedicated lead workflow endpoints for terminal statuses"
+                    )
+                lead.status = next_status
+            if "source" in fields_set and payload.source is not None:
+                lead.source = LeadIntakeSource(payload.source)
+            if "name" in fields_set:
+                lead.name = LeadService._clean_optional(payload.name)
+            if "phone" in fields_set:
+                lead.phone = LeadService._clean_optional(payload.phone)
+            if "email" in fields_set:
+                lead.email = LeadService._clean_optional(payload.email)
+            if "inn" in fields_set:
+                lead.inn = LeadService._clean_optional(payload.inn)
+                should_recompute_segment = True
+            if "company_name" in fields_set:
+                lead.company_name = LeadService._clean_optional(payload.company_name)
+            if "request_text" in fields_set and payload.request_text is not None:
+                request_text = payload.request_text.strip()
+                if not request_text:
+                    raise ValueError("request_text cannot be empty")
+                lead.request_text = request_text
+            if "source_message_id" in fields_set:
+                lead.source_message_id = LeadService._clean_optional(
+                    payload.source_message_id
+                )
+            if "source_fingerprint" in fields_set:
+                lead.source_fingerprint = LeadService._clean_optional(
+                    payload.source_fingerprint
+                )
+            if "loss_reason" in fields_set:
+                lead.loss_reason = (
+                    LeadLossReason(payload.loss_reason)
+                    if payload.loss_reason
+                    else None
+                )
+            if "next_followup_date" in fields_set:
+                lead.next_followup_date = LeadService._normalize_naive_datetime(
+                    payload.next_followup_date
+                )
+            if "archived_at" in fields_set:
+                lead.archived_at = LeadService._normalize_naive_datetime(
+                    payload.archived_at
+                )
+            if "segment_hint" in fields_set:
+                explicit_segment_hint = payload.segment_hint
+                should_recompute_segment = True
+
+            if should_recompute_segment:
+                lead.segment_hint = LeadService._normalize_segment_hint(
+                    lead.inn,
+                    explicit_segment_hint,
+                )
+
+            session.add(lead)
+            await session.flush()
+
+        await session.refresh(lead)
+        return LeadService._map_lead(lead)
+
+    @staticmethod
+    async def mark_lead_lost(
+        session: AsyncSession,
+        lead_id: int,
+        payload: Any,
+        *,
+        tenant_scope: TenantScope,
+    ) -> Optional[Dict[str, Any]]:
+        async with command_transaction(session):
+            lead = await TenantEntityAccessService.get_lead(
+                session,
+                lead_id,
+                tenant_scope=tenant_scope,
+                for_update=True,
+            )
+            if not lead:
+                return None
+
+            next_status = LeadStatus(payload.status)
+            if next_status not in {LeadStatus.lost, LeadStatus.spam}:
+                raise ValueError("Lead can only be marked lost or spam here")
+            lead.status = next_status
+            lead.loss_reason = (
+                LeadLossReason(payload.loss_reason)
+                if payload.loss_reason
+                else (
+                    LeadLossReason.spam
+                    if lead.status == LeadStatus.spam
+                    else lead.loss_reason
+                )
+            )
+            lead.next_followup_date = None
+            session.add(lead)
+            await session.flush()
+
+        await session.refresh(lead)
+        return LeadService._map_lead(lead)
+
+    @staticmethod
+    async def qualify_lead(
+        session: AsyncSession,
+        lead_id: int,
+        payload: Any,
+        *,
+        tenant_scope: TenantScope,
+    ) -> Optional[Dict[str, Any]]:
+        async with command_transaction(session):
+            return await LeadService._qualify_lead_mutation(
+                session,
+                lead_id,
+                payload,
+                tenant_scope=tenant_scope,
+            )

--- a/services/lead_service.py
+++ b/services/lead_service.py
@@ -13,7 +13,6 @@ from models import (
     CustomerType,
     Lead,
     LeadIntakeSource,
-    LeadLossReason,
     LeadSegmentHint,
     LeadSource as OrderLeadSource,
     LeadStatus,
@@ -149,34 +148,14 @@ class LeadService:
         *,
         tenant_scope: TenantScope,
     ) -> Dict[str, Any]:
-        request_text = (payload.request_text or "").strip()
-        if not request_text:
-            raise ValueError("request_text is required")
+        """Compatibility delegate to the transactional Lead command."""
+        from services.lead_command_service import LeadCommandService
 
-        inn = LeadService._clean_optional(payload.inn)
-        segment_hint = LeadService._normalize_segment_hint(inn, payload.segment_hint)
-        source = LeadIntakeSource(payload.source)
-
-        lead = Lead(
-            tenant_id=tenant_scope.tenant_id,
-            storefront_id=tenant_scope.storefront_id,
-            status=LeadStatus.new,
-            source=source,
-            segment_hint=segment_hint,
-            name=LeadService._clean_optional(payload.name),
-            phone=LeadService._clean_optional(payload.phone),
-            email=LeadService._clean_optional(payload.email),
-            inn=inn,
-            company_name=LeadService._clean_optional(payload.company_name),
-            request_text=request_text,
-            source_message_id=LeadService._clean_optional(getattr(payload, "source_message_id", None)),
-            source_fingerprint=LeadService._clean_optional(getattr(payload, "source_fingerprint", None)),
-            next_followup_date=LeadService._normalize_naive_datetime(payload.next_followup_date),
+        return await LeadCommandService.create_lead(
+            session,
+            payload,
+            tenant_scope=tenant_scope,
         )
-        session.add(lead)
-        await session.commit()
-        await session.refresh(lead)
-        return LeadService._map_lead(lead)
 
     @staticmethod
     async def list_leads(
@@ -271,66 +250,15 @@ class LeadService:
         *,
         tenant_scope: TenantScope,
     ) -> Optional[Dict[str, Any]]:
-        lead = await TenantEntityAccessService.get_lead(
+        """Compatibility delegate to the transactional Lead command."""
+        from services.lead_command_service import LeadCommandService
+
+        return await LeadCommandService.update_lead(
             session,
             lead_id,
+            payload,
             tenant_scope=tenant_scope,
-            for_update=True,
         )
-        if not lead:
-            return None
-
-        fields_set = getattr(payload, "model_fields_set", None)
-        if fields_set is None:
-            fields_set = getattr(payload, "__fields_set__", set())
-
-        explicit_segment_hint: Optional[str] = None
-        should_recompute_segment = False
-
-        if "status" in fields_set and payload.status is not None:
-            next_status = LeadStatus(payload.status)
-            if next_status in {LeadStatus.qualified, LeadStatus.lost, LeadStatus.spam}:
-                raise ValueError("Use dedicated lead workflow endpoints for terminal statuses")
-            lead.status = next_status
-        if "source" in fields_set and payload.source is not None:
-            lead.source = LeadIntakeSource(payload.source)
-        if "name" in fields_set:
-            lead.name = LeadService._clean_optional(payload.name)
-        if "phone" in fields_set:
-            lead.phone = LeadService._clean_optional(payload.phone)
-        if "email" in fields_set:
-            lead.email = LeadService._clean_optional(payload.email)
-        if "inn" in fields_set:
-            lead.inn = LeadService._clean_optional(payload.inn)
-            should_recompute_segment = True
-        if "company_name" in fields_set:
-            lead.company_name = LeadService._clean_optional(payload.company_name)
-        if "request_text" in fields_set and payload.request_text is not None:
-            request_text = payload.request_text.strip()
-            if not request_text:
-                raise ValueError("request_text cannot be empty")
-            lead.request_text = request_text
-        if "source_message_id" in fields_set:
-            lead.source_message_id = LeadService._clean_optional(payload.source_message_id)
-        if "source_fingerprint" in fields_set:
-            lead.source_fingerprint = LeadService._clean_optional(payload.source_fingerprint)
-        if "loss_reason" in fields_set:
-            lead.loss_reason = LeadLossReason(payload.loss_reason) if payload.loss_reason else None
-        if "next_followup_date" in fields_set:
-            lead.next_followup_date = LeadService._normalize_naive_datetime(payload.next_followup_date)
-        if "archived_at" in fields_set:
-            lead.archived_at = LeadService._normalize_naive_datetime(payload.archived_at)
-        if "segment_hint" in fields_set:
-            explicit_segment_hint = payload.segment_hint
-            should_recompute_segment = True
-
-        if should_recompute_segment:
-            lead.segment_hint = LeadService._normalize_segment_hint(lead.inn, explicit_segment_hint)
-
-        session.add(lead)
-        await session.commit()
-        await session.refresh(lead)
-        return LeadService._map_lead(lead)
 
     @staticmethod
     async def mark_lead_lost(
@@ -340,28 +268,15 @@ class LeadService:
         *,
         tenant_scope: TenantScope,
     ) -> Optional[Dict[str, Any]]:
-        lead = await TenantEntityAccessService.get_lead(
+        """Compatibility delegate to the transactional Lead command."""
+        from services.lead_command_service import LeadCommandService
+
+        return await LeadCommandService.mark_lead_lost(
             session,
             lead_id,
+            payload,
             tenant_scope=tenant_scope,
-            for_update=True,
         )
-        if not lead:
-            return None
-
-        next_status = LeadStatus(payload.status)
-        if next_status not in {LeadStatus.lost, LeadStatus.spam}:
-            raise ValueError("Lead can only be marked lost or spam here")
-        lead.status = next_status
-        lead.loss_reason = LeadLossReason(payload.loss_reason) if payload.loss_reason else (
-            LeadLossReason.spam if lead.status == LeadStatus.spam else lead.loss_reason
-        )
-        lead.next_followup_date = None
-
-        session.add(lead)
-        await session.commit()
-        await session.refresh(lead)
-        return LeadService._map_lead(lead)
 
     @staticmethod
     async def _find_existing_customer(
@@ -408,6 +323,24 @@ class LeadService:
 
     @staticmethod
     async def qualify_lead(
+        session: AsyncSession,
+        lead_id: int,
+        payload: Any,
+        *,
+        tenant_scope: TenantScope,
+    ) -> Optional[Dict[str, Any]]:
+        """Compatibility delegate to the transactional Lead command."""
+        from services.lead_command_service import LeadCommandService
+
+        return await LeadCommandService.qualify_lead(
+            session,
+            lead_id,
+            payload,
+            tenant_scope=tenant_scope,
+        )
+
+    @staticmethod
+    async def _qualify_lead_mutation(
         session: AsyncSession,
         lead_id: int,
         payload: Any,
@@ -579,7 +512,7 @@ class LeadService:
         lead.loss_reason = None
         session.add(lead)
 
-        await session.commit()
+        await session.flush()
         await session.refresh(lead)
 
         return {

--- a/services/order_create_command_service.py
+++ b/services/order_create_command_service.py
@@ -1,0 +1,93 @@
+"""Transactional Manager order creation command."""
+
+from typing import Any, Dict
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm.attributes import flag_modified
+
+from models import LeadSource, OrderStatus
+from services.command_transaction import command_transaction
+from services.order_projection_service import OrderProjectionService
+from services.order_service import OrderService
+from services.tenant_scope_service import TenantScope
+
+
+class OrderCreateCommandService:
+    @staticmethod
+    async def create_manager_order(
+        session: AsyncSession,
+        payload: Any,
+        *,
+        tenant_scope: TenantScope,
+    ) -> Dict[str, Any]:
+        async with command_transaction(session):
+            source = (
+                LeadSource(payload.source)
+                if payload.source
+                else LeadSource.MANAGER
+            )
+            initial_status = (
+                OrderStatus.NEGOTIATION
+                if payload.customer_id or payload.service_type == "maintenance"
+                else OrderStatus.NEW_LEAD
+            )
+
+            order = await OrderService.create_from_website(
+                session=session,
+                customer_name=payload.name or "Новый клиент",
+                customer_phone=payload.phone or "",
+                customer_email=None,
+                customer_address=payload.address,
+                items=[],
+                lead_source=source,
+                initial_status=initial_status,
+                comment=payload.request_text,
+                customer_id=payload.customer_id,
+                customer_type=payload.customer_type,
+                customer_inn=payload.customer_inn,
+                customer_full_legal_name=payload.customer_full_legal_name,
+                tenant_scope=tenant_scope,
+                commit=False,
+            )
+
+            default_title = OrderService._build_default_order_title(
+                service_type=payload.service_type,
+                comment=payload.request_text,
+            )
+            if default_title:
+                order.title = default_title
+
+            if payload.service_type == "maintenance" and payload.target_date:
+                order.installation_date = OrderService._normalize_naive_datetime(
+                    payload.target_date
+                )
+
+            if payload.service_type:
+                order.technical_meta = dict(order.technical_meta or {})
+                order.technical_meta["service_type"] = payload.service_type
+                order.workflow_type = OrderService._workflow_type_from_service_type(
+                    payload.service_type,
+                    order.workflow_type,
+                )
+                flag_modified(order, "technical_meta")
+
+            if order.workflow_type == "repair":
+                OrderService._ensure_repair_meta_defaults(order)
+                flag_modified(order, "technical_meta")
+                await OrderService._maybe_add_default_repair_diagnostic(
+                    session,
+                    order,
+                )
+
+            session.add(order)
+            await session.flush()
+            order_id = int(order.id)
+
+        data = await OrderProjectionService.get_order_detail_for_manager(
+            session,
+            order_id,
+            tenant_scope=tenant_scope,
+        )
+        if data is None:
+            raise RuntimeError("Committed order is no longer visible in its tenant scope")
+        return data

--- a/services/order_service.py
+++ b/services/order_service.py
@@ -926,64 +926,12 @@ class OrderService:
         *,
         tenant_scope: TenantScope,
     ) -> Optional[Dict[str, Any]]:
-        source_enum = LeadSource(payload.source) if payload.source else LeadSource.MANAGER
-        initial_status = (
-            OrderStatus.NEGOTIATION
-            if payload.customer_id or payload.service_type == "maintenance"
-            else OrderStatus.NEW_LEAD
-        )
+        """Compatibility delegate to the transactional create command."""
+        from services.order_create_command_service import OrderCreateCommandService
 
-        order = await OrderService.create_from_website(
-            session=session,
-            customer_name=payload.name or "Новый клиент",
-            customer_phone=payload.phone or "",
-            customer_email=None,
-            customer_address=payload.address,
-            items=[],
-            lead_source=source_enum,
-            initial_status=initial_status,
-            comment=payload.request_text,
-            customer_id=payload.customer_id,
-            customer_type=payload.customer_type,
-            customer_inn=payload.customer_inn,
-            customer_full_legal_name=payload.customer_full_legal_name,
-            tenant_scope=tenant_scope,
-        )
-
-        changed = False
-        default_title = OrderService._build_default_order_title(
-            service_type=payload.service_type,
-            comment=payload.request_text,
-        )
-        if default_title:
-            order.title = default_title
-            changed = True
-
-        if payload.service_type == "maintenance" and payload.target_date:
-            order.installation_date = OrderService._normalize_naive_datetime(payload.target_date)
-            changed = True
-
-        if payload.service_type:
-            order.technical_meta = dict(order.technical_meta or {})
-            order.technical_meta["service_type"] = payload.service_type
-            order.workflow_type = OrderService._workflow_type_from_service_type(payload.service_type, order.workflow_type)
-            flag_modified(order, "technical_meta")
-            changed = True
-
-        if order.workflow_type == "repair":
-            OrderService._ensure_repair_meta_defaults(order)
-            flag_modified(order, "technical_meta")
-            await OrderService._maybe_add_default_repair_diagnostic(session, order)
-            changed = True
-
-        if changed:
-            session.add(order)
-            await session.commit()
-            await session.refresh(order)
-
-        return await OrderService.get_order_detail_for_manager(
+        return await OrderCreateCommandService.create_manager_order(
             session,
-            int(order.id),
+            payload,
             tenant_scope=tenant_scope,
         )
 

--- a/tests/unit/test_order_lead_command_service.py
+++ b/tests/unit/test_order_lead_command_service.py
@@ -1,0 +1,209 @@
+from pathlib import Path
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import SQLModel, select
+
+from models import Customer, Lead, LeadStatus, Order, OrderProposal
+from models.tenancy import TenantScope
+from schemas import (
+    LeadCreatePayload,
+    LeadLossPayload,
+    LeadQualifyPayload,
+    LeadUpdatePayload,
+    ManagerOrderCreatePayload,
+)
+from services.lead_command_service import LeadCommandService
+from services.order_create_command_service import OrderCreateCommandService
+from services.order_service import OrderService
+
+
+TEST_TENANT_SCOPE = TenantScope(tenant_id=1, storefront_id=1, is_system=True)
+
+
+@pytest.fixture
+async def command_session(tmp_path: Path):
+    engine = create_async_engine(
+        f"sqlite+aiosqlite:///{tmp_path / 'order_lead_commands.db'}",
+        echo=False,
+    )
+    async with engine.begin() as connection:
+        await connection.run_sync(SQLModel.metadata.create_all)
+
+    session_factory = sessionmaker(
+        bind=engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+    async with session_factory() as session:
+        yield session
+
+    await engine.dispose()
+
+
+async def _create_lead(session: AsyncSession) -> int:
+    lead = Lead(
+        tenant_id=TEST_TENANT_SCOPE.tenant_id,
+        storefront_id=TEST_TENANT_SCOPE.storefront_id,
+        name="Исходный лид",
+        request_text="Исходная заявка",
+    )
+    session.add(lead)
+    await session.commit()
+    return int(lead.id)
+
+
+def _raise_after_flush(original_flush, *, fail_on_call: int = 1):
+    call_count = 0
+
+    async def flush_then_fail(session: AsyncSession, *args, **kwargs) -> None:
+        nonlocal call_count
+        await original_flush(session, *args, **kwargs)
+        call_count += 1
+        if call_count == fail_on_call:
+            raise RuntimeError("injected final-step failure")
+
+    return flush_then_fail
+
+
+@pytest.mark.asyncio
+async def test_create_manager_order_rolls_back_customer_order_and_proposal(
+    command_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    async def fail_after_create(
+        _session: AsyncSession,
+        _order: Order,
+    ) -> None:
+        raise RuntimeError("injected final-step failure")
+
+    monkeypatch.setattr(
+        OrderService,
+        "_maybe_add_default_repair_diagnostic",
+        fail_after_create,
+    )
+
+    with pytest.raises(RuntimeError, match="injected final-step failure"):
+        await OrderCreateCommandService.create_manager_order(
+            command_session,
+            ManagerOrderCreatePayload(
+                source="manager",
+                request_text="Диагностика кондиционера",
+                service_type="repair",
+                name="Новый клиент",
+                phone="+375290000003",
+            ),
+            tenant_scope=TEST_TENANT_SCOPE,
+        )
+
+    assert list((await command_session.execute(select(Customer))).scalars()) == []
+    assert list((await command_session.execute(select(Order))).scalars()) == []
+    assert list((await command_session.execute(select(OrderProposal))).scalars()) == []
+
+
+@pytest.mark.asyncio
+async def test_create_lead_rolls_back_flushed_row(
+    command_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(
+        AsyncSession,
+        "flush",
+        _raise_after_flush(AsyncSession.flush),
+    )
+
+    with pytest.raises(RuntimeError, match="injected final-step failure"):
+        await LeadCommandService.create_lead(
+            command_session,
+            LeadCreatePayload(
+                source="manager",
+                name="Новый лид",
+                request_text="Нужен кондиционер",
+            ),
+            tenant_scope=TEST_TENANT_SCOPE,
+        )
+
+    assert list((await command_session.execute(select(Lead))).scalars()) == []
+
+
+@pytest.mark.asyncio
+async def test_update_lead_rolls_back_flushed_fields(
+    command_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    lead_id = await _create_lead(command_session)
+    monkeypatch.setattr(
+        AsyncSession,
+        "flush",
+        _raise_after_flush(AsyncSession.flush),
+    )
+
+    with pytest.raises(RuntimeError, match="injected final-step failure"):
+        await LeadCommandService.update_lead(
+            command_session,
+            lead_id,
+            LeadUpdatePayload(name="Не должно сохраниться"),
+            tenant_scope=TEST_TENANT_SCOPE,
+        )
+
+    command_session.expire_all()
+    stored = await command_session.get(Lead, lead_id)
+    assert stored is not None
+    assert stored.name == "Исходный лид"
+
+
+@pytest.mark.asyncio
+async def test_mark_lead_lost_rolls_back_flushed_status(
+    command_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    lead_id = await _create_lead(command_session)
+    monkeypatch.setattr(
+        AsyncSession,
+        "flush",
+        _raise_after_flush(AsyncSession.flush),
+    )
+
+    with pytest.raises(RuntimeError, match="injected final-step failure"):
+        await LeadCommandService.mark_lead_lost(
+            command_session,
+            lead_id,
+            LeadLossPayload(status="lost", loss_reason="no_product"),
+            tenant_scope=TEST_TENANT_SCOPE,
+        )
+
+    command_session.expire_all()
+    stored = await command_session.get(Lead, lead_id)
+    assert stored is not None
+    assert stored.status == LeadStatus.new
+    assert stored.loss_reason is None
+
+
+@pytest.mark.asyncio
+async def test_qualify_lead_rolls_back_customer_order_and_conversion(
+    command_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    lead_id = await _create_lead(command_session)
+    monkeypatch.setattr(
+        AsyncSession,
+        "flush",
+        _raise_after_flush(AsyncSession.flush, fail_on_call=3),
+    )
+
+    with pytest.raises(RuntimeError, match="injected final-step failure"):
+        await LeadCommandService.qualify_lead(
+            command_session,
+            lead_id,
+            LeadQualifyPayload(order_comment="Квалифицировать атомарно"),
+            tenant_scope=TEST_TENANT_SCOPE,
+        )
+
+    command_session.expire_all()
+    stored = await command_session.get(Lead, lead_id)
+    assert stored is not None
+    assert stored.status == LeadStatus.new
+    assert stored.converted_order_id is None
+    assert list((await command_session.execute(select(Customer))).scalars()) == []
+    assert list((await command_session.execute(select(Order))).scalars()) == []


### PR DESCRIPTION
## Что изменено
- создание Manager Order вынесено в отдельный command handler с единой транзакционной границей;
- create/update/loss/qualification для Lead собраны в `LeadCommandService`;
- сервисные помощники больше не фиксируют частичные изменения самостоятельно;
- добавлены fault-injection и rollback-тесты для финальных шагов команд;
- внешний Manager API и OpenAPI-контракт не изменены.

## Проверка
- 115 профильных unit/integration тестов;
- повторная генерация OpenAPI без diff;
- `git diff --check`.
