### PR TITLE
Make order deletion and document cleanup durable

### DIFF
--- a/docs/order-domain-refactor.md
+++ b/docs/order-domain-refactor.md
@@ -54,12 +54,14 @@ Deliver R2 as independently deployable slices:
 2. [x] work-stage and payment commands;
 3. [x] Manager order creation and Lead create/update/loss/qualification;
 4. [x] Manager order update, split into order/customer/commercial/finalization slices;
-5. [ ] order deletion and external document cleanup.
+5. [x] order deletion and durable post-commit external document cleanup.
 
 Order deletion stays separate because deleting a Google Drive document is an
-external side effect. A database transaction alone cannot undo that operation;
-the command needs an after-commit cleanup/outbox boundary instead of pretending
-that Drive and PostgreSQL share one transaction.
+external side effect. The command now stores one narrow cleanup event per file
+inside the same transaction as the database deletion. A dedicated scheduler
+consumer processes only that exact event type after commit, with leases,
+bounded retries and dead-letter state; the communications allowlist is not
+widened.
 
 When a command participates in an explicit caller-owned unit of work, its local
 boundary is a SAVEPOINT; ordinary HTTP commands own the root transaction.

--- a/routers/manager_orders_write.py
+++ b/routers/manager_orders_write.py
@@ -46,6 +46,7 @@ from schemas import (
 )
 from services.document_service import DocumentService, OrderDocumentsLockedError
 from services.order_create_command_service import OrderCreateCommandService
+from services.order_delete_command_service import OrderDeleteCommandService
 from services.order_payment_command_service import OrderPaymentCommandService
 from services.order_proposal_command_service import OrderProposalCommandService
 from services.order_service import OrderService
@@ -557,7 +558,7 @@ async def delete_manager_order(
     tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     try:
-        await OrderService.delete_order(
+        await OrderDeleteCommandService.delete_order(
             session,
             order_id,
             tenant_scope=tenant_scope,

--- a/services/google_service.py
+++ b/services/google_service.py
@@ -7,6 +7,7 @@ from io import BytesIO
 from google_auth_oauthlib.flow import Flow
 from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
 from googleapiclient.http import MediaIoBaseDownload, MediaFileUpload, MediaIoBaseUpload
 import datetime
 
@@ -1013,17 +1014,33 @@ class GoogleDocsService:
         Args:
             file_id: ID файла в Google Drive
         """
-        credentials = self._require_credentials()
-                
         try:
-            drive_service = build('drive', 'v3', credentials=credentials)
-            
-            # Обновляем метаданные файла, устанавливая trashed=True
-            drive_service.files().update(fileId=file_id, body={'trashed': True}).execute()
-            
+            self.delete_file_strict(file_id)
         except Exception as e:
             # Логируем ошибку, но не прерываем выполнение (файл мог быть уже удален)
             logger.warning(f"Failed to delete Google Drive file {file_id}: {str(e)}")
+
+    def delete_file_strict(self, file_id: str) -> None:
+        """Move a file to trash and surface retryable provider failures.
+
+        A missing file is already in the desired state and is therefore
+        treated as success. Durable cleanup workers use this strict variant;
+        legacy best-effort callers keep using ``delete_file``.
+        """
+        normalized_file_id = str(file_id or "").strip()
+        if not normalized_file_id:
+            raise ValueError("Google Drive file_id is required")
+        credentials = self._require_credentials()
+        drive_service = build("drive", "v3", credentials=credentials)
+        try:
+            drive_service.files().update(
+                fileId=normalized_file_id,
+                body={"trashed": True},
+            ).execute()
+        except HttpError as exc:
+            if getattr(exc.resp, "status", None) == 404:
+                return
+            raise
 
 
     def upload_file(self, file_path: str, filename: str, mime_type: str, folder_id: str = None) -> str:

--- a/services/order_delete_command_service.py
+++ b/services/order_delete_command_service.py
@@ -1,0 +1,102 @@
+"""Transactional Manager order deletion with durable external cleanup."""
+
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.order import (
+    BankReceipt,
+    Order,
+    OrderDocument,
+    OrderInstaller,
+    OrderProductLink,
+    OrderProposal,
+    OrderServiceLink,
+    OrderWorkStage,
+    OutgoingEmail,
+    Payment,
+)
+from services.command_transaction import command_transaction
+from services.document_service import DocumentService
+from services.order_document_cleanup_service import OrderDocumentCleanupService
+from services.tenant_entity_access_service import TenantEntityAccessService
+from services.tenant_scope_service import TenantScope
+
+
+class OrderDeleteCommandService:
+    @staticmethod
+    async def delete_order(
+        session: AsyncSession,
+        order_id: int,
+        *,
+        tenant_scope: TenantScope,
+    ) -> bool:
+        async with command_transaction(session):
+            order = await TenantEntityAccessService.get_order(
+                session,
+                order_id,
+                tenant_scope=tenant_scope,
+                for_update=True,
+            )
+            if not order:
+                raise ValueError(f"Order {order_id} not found")
+
+            documents = await DocumentService.list_order_documents(
+                session,
+                order_id,
+                tenant_scope=tenant_scope,
+            )
+            await OrderDocumentCleanupService.enqueue_order_documents(
+                session,
+                order_id=order_id,
+                documents=documents or [],
+                tenant_scope=tenant_scope,
+            )
+
+            # Keep audit/history rows but detach them from the hard-deleted order.
+            await session.execute(
+                sa.update(BankReceipt)
+                .where(BankReceipt.matched_order_id == order_id)
+                .values(
+                    status="requires_review",
+                    matched_order_id=None,
+                    matched_payment_id=None,
+                    match_meta={
+                        "reason": "matched_order_deleted",
+                        "deleted_order_id": order_id,
+                    },
+                )
+            )
+            await session.execute(
+                sa.update(OutgoingEmail)
+                .where(OutgoingEmail.order_id == order_id)
+                .values(order_id=None)
+            )
+            await session.execute(
+                sa.delete(OrderProductLink).where(
+                    OrderProductLink.order_id == order_id
+                )
+            )
+            await session.execute(
+                sa.delete(OrderServiceLink).where(
+                    OrderServiceLink.order_id == order_id
+                )
+            )
+            await session.execute(
+                sa.delete(OrderWorkStage).where(OrderWorkStage.order_id == order_id)
+            )
+            await session.execute(
+                sa.delete(OrderInstaller).where(OrderInstaller.order_id == order_id)
+            )
+            await session.execute(
+                sa.delete(Payment).where(Payment.order_id == order_id)
+            )
+            await session.execute(
+                sa.delete(OrderDocument).where(OrderDocument.order_id == order_id)
+            )
+            await session.execute(
+                sa.delete(OrderProposal).where(OrderProposal.order_id == order_id)
+            )
+            await session.execute(sa.delete(Order).where(Order.id == order_id))
+            await session.flush()
+
+        return True

--- a/services/order_document_cleanup_service.py
+++ b/services/order_document_cleanup_service.py
@@ -1,0 +1,351 @@
+"""Durable, tenant-aware cleanup of Google Drive files after order deletion."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Iterable
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from sqlalchemy import and_, or_
+from sqlmodel import select
+
+from core.database import async_session_maker
+from core.logger import logger
+from models import IntegrationOutboxEvent
+from services.communications.outbox_service import IntegrationOutboxService
+from services.google_service import get_google_service
+from services.tenant_scope_service import TenantScope
+
+
+ORDER_DOCUMENT_DELETE_REQUESTED_EVENT = "order.document.delete_requested.v1"
+
+
+class OrderDocumentDeleteRequestedV1(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    tenant_id: int = Field(gt=0)
+    storefront_id: int = Field(gt=0)
+    order_id: int = Field(gt=0)
+    document_id: int = Field(gt=0)
+    google_file_id: str = Field(min_length=1, max_length=512)
+
+
+class InvalidOrderDocumentCleanupEvent(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class DocumentCleanupClaim:
+    event_id: str
+    lease_token: str
+    payload: dict[str, Any]
+    attempts: int
+    max_attempts: int
+
+
+@dataclass(frozen=True)
+class DocumentCleanupOutcome:
+    event_id: str
+    outcome: str
+    attempts: int
+    next_attempt_at: datetime | None = None
+
+
+class OrderDocumentCleanupService:
+    LEASE_SECONDS = 120
+    RETRY_BASE_SECONDS = 30
+    RETRY_MAX_SECONDS = 3600
+
+    @staticmethod
+    async def enqueue_order_documents(
+        session,
+        *,
+        order_id: int,
+        documents: Iterable[Any],
+        tenant_scope: TenantScope,
+    ) -> int:
+        enqueued = 0
+        seen_file_ids: set[str] = set()
+        for document in documents:
+            file_id = str(getattr(document, "google_file_id", "") or "").strip()
+            document_id = int(getattr(document, "id", 0) or 0)
+            if not file_id or not document_id or file_id in seen_file_ids:
+                continue
+            seen_file_ids.add(file_id)
+            payload = OrderDocumentDeleteRequestedV1(
+                tenant_id=tenant_scope.tenant_id,
+                storefront_id=tenant_scope.storefront_id,
+                order_id=order_id,
+                document_id=document_id,
+                google_file_id=file_id,
+            )
+            await IntegrationOutboxService.enqueue(
+                session,
+                event_type=ORDER_DOCUMENT_DELETE_REQUESTED_EVENT,
+                aggregate_type="order_document",
+                aggregate_id=document_id,
+                aggregate_version=1,
+                payload=payload,
+                priority=50,
+                max_attempts=12,
+            )
+            enqueued += 1
+        return enqueued
+
+    @classmethod
+    async def process_next(
+        cls,
+        *,
+        worker_id: str,
+        session_factory=async_session_maker,
+        google_service=None,
+        now: datetime | None = None,
+    ) -> DocumentCleanupOutcome | None:
+        normalized_worker_id = str(worker_id or "").strip()
+        if not normalized_worker_id:
+            raise ValueError("Document cleanup worker_id is required")
+        if len(normalized_worker_id) > 128:
+            raise ValueError("Document cleanup worker_id is too long")
+
+        process_time = now or datetime.now(timezone.utc)
+        claim = await cls._claim_next(
+            worker_id=normalized_worker_id,
+            session_factory=session_factory,
+            now=process_time,
+        )
+        if claim is None:
+            return None
+
+        try:
+            try:
+                payload = OrderDocumentDeleteRequestedV1.model_validate(claim.payload)
+            except ValidationError as exc:
+                raise InvalidOrderDocumentCleanupEvent(
+                    "Document cleanup payload is invalid"
+                ) from exc
+            service = google_service or get_google_service()
+            await asyncio.to_thread(
+                service.delete_file_strict,
+                payload.google_file_id,
+            )
+        except Exception as exc:
+            permanent = isinstance(exc, InvalidOrderDocumentCleanupEvent)
+            return await cls._finish_failure(
+                claim=claim,
+                error=exc,
+                permanent=permanent,
+                session_factory=session_factory,
+                now=process_time,
+            )
+
+        return await cls._finish_success(
+            claim=claim,
+            session_factory=session_factory,
+            now=process_time,
+        )
+
+    @classmethod
+    async def process_batch(
+        cls,
+        *,
+        worker_id: str,
+        limit: int = 25,
+        session_factory=async_session_maker,
+        google_service=None,
+    ) -> list[DocumentCleanupOutcome]:
+        outcomes = []
+        for _ in range(max(1, min(int(limit), 100))):
+            outcome = await cls.process_next(
+                worker_id=worker_id,
+                session_factory=session_factory,
+                google_service=google_service,
+            )
+            if outcome is None:
+                break
+            outcomes.append(outcome)
+        return outcomes
+
+    @classmethod
+    async def _claim_next(
+        cls,
+        *,
+        worker_id: str,
+        session_factory,
+        now: datetime,
+    ) -> DocumentCleanupClaim | None:
+        async with session_factory() as session:
+            async with session.begin():
+                query = (
+                    select(IntegrationOutboxEvent)
+                    .where(
+                        IntegrationOutboxEvent.event_type
+                        == ORDER_DOCUMENT_DELETE_REQUESTED_EVENT,
+                        or_(
+                            and_(
+                                IntegrationOutboxEvent.status == "pending",
+                                IntegrationOutboxEvent.available_at <= now,
+                            ),
+                            and_(
+                                IntegrationOutboxEvent.status == "processing",
+                                IntegrationOutboxEvent.lease_expires_at.is_not(None),
+                                IntegrationOutboxEvent.lease_expires_at <= now,
+                            ),
+                        ),
+                    )
+                    .order_by(
+                        IntegrationOutboxEvent.priority.asc(),
+                        IntegrationOutboxEvent.available_at.asc(),
+                        IntegrationOutboxEvent.event_id.asc(),
+                    )
+                    .limit(1)
+                )
+                if session.get_bind().dialect.name == "postgresql":
+                    query = query.with_for_update(skip_locked=True)
+                event = (await session.execute(query)).scalar_one_or_none()
+                if event is None:
+                    return None
+
+                lease_token = uuid.uuid4().hex
+                event.status = "processing"
+                event.attempts += 1
+                event.worker_id = worker_id
+                event.lease_token = lease_token
+                event.lease_expires_at = now + timedelta(seconds=cls.LEASE_SECONDS)
+                event.last_error_code = None
+                event.last_error_message = None
+                event.updated_at = now
+                session.add(event)
+                return DocumentCleanupClaim(
+                    event_id=event.event_id,
+                    lease_token=lease_token,
+                    payload=dict(event.payload or {}),
+                    attempts=event.attempts,
+                    max_attempts=event.max_attempts,
+                )
+
+    @classmethod
+    async def _finish_success(
+        cls,
+        *,
+        claim: DocumentCleanupClaim,
+        session_factory,
+        now: datetime,
+    ) -> DocumentCleanupOutcome:
+        async with session_factory() as session:
+            async with session.begin():
+                event = await cls._leased_event(
+                    session,
+                    claim=claim,
+                )
+                if event is None:
+                    return DocumentCleanupOutcome(
+                        event_id=claim.event_id,
+                        outcome="lease_lost",
+                        attempts=claim.attempts,
+                    )
+                event.status = "published"
+                event.published_at = now
+                cls._clear_lease(event)
+                event.last_error_code = None
+                event.last_error_message = None
+                event.updated_at = now
+                session.add(event)
+        return DocumentCleanupOutcome(
+            event_id=claim.event_id,
+            outcome="deleted",
+            attempts=claim.attempts,
+        )
+
+    @classmethod
+    async def _finish_failure(
+        cls,
+        *,
+        claim: DocumentCleanupClaim,
+        error: Exception,
+        permanent: bool,
+        session_factory,
+        now: datetime,
+    ) -> DocumentCleanupOutcome:
+        is_dead = permanent or claim.attempts >= claim.max_attempts
+        next_attempt_at = None
+        if not is_dead:
+            next_attempt_at = now + cls._retry_delay(
+                event_id=claim.event_id,
+                attempts=claim.attempts,
+            )
+
+        async with session_factory() as session:
+            async with session.begin():
+                event = await cls._leased_event(
+                    session,
+                    claim=claim,
+                )
+                if event is None:
+                    return DocumentCleanupOutcome(
+                        event_id=claim.event_id,
+                        outcome="lease_lost",
+                        attempts=claim.attempts,
+                    )
+                event.status = "dead" if is_dead else "pending"
+                if next_attempt_at is not None:
+                    event.available_at = next_attempt_at
+                cls._clear_lease(event)
+                event.last_error_code = type(error).__name__[:100]
+                event.last_error_message = (
+                    str(error).strip() or type(error).__name__
+                )[:1000]
+                event.updated_at = now
+                session.add(event)
+
+        logger.warning(
+            "Order document cleanup failed event_id=%s outcome=%s attempts=%s error_code=%s",
+            claim.event_id,
+            "dead" if is_dead else "retry_scheduled",
+            claim.attempts,
+            type(error).__name__,
+        )
+        return DocumentCleanupOutcome(
+            event_id=claim.event_id,
+            outcome="dead" if is_dead else "retry_scheduled",
+            attempts=claim.attempts,
+            next_attempt_at=next_attempt_at,
+        )
+
+    @staticmethod
+    async def _leased_event(
+        session,
+        *,
+        claim: DocumentCleanupClaim,
+    ) -> IntegrationOutboxEvent | None:
+        query = select(IntegrationOutboxEvent).where(
+            IntegrationOutboxEvent.event_id == claim.event_id,
+            IntegrationOutboxEvent.status == "processing",
+            IntegrationOutboxEvent.lease_token == claim.lease_token,
+        )
+        if session.get_bind().dialect.name == "postgresql":
+            query = query.with_for_update()
+        return (await session.execute(query)).scalar_one_or_none()
+
+    @staticmethod
+    def _clear_lease(event: IntegrationOutboxEvent) -> None:
+        event.worker_id = None
+        event.lease_token = None
+        event.lease_expires_at = None
+
+    @classmethod
+    def _retry_delay(cls, *, event_id: str, attempts: int) -> timedelta:
+        exponent = max(0, min(int(attempts) - 1, 16))
+        base_seconds = min(
+            cls.RETRY_MAX_SECONDS,
+            cls.RETRY_BASE_SECONDS * (2**exponent),
+        )
+        jitter_window = max(1, base_seconds // 5)
+        digest = hashlib.sha256(f"{event_id}:{attempts}".encode()).digest()
+        jitter_seconds = int.from_bytes(digest[:4], "big") % (jitter_window + 1)
+        return timedelta(
+            seconds=min(cls.RETRY_MAX_SECONDS, base_seconds + jitter_seconds)
+        )

--- a/services/order_service.py
+++ b/services/order_service.py
@@ -2413,78 +2413,11 @@ class OrderService:
         *,
         tenant_scope: TenantScope,
     ) -> bool:
-        """
-        Delete an order and all cascading dependencies from DB.
-        Google Drive files are deleted on a best-effort basis and do not block DB deletion.
-        """
-        import sqlalchemy as sa
-        from models.order import (
-            BankReceipt,
-            Order,
-            OrderDocument,
-            OrderInstaller,
-            OrderProductLink,
-            OrderProposal,
-            OrderServiceLink,
-            OrderWorkStage,
-            OutgoingEmail,
-            Payment,
-        )
-        from services.document_service import DocumentService
-        from services.google_service import get_google_service
-        
-        order = await TenantEntityAccessService.get_order(
-            session,
-            order_id,
-            tenant_scope=tenant_scope,
-            for_update=True,
-        )
-        if not order:
-            raise ValueError(f"Order {order_id} not found")
+        """Compatibility delegate to the transactional delete command."""
+        from services.order_delete_command_service import OrderDeleteCommandService
 
-        # Delete associated documents from Google Drive (best-effort).
-        # OrderDocument rows themselves are deleted by ORM cascade together with the order.
-        docs = await DocumentService.list_order_documents(
+        return await OrderDeleteCommandService.delete_order(
             session,
             order_id,
             tenant_scope=tenant_scope,
         )
-        for doc in docs or []:
-            if not doc.google_file_id:
-                continue
-            try:
-                get_google_service().delete_file(doc.google_file_id)
-            except Exception as exc:
-                logger.warning(
-                    "Failed to delete Google Drive file while deleting order",
-                    extra={"order_id": order_id, "doc_id": doc.id, "google_file_id": doc.google_file_id, "error": str(exc)},
-                )
-
-        # Explicit SQL updates/deletes avoid async lazy-load cascade pitfalls on AsyncSession.
-        # Keep audit/history rows, but detach them from an order that is being hard-deleted.
-        await session.execute(
-            sa.update(BankReceipt)
-            .where(BankReceipt.matched_order_id == order_id)
-            .values(
-                status="requires_review",
-                matched_order_id=None,
-                matched_payment_id=None,
-                match_meta={"reason": "matched_order_deleted", "deleted_order_id": order_id},
-            )
-        )
-        await session.execute(
-            sa.update(OutgoingEmail)
-            .where(OutgoingEmail.order_id == order_id)
-            .values(order_id=None)
-        )
-        await session.execute(sa.delete(OrderProductLink).where(OrderProductLink.order_id == order_id))
-        await session.execute(sa.delete(OrderServiceLink).where(OrderServiceLink.order_id == order_id))
-        await session.execute(sa.delete(OrderWorkStage).where(OrderWorkStage.order_id == order_id))
-        await session.execute(sa.delete(OrderInstaller).where(OrderInstaller.order_id == order_id))
-        await session.execute(sa.delete(Payment).where(Payment.order_id == order_id))
-        await session.execute(sa.delete(OrderDocument).where(OrderDocument.order_id == order_id))
-        await session.execute(sa.delete(OrderProposal).where(OrderProposal.order_id == order_id))
-        await session.execute(sa.delete(Order).where(Order.id == order_id))
-        await session.commit()
-        
-        return True

--- a/services/scheduler_service.py
+++ b/services/scheduler_service.py
@@ -155,6 +155,9 @@ class SchedulerService:
         # Materialize idempotent staff departure reminders every five minutes.
         tasks.append(asyncio.create_task(self._staff_task_departure_reminder_loop()))
 
+        # Delete external order documents only after their database transaction commits.
+        tasks.append(asyncio.create_task(self._order_document_cleanup_loop()))
+
         # Run bank receipt IMAP import loop
         tasks.append(asyncio.create_task(self._bank_mail_import_loop()))
 
@@ -342,6 +345,32 @@ class SchedulerService:
             except Exception:
                 logger.exception("Staff departure reminder loop error")
             await asyncio.sleep(5 * 60)
+
+    async def _order_document_cleanup_loop(self):
+        from services.order_document_cleanup_service import (
+            OrderDocumentCleanupService,
+        )
+
+        while True:
+            try:
+                outcomes = await OrderDocumentCleanupService.process_batch(
+                    worker_id="scheduler-order-document-cleanup",
+                    limit=25,
+                )
+                if outcomes:
+                    logger.info(
+                        "Order document cleanup batch processed: total=%s deleted=%s retry=%s dead=%s",
+                        len(outcomes),
+                        sum(item.outcome == "deleted" for item in outcomes),
+                        sum(item.outcome == "retry_scheduled" for item in outcomes),
+                        sum(item.outcome == "dead" for item in outcomes),
+                    )
+                    await asyncio.sleep(1)
+                else:
+                    await asyncio.sleep(30)
+            except Exception:
+                logger.exception("Order document cleanup loop error")
+                await asyncio.sleep(60)
 
     async def _bank_mail_import_loop(self):
         while True:

--- a/tests/integration/test_manager_orders_api.py
+++ b/tests/integration/test_manager_orders_api.py
@@ -14,6 +14,7 @@ from models import (
     DocumentTemplate,
     GlobalConfig,
     Installer,
+    IntegrationOutboxEvent,
     Order,
     OrderDocument,
     OrderInstaller,
@@ -3407,15 +3408,16 @@ async def test_manager_order_delete_cascades_related_entities(async_client, db, 
     db.add(order)
     await db.commit()
     await db.refresh(order)
+    order_id = int(order.id)
 
-    db.add(OrderProductLink(order_id=order.id, product_id=product.id, quantity=1, price=4000, cost=2500))
-    db.add(OrderServiceLink(order_id=order.id, service_id=service.id, title=service.title, quantity=1, price=200, cost=80))
-    db.add(OrderInstaller(order_id=order.id, installer_id=installer.id, role="main", agreed_pay=100))
-    db.add(OrderWorkStage(order_id=order.id, name="Монтаж"))
-    db.add(Payment(order_id=order.id, amount=500))
+    db.add(OrderProductLink(order_id=order_id, product_id=product.id, quantity=1, price=4000, cost=2500))
+    db.add(OrderServiceLink(order_id=order_id, service_id=service.id, title=service.title, quantity=1, price=200, cost=80))
+    db.add(OrderInstaller(order_id=order_id, installer_id=installer.id, role="main", agreed_pay=100))
+    db.add(OrderWorkStage(order_id=order_id, name="Монтаж"))
+    db.add(Payment(order_id=order_id, amount=500))
     db.add(
         OrderDocument(
-            order_id=order.id,
+            order_id=order_id,
             doc_type="contract",
             number="D-DELETE-1",
             google_file_id="google-file-delete-1",
@@ -3431,28 +3433,40 @@ async def test_manager_order_delete_cascades_related_entities(async_client, db, 
     def _fake_delete_file(file_id):
         deleted_ids.append(file_id)
 
-    monkeypatch.setattr(get_google_service(), "delete_file", _fake_delete_file)
+    monkeypatch.setattr(get_google_service(), "delete_file_strict", _fake_delete_file)
 
     headers = await _auth_headers(async_client)
-    resp = await async_client.delete(f"/api/manager/orders/{order.id}", headers=headers)
+    resp = await async_client.delete(f"/api/manager/orders/{order_id}", headers=headers)
     assert resp.status_code == 200
     assert resp.json()["ok"] is True
 
-    assert await db.get(Order, order.id) is None
+    assert await db.get(Order, order_id) is None
 
-    plinks = await db.execute(select(OrderProductLink).where(OrderProductLink.order_id == order.id))
+    plinks = await db.execute(select(OrderProductLink).where(OrderProductLink.order_id == order_id))
     assert plinks.scalars().first() is None
-    slinks = await db.execute(select(OrderServiceLink).where(OrderServiceLink.order_id == order.id))
+    slinks = await db.execute(select(OrderServiceLink).where(OrderServiceLink.order_id == order_id))
     assert slinks.scalars().first() is None
-    installers = await db.execute(select(OrderInstaller).where(OrderInstaller.order_id == order.id))
+    installers = await db.execute(select(OrderInstaller).where(OrderInstaller.order_id == order_id))
     assert installers.scalars().first() is None
-    stages = await db.execute(select(OrderWorkStage).where(OrderWorkStage.order_id == order.id))
+    stages = await db.execute(select(OrderWorkStage).where(OrderWorkStage.order_id == order_id))
     assert stages.scalars().first() is None
-    payments = await db.execute(select(Payment).where(Payment.order_id == order.id))
+    payments = await db.execute(select(Payment).where(Payment.order_id == order_id))
     assert payments.scalars().first() is None
-    docs = await db.execute(select(OrderDocument).where(OrderDocument.order_id == order.id))
+    docs = await db.execute(select(OrderDocument).where(OrderDocument.order_id == order_id))
     assert docs.scalars().first() is None
-    assert "google-file-delete-1" in deleted_ids
+    cleanup_event = (
+        await db.execute(
+            select(IntegrationOutboxEvent).where(
+                IntegrationOutboxEvent.event_type
+                == "order.document.delete_requested.v1",
+                IntegrationOutboxEvent.aggregate_type == "order_document",
+            )
+        )
+    ).scalar_one()
+    assert cleanup_event.status == "pending"
+    assert cleanup_event.payload["order_id"] == order_id
+    assert cleanup_event.payload["google_file_id"] == "google-file-delete-1"
+    assert deleted_ids == []
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_google_service_security.py
+++ b/tests/unit/test_google_service_security.py
@@ -411,3 +411,61 @@ def test_list_files_propagates_provider_failure_instead_of_returning_empty(
 
     with pytest.raises(GoogleDriveListError, match="failed to list files"):
         service.list_files("backup-folder")
+
+
+def test_delete_file_strict_treats_provider_not_found_as_success(monkeypatch):
+    class FakeHttpError(Exception):
+        def __init__(self, status: int):
+            super().__init__(f"provider status {status}")
+            self.resp = type("Response", (), {"status": status})()
+
+    class DeleteRequest:
+        def execute(self):
+            raise FakeHttpError(404)
+
+    class DriveFiles:
+        def update(self, *, fileId, body):
+            assert fileId == "drive-file"
+            assert body == {"trashed": True}
+            return DeleteRequest()
+
+    class DriveService:
+        @staticmethod
+        def files():
+            return DriveFiles()
+
+    service = _service_without_authentication()
+    monkeypatch.setattr(service, "_require_credentials", lambda: object())
+    monkeypatch.setattr(google_service, "HttpError", FakeHttpError)
+    monkeypatch.setattr(google_service, "build", lambda *_args, **_kwargs: DriveService())
+
+    service.delete_file_strict(" drive-file ")
+
+
+def test_delete_file_strict_surfaces_retryable_provider_failure(monkeypatch):
+    class FakeHttpError(Exception):
+        def __init__(self, status: int):
+            super().__init__(f"provider status {status}")
+            self.resp = type("Response", (), {"status": status})()
+
+    class DeleteRequest:
+        def execute(self):
+            raise FakeHttpError(503)
+
+    class DriveFiles:
+        @staticmethod
+        def update(**_kwargs):
+            return DeleteRequest()
+
+    class DriveService:
+        @staticmethod
+        def files():
+            return DriveFiles()
+
+    service = _service_without_authentication()
+    monkeypatch.setattr(service, "_require_credentials", lambda: object())
+    monkeypatch.setattr(google_service, "HttpError", FakeHttpError)
+    monkeypatch.setattr(google_service, "build", lambda *_args, **_kwargs: DriveService())
+
+    with pytest.raises(FakeHttpError, match="provider status 503"):
+        service.delete_file_strict("drive-file")

--- a/tests/unit/test_order_delete_command_service.py
+++ b/tests/unit/test_order_delete_command_service.py
@@ -1,0 +1,91 @@
+from pathlib import Path
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import SQLModel, select
+
+from models import Customer, IntegrationOutboxEvent, Order, OrderDocument, OrderStatus
+from models.tenancy import TenantScope
+from services.order_delete_command_service import OrderDeleteCommandService
+from services.order_document_cleanup_service import OrderDocumentCleanupService
+
+
+TEST_TENANT_SCOPE = TenantScope(tenant_id=1, storefront_id=1, is_system=True)
+
+
+@pytest.fixture
+async def delete_session(tmp_path: Path):
+    engine = create_async_engine(
+        f"sqlite+aiosqlite:///{tmp_path / 'order_delete_command.db'}"
+    )
+    async with engine.begin() as connection:
+        await connection.run_sync(SQLModel.metadata.create_all)
+
+    factory = sessionmaker(
+        engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+    async with factory() as session:
+        yield session
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_delete_rolls_back_order_and_cleanup_event_together(
+    delete_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    customer = Customer(
+        tenant_id=TEST_TENANT_SCOPE.tenant_id,
+        name="Delete rollback customer",
+        phone="+375290000005",
+    )
+    delete_session.add(customer)
+    await delete_session.flush()
+    order = Order(
+        tenant_id=TEST_TENANT_SCOPE.tenant_id,
+        storefront_id=TEST_TENANT_SCOPE.storefront_id,
+        customer_id=customer.id,
+        status=OrderStatus.NEW_LEAD,
+    )
+    delete_session.add(order)
+    await delete_session.flush()
+    document = OrderDocument(
+        order_id=order.id,
+        doc_type="contract",
+        number="ROLLBACK-1",
+        google_file_id="drive-file-rollback",
+        google_edit_url="https://docs.google.com/document/d/drive-file-rollback/edit",
+    )
+    delete_session.add(document)
+    await delete_session.commit()
+    order_id = int(order.id)
+    document_id = int(document.id)
+
+    original_enqueue = OrderDocumentCleanupService.enqueue_order_documents
+
+    async def enqueue_then_fail(*args, **kwargs):
+        await original_enqueue(*args, **kwargs)
+        raise RuntimeError("injected final-step failure")
+
+    monkeypatch.setattr(
+        OrderDocumentCleanupService,
+        "enqueue_order_documents",
+        enqueue_then_fail,
+    )
+
+    with pytest.raises(RuntimeError, match="injected final-step failure"):
+        await OrderDeleteCommandService.delete_order(
+            delete_session,
+            order_id,
+            tenant_scope=TEST_TENANT_SCOPE,
+        )
+
+    assert await delete_session.get(Order, order_id) is not None
+    assert await delete_session.get(OrderDocument, document_id) is not None
+    events = list(
+        (await delete_session.execute(select(IntegrationOutboxEvent))).scalars()
+    )
+    assert events == []

--- a/tests/unit/test_order_document_cleanup_service.py
+++ b/tests/unit/test_order_document_cleanup_service.py
@@ -1,0 +1,163 @@
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import select
+
+from models import IntegrationOutboxEvent
+from models.tenancy import TenantScope
+from services.order_document_cleanup_service import (
+    ORDER_DOCUMENT_DELETE_REQUESTED_EVENT,
+    OrderDocumentCleanupService,
+)
+
+
+TEST_TENANT_SCOPE = TenantScope(tenant_id=1, storefront_id=1, is_system=True)
+
+
+@pytest.fixture
+async def cleanup_session_factory(tmp_path):
+    engine = create_async_engine(
+        f"sqlite+aiosqlite:///{tmp_path / 'document_cleanup.db'}"
+    )
+    async with engine.begin() as connection:
+        await connection.run_sync(IntegrationOutboxEvent.__table__.create)
+
+    factory = sessionmaker(
+        engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+async def _enqueue(cleanup_session_factory, *, file_id: str = "drive-file-1") -> str:
+    async with cleanup_session_factory() as session:
+        count = await OrderDocumentCleanupService.enqueue_order_documents(
+            session,
+            order_id=41,
+            documents=[SimpleNamespace(id=17, google_file_id=file_id)],
+            tenant_scope=TEST_TENANT_SCOPE,
+        )
+        assert count == 1
+        await session.commit()
+        event = (
+            await session.execute(
+                select(IntegrationOutboxEvent).where(
+                    IntegrationOutboxEvent.event_type
+                    == ORDER_DOCUMENT_DELETE_REQUESTED_EVENT
+                )
+            )
+        ).scalar_one()
+        return event.event_id
+
+
+class _SuccessfulGoogleService:
+    def __init__(self):
+        self.deleted_file_ids = []
+
+    def delete_file_strict(self, file_id: str) -> None:
+        self.deleted_file_ids.append(file_id)
+
+
+@pytest.mark.asyncio
+async def test_cleanup_worker_publishes_event_after_drive_delete(
+    cleanup_session_factory,
+):
+    event_id = await _enqueue(cleanup_session_factory)
+    google_service = _SuccessfulGoogleService()
+    now = datetime.now(timezone.utc) + timedelta(minutes=1)
+
+    outcome = await OrderDocumentCleanupService.process_next(
+        worker_id="test-cleanup-worker",
+        session_factory=cleanup_session_factory,
+        google_service=google_service,
+        now=now,
+    )
+
+    assert outcome is not None
+    assert outcome.event_id == event_id
+    assert outcome.outcome == "deleted"
+    assert google_service.deleted_file_ids == ["drive-file-1"]
+    async with cleanup_session_factory() as session:
+        event = await session.get(IntegrationOutboxEvent, event_id)
+        assert event is not None
+        assert event.status == "published"
+        assert event.attempts == 1
+        assert event.published_at is not None
+        assert event.worker_id is None
+        assert event.lease_token is None
+
+
+@pytest.mark.asyncio
+async def test_cleanup_worker_retries_provider_failure_then_succeeds(
+    cleanup_session_factory,
+):
+    event_id = await _enqueue(cleanup_session_factory, file_id="drive-file-retry")
+
+    class _FailingGoogleService:
+        def delete_file_strict(self, _file_id: str) -> None:
+            raise RuntimeError("temporary provider failure")
+
+    first_time = datetime.now(timezone.utc) + timedelta(minutes=1)
+    first = await OrderDocumentCleanupService.process_next(
+        worker_id="test-cleanup-worker",
+        session_factory=cleanup_session_factory,
+        google_service=_FailingGoogleService(),
+        now=first_time,
+    )
+    assert first is not None
+    assert first.outcome == "retry_scheduled"
+    assert first.next_attempt_at is not None
+
+    successful_service = _SuccessfulGoogleService()
+    second = await OrderDocumentCleanupService.process_next(
+        worker_id="test-cleanup-worker",
+        session_factory=cleanup_session_factory,
+        google_service=successful_service,
+        now=first.next_attempt_at + timedelta(seconds=1),
+    )
+    assert second is not None
+    assert second.outcome == "deleted"
+    assert second.attempts == 2
+    assert successful_service.deleted_file_ids == ["drive-file-retry"]
+
+    async with cleanup_session_factory() as session:
+        event = await session.get(IntegrationOutboxEvent, event_id)
+        assert event is not None
+        assert event.status == "published"
+        assert event.attempts == 2
+
+
+@pytest.mark.asyncio
+async def test_cleanup_worker_reclaims_expired_processing_lease(
+    cleanup_session_factory,
+):
+    event_id = await _enqueue(cleanup_session_factory, file_id="drive-file-expired")
+    now = datetime.now(timezone.utc) + timedelta(minutes=1)
+    async with cleanup_session_factory() as session:
+        event = await session.get(IntegrationOutboxEvent, event_id)
+        assert event is not None
+        event.status = "processing"
+        event.worker_id = "crashed-worker"
+        event.lease_token = "expired-token"
+        event.lease_expires_at = now - timedelta(seconds=1)
+        session.add(event)
+        await session.commit()
+
+    google_service = _SuccessfulGoogleService()
+    outcome = await OrderDocumentCleanupService.process_next(
+        worker_id="recovery-worker",
+        session_factory=cleanup_session_factory,
+        google_service=google_service,
+        now=now,
+    )
+
+    assert outcome is not None
+    assert outcome.outcome == "deleted"
+    assert google_service.deleted_file_ids == ["drive-file-expired"]


### PR DESCRIPTION
## Что изменено
- удаление Order вынесено в отдельный transactional command handler;
- внешняя очистка Google Drive больше не выполняется внутри транзакции БД;
- добавлен durable cleanup outbox с lease, retry/backoff и обработкой scheduler;
- повторная обработка идемпотентна, а ошибка внешнего провайдера не возвращает удалённый Order и не оставляет частичный commit;
- внешний Manager API и OpenAPI-контракт не изменены.

## Проверка
- 85 профильных unit/integration тестов после rebase на актуальный `main`;
- повторная генерация OpenAPI без diff;
- `git diff --check`.
