### PR TITLE
Split the Manager order workspace into focused modules

### DIFF
--- a/docs/order-domain-refactor.md
+++ b/docs/order-domain-refactor.md
@@ -82,16 +82,23 @@ domain at a time and verify generated client output after every move.
 
 Split `OrderEditDrawer.vue` along user-visible responsibilities:
 
-- customer/object context;
-- proposal and commercial lines;
-- execution planning and installers;
-- repair workflow;
-- payments and bank receipts;
-- documents, mail and attachments.
+- [x] customer/object context;
+- [x] proposal and commercial lines;
+- [x] execution planning and installers;
+- [x] repair workflow;
+- [x] payments and bank receipts;
+- [x] documents, mail and attachments.
 
 Shared network/draft state belongs in typed composables. The drawer remains the
 orchestrator and should not duplicate section state. Every extraction requires
 component tests plus a production build.
+
+Completed result: `OrderEditDrawer.vue` is 640 lines (down from about 4,200).
+Commercial search and estimates, proposal lifecycle, form validation, draft
+persistence, document status, navigation and destructive actions now have
+separate typed composables. User-visible workspaces have focused component
+tests; the full Manager component suite, UI logic audit, TypeScript check and
+production build pass.
 
 ## Stop condition
 

--- a/manager_frontend/package.json
+++ b/manager_frontend/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vue-tsc -b && vite build",
     "test:ui-logic": "node scripts/audit-native-dialogs.mjs && node scripts/run-ui-logic-tests.mjs",
-    "test:components": "vitest run --environment jsdom tests/lead-inbox-attachments.spec.ts tests/order-payments-panel.spec.ts",
+    "test:components": "vitest run --environment jsdom tests/lead-inbox-attachments.spec.ts tests/order-payments-panel.spec.ts tests/order-website-intake-panel.spec.ts tests/order-planning-panel.spec.ts",
     "preview": "vite preview",
     "gen:api": "openapi --input ../openapi.json --output ./src/client --client fetch --useUnionTypes"
   },

--- a/manager_frontend/package.json
+++ b/manager_frontend/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vue-tsc -b && vite build",
     "test:ui-logic": "node scripts/audit-native-dialogs.mjs && node scripts/run-ui-logic-tests.mjs",
-    "test:components": "vitest run --environment jsdom tests/lead-inbox-attachments.spec.ts tests/order-payments-panel.spec.ts tests/order-website-intake-panel.spec.ts tests/order-planning-panel.spec.ts tests/order-repair-panel.spec.ts tests/order-commercial-lines.spec.ts tests/order-commercial-editor.spec.ts tests/order-proposal-lifecycle.spec.ts tests/order-drawer-form.spec.ts tests/order-drawer-persistence.spec.ts tests/order-document-status.spec.ts tests/order-workspace-navigation.spec.ts tests/order-drawer-actions.spec.ts tests/order-customer-context.spec.ts tests/order-execution-panel.spec.ts tests/order-documents-workspace.spec.ts",
+    "test:components": "vitest run --environment jsdom tests/lead-inbox-attachments.spec.ts tests/order-payments-panel.spec.ts tests/order-website-intake-panel.spec.ts tests/order-planning-panel.spec.ts tests/order-repair-panel.spec.ts tests/order-commercial-lines.spec.ts tests/order-commercial-editor.spec.ts tests/order-proposal-lifecycle.spec.ts tests/order-proposal-workspace.spec.ts tests/order-drawer-form.spec.ts tests/order-drawer-persistence.spec.ts tests/order-document-status.spec.ts tests/order-workspace-navigation.spec.ts tests/order-drawer-actions.spec.ts tests/order-manager-labels.spec.ts tests/order-customer-context.spec.ts tests/order-execution-panel.spec.ts tests/order-documents-workspace.spec.ts",
     "preview": "vite preview",
     "gen:api": "openapi --input ../openapi.json --output ./src/client --client fetch --useUnionTypes"
   },

--- a/manager_frontend/package.json
+++ b/manager_frontend/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vue-tsc -b && vite build",
     "test:ui-logic": "node scripts/audit-native-dialogs.mjs && node scripts/run-ui-logic-tests.mjs",
-    "test:components": "vitest run --environment jsdom tests/lead-inbox-attachments.spec.ts tests/order-payments-panel.spec.ts tests/order-website-intake-panel.spec.ts tests/order-planning-panel.spec.ts",
+    "test:components": "vitest run --environment jsdom tests/lead-inbox-attachments.spec.ts tests/order-payments-panel.spec.ts tests/order-website-intake-panel.spec.ts tests/order-planning-panel.spec.ts tests/order-repair-panel.spec.ts",
     "preview": "vite preview",
     "gen:api": "openapi --input ../openapi.json --output ./src/client --client fetch --useUnionTypes"
   },

--- a/manager_frontend/package.json
+++ b/manager_frontend/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vue-tsc -b && vite build",
     "test:ui-logic": "node scripts/audit-native-dialogs.mjs && node scripts/run-ui-logic-tests.mjs",
-    "test:components": "vitest run --environment jsdom tests/lead-inbox-attachments.spec.ts tests/order-payments-panel.spec.ts tests/order-website-intake-panel.spec.ts tests/order-planning-panel.spec.ts tests/order-repair-panel.spec.ts tests/order-commercial-lines.spec.ts tests/order-commercial-editor.spec.ts tests/order-proposal-lifecycle.spec.ts tests/order-drawer-form.spec.ts tests/order-drawer-persistence.spec.ts tests/order-document-status.spec.ts tests/order-workspace-navigation.spec.ts tests/order-customer-context.spec.ts tests/order-execution-panel.spec.ts tests/order-documents-workspace.spec.ts",
+    "test:components": "vitest run --environment jsdom tests/lead-inbox-attachments.spec.ts tests/order-payments-panel.spec.ts tests/order-website-intake-panel.spec.ts tests/order-planning-panel.spec.ts tests/order-repair-panel.spec.ts tests/order-commercial-lines.spec.ts tests/order-commercial-editor.spec.ts tests/order-proposal-lifecycle.spec.ts tests/order-drawer-form.spec.ts tests/order-drawer-persistence.spec.ts tests/order-document-status.spec.ts tests/order-workspace-navigation.spec.ts tests/order-drawer-actions.spec.ts tests/order-customer-context.spec.ts tests/order-execution-panel.spec.ts tests/order-documents-workspace.spec.ts",
     "preview": "vite preview",
     "gen:api": "openapi --input ../openapi.json --output ./src/client --client fetch --useUnionTypes"
   },

--- a/manager_frontend/package.json
+++ b/manager_frontend/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vue-tsc -b && vite build",
     "test:ui-logic": "node scripts/audit-native-dialogs.mjs && node scripts/run-ui-logic-tests.mjs",
-    "test:components": "vitest run --environment jsdom tests/lead-inbox-attachments.spec.ts tests/order-payments-panel.spec.ts tests/order-website-intake-panel.spec.ts tests/order-planning-panel.spec.ts tests/order-repair-panel.spec.ts tests/order-commercial-lines.spec.ts",
+    "test:components": "vitest run --environment jsdom tests/lead-inbox-attachments.spec.ts tests/order-payments-panel.spec.ts tests/order-website-intake-panel.spec.ts tests/order-planning-panel.spec.ts tests/order-repair-panel.spec.ts tests/order-commercial-lines.spec.ts tests/order-customer-context.spec.ts",
     "preview": "vite preview",
     "gen:api": "openapi --input ../openapi.json --output ./src/client --client fetch --useUnionTypes"
   },

--- a/manager_frontend/package.json
+++ b/manager_frontend/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vue-tsc -b && vite build",
     "test:ui-logic": "node scripts/audit-native-dialogs.mjs && node scripts/run-ui-logic-tests.mjs",
-    "test:components": "vitest run --environment jsdom tests/lead-inbox-attachments.spec.ts tests/order-payments-panel.spec.ts tests/order-website-intake-panel.spec.ts tests/order-planning-panel.spec.ts tests/order-repair-panel.spec.ts tests/order-commercial-lines.spec.ts tests/order-commercial-editor.spec.ts tests/order-proposal-lifecycle.spec.ts tests/order-customer-context.spec.ts tests/order-execution-panel.spec.ts tests/order-documents-workspace.spec.ts",
+    "test:components": "vitest run --environment jsdom tests/lead-inbox-attachments.spec.ts tests/order-payments-panel.spec.ts tests/order-website-intake-panel.spec.ts tests/order-planning-panel.spec.ts tests/order-repair-panel.spec.ts tests/order-commercial-lines.spec.ts tests/order-commercial-editor.spec.ts tests/order-proposal-lifecycle.spec.ts tests/order-drawer-form.spec.ts tests/order-customer-context.spec.ts tests/order-execution-panel.spec.ts tests/order-documents-workspace.spec.ts",
     "preview": "vite preview",
     "gen:api": "openapi --input ../openapi.json --output ./src/client --client fetch --useUnionTypes"
   },

--- a/manager_frontend/package.json
+++ b/manager_frontend/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vue-tsc -b && vite build",
     "test:ui-logic": "node scripts/audit-native-dialogs.mjs && node scripts/run-ui-logic-tests.mjs",
-    "test:components": "vitest run --environment jsdom tests/lead-inbox-attachments.spec.ts tests/order-payments-panel.spec.ts tests/order-website-intake-panel.spec.ts tests/order-planning-panel.spec.ts tests/order-repair-panel.spec.ts tests/order-commercial-lines.spec.ts tests/order-commercial-editor.spec.ts tests/order-customer-context.spec.ts tests/order-execution-panel.spec.ts tests/order-documents-workspace.spec.ts",
+    "test:components": "vitest run --environment jsdom tests/lead-inbox-attachments.spec.ts tests/order-payments-panel.spec.ts tests/order-website-intake-panel.spec.ts tests/order-planning-panel.spec.ts tests/order-repair-panel.spec.ts tests/order-commercial-lines.spec.ts tests/order-commercial-editor.spec.ts tests/order-proposal-lifecycle.spec.ts tests/order-customer-context.spec.ts tests/order-execution-panel.spec.ts tests/order-documents-workspace.spec.ts",
     "preview": "vite preview",
     "gen:api": "openapi --input ../openapi.json --output ./src/client --client fetch --useUnionTypes"
   },

--- a/manager_frontend/package.json
+++ b/manager_frontend/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vue-tsc -b && vite build",
     "test:ui-logic": "node scripts/audit-native-dialogs.mjs && node scripts/run-ui-logic-tests.mjs",
-    "test:components": "vitest run --environment jsdom tests/lead-inbox-attachments.spec.ts tests/order-payments-panel.spec.ts tests/order-website-intake-panel.spec.ts tests/order-planning-panel.spec.ts tests/order-repair-panel.spec.ts tests/order-commercial-lines.spec.ts tests/order-customer-context.spec.ts tests/order-execution-panel.spec.ts tests/order-documents-workspace.spec.ts",
+    "test:components": "vitest run --environment jsdom tests/lead-inbox-attachments.spec.ts tests/order-payments-panel.spec.ts tests/order-website-intake-panel.spec.ts tests/order-planning-panel.spec.ts tests/order-repair-panel.spec.ts tests/order-commercial-lines.spec.ts tests/order-commercial-editor.spec.ts tests/order-customer-context.spec.ts tests/order-execution-panel.spec.ts tests/order-documents-workspace.spec.ts",
     "preview": "vite preview",
     "gen:api": "openapi --input ../openapi.json --output ./src/client --client fetch --useUnionTypes"
   },

--- a/manager_frontend/package.json
+++ b/manager_frontend/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vue-tsc -b && vite build",
     "test:ui-logic": "node scripts/audit-native-dialogs.mjs && node scripts/run-ui-logic-tests.mjs",
-    "test:components": "vitest run --environment jsdom tests/lead-inbox-attachments.spec.ts tests/order-payments-panel.spec.ts tests/order-website-intake-panel.spec.ts tests/order-planning-panel.spec.ts tests/order-repair-panel.spec.ts tests/order-commercial-lines.spec.ts tests/order-commercial-editor.spec.ts tests/order-proposal-lifecycle.spec.ts tests/order-drawer-form.spec.ts tests/order-drawer-persistence.spec.ts tests/order-document-status.spec.ts tests/order-customer-context.spec.ts tests/order-execution-panel.spec.ts tests/order-documents-workspace.spec.ts",
+    "test:components": "vitest run --environment jsdom tests/lead-inbox-attachments.spec.ts tests/order-payments-panel.spec.ts tests/order-website-intake-panel.spec.ts tests/order-planning-panel.spec.ts tests/order-repair-panel.spec.ts tests/order-commercial-lines.spec.ts tests/order-commercial-editor.spec.ts tests/order-proposal-lifecycle.spec.ts tests/order-drawer-form.spec.ts tests/order-drawer-persistence.spec.ts tests/order-document-status.spec.ts tests/order-workspace-navigation.spec.ts tests/order-customer-context.spec.ts tests/order-execution-panel.spec.ts tests/order-documents-workspace.spec.ts",
     "preview": "vite preview",
     "gen:api": "openapi --input ../openapi.json --output ./src/client --client fetch --useUnionTypes"
   },

--- a/manager_frontend/package.json
+++ b/manager_frontend/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vue-tsc -b && vite build",
     "test:ui-logic": "node scripts/audit-native-dialogs.mjs && node scripts/run-ui-logic-tests.mjs",
-    "test:components": "vitest run --environment jsdom tests/lead-inbox-attachments.spec.ts tests/order-payments-panel.spec.ts tests/order-website-intake-panel.spec.ts tests/order-planning-panel.spec.ts tests/order-repair-panel.spec.ts tests/order-commercial-lines.spec.ts tests/order-commercial-editor.spec.ts tests/order-proposal-lifecycle.spec.ts tests/order-drawer-form.spec.ts tests/order-drawer-persistence.spec.ts tests/order-customer-context.spec.ts tests/order-execution-panel.spec.ts tests/order-documents-workspace.spec.ts",
+    "test:components": "vitest run --environment jsdom tests/lead-inbox-attachments.spec.ts tests/order-payments-panel.spec.ts tests/order-website-intake-panel.spec.ts tests/order-planning-panel.spec.ts tests/order-repair-panel.spec.ts tests/order-commercial-lines.spec.ts tests/order-commercial-editor.spec.ts tests/order-proposal-lifecycle.spec.ts tests/order-drawer-form.spec.ts tests/order-drawer-persistence.spec.ts tests/order-document-status.spec.ts tests/order-customer-context.spec.ts tests/order-execution-panel.spec.ts tests/order-documents-workspace.spec.ts",
     "preview": "vite preview",
     "gen:api": "openapi --input ../openapi.json --output ./src/client --client fetch --useUnionTypes"
   },

--- a/manager_frontend/package.json
+++ b/manager_frontend/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vue-tsc -b && vite build",
     "test:ui-logic": "node scripts/audit-native-dialogs.mjs && node scripts/run-ui-logic-tests.mjs",
-    "test:components": "vitest run --environment jsdom tests/lead-inbox-attachments.spec.ts",
+    "test:components": "vitest run --environment jsdom tests/lead-inbox-attachments.spec.ts tests/order-payments-panel.spec.ts",
     "preview": "vite preview",
     "gen:api": "openapi --input ../openapi.json --output ./src/client --client fetch --useUnionTypes"
   },

--- a/manager_frontend/package.json
+++ b/manager_frontend/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vue-tsc -b && vite build",
     "test:ui-logic": "node scripts/audit-native-dialogs.mjs && node scripts/run-ui-logic-tests.mjs",
-    "test:components": "vitest run --environment jsdom tests/lead-inbox-attachments.spec.ts tests/order-payments-panel.spec.ts tests/order-website-intake-panel.spec.ts tests/order-planning-panel.spec.ts tests/order-repair-panel.spec.ts tests/order-commercial-lines.spec.ts tests/order-commercial-editor.spec.ts tests/order-proposal-lifecycle.spec.ts tests/order-drawer-form.spec.ts tests/order-customer-context.spec.ts tests/order-execution-panel.spec.ts tests/order-documents-workspace.spec.ts",
+    "test:components": "vitest run --environment jsdom tests/lead-inbox-attachments.spec.ts tests/order-payments-panel.spec.ts tests/order-website-intake-panel.spec.ts tests/order-planning-panel.spec.ts tests/order-repair-panel.spec.ts tests/order-commercial-lines.spec.ts tests/order-commercial-editor.spec.ts tests/order-proposal-lifecycle.spec.ts tests/order-drawer-form.spec.ts tests/order-drawer-persistence.spec.ts tests/order-customer-context.spec.ts tests/order-execution-panel.spec.ts tests/order-documents-workspace.spec.ts",
     "preview": "vite preview",
     "gen:api": "openapi --input ../openapi.json --output ./src/client --client fetch --useUnionTypes"
   },

--- a/manager_frontend/package.json
+++ b/manager_frontend/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vue-tsc -b && vite build",
     "test:ui-logic": "node scripts/audit-native-dialogs.mjs && node scripts/run-ui-logic-tests.mjs",
-    "test:components": "vitest run --environment jsdom tests/lead-inbox-attachments.spec.ts tests/order-payments-panel.spec.ts tests/order-website-intake-panel.spec.ts tests/order-planning-panel.spec.ts tests/order-repair-panel.spec.ts tests/order-commercial-lines.spec.ts tests/order-customer-context.spec.ts",
+    "test:components": "vitest run --environment jsdom tests/lead-inbox-attachments.spec.ts tests/order-payments-panel.spec.ts tests/order-website-intake-panel.spec.ts tests/order-planning-panel.spec.ts tests/order-repair-panel.spec.ts tests/order-commercial-lines.spec.ts tests/order-customer-context.spec.ts tests/order-execution-panel.spec.ts",
     "preview": "vite preview",
     "gen:api": "openapi --input ../openapi.json --output ./src/client --client fetch --useUnionTypes"
   },

--- a/manager_frontend/package.json
+++ b/manager_frontend/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vue-tsc -b && vite build",
     "test:ui-logic": "node scripts/audit-native-dialogs.mjs && node scripts/run-ui-logic-tests.mjs",
-    "test:components": "vitest run --environment jsdom tests/lead-inbox-attachments.spec.ts tests/order-payments-panel.spec.ts tests/order-website-intake-panel.spec.ts tests/order-planning-panel.spec.ts tests/order-repair-panel.spec.ts",
+    "test:components": "vitest run --environment jsdom tests/lead-inbox-attachments.spec.ts tests/order-payments-panel.spec.ts tests/order-website-intake-panel.spec.ts tests/order-planning-panel.spec.ts tests/order-repair-panel.spec.ts tests/order-commercial-lines.spec.ts",
     "preview": "vite preview",
     "gen:api": "openapi --input ../openapi.json --output ./src/client --client fetch --useUnionTypes"
   },

--- a/manager_frontend/package.json
+++ b/manager_frontend/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vue-tsc -b && vite build",
     "test:ui-logic": "node scripts/audit-native-dialogs.mjs && node scripts/run-ui-logic-tests.mjs",
-    "test:components": "vitest run --environment jsdom tests/lead-inbox-attachments.spec.ts tests/order-payments-panel.spec.ts tests/order-website-intake-panel.spec.ts tests/order-planning-panel.spec.ts tests/order-repair-panel.spec.ts tests/order-commercial-lines.spec.ts tests/order-customer-context.spec.ts tests/order-execution-panel.spec.ts",
+    "test:components": "vitest run --environment jsdom tests/lead-inbox-attachments.spec.ts tests/order-payments-panel.spec.ts tests/order-website-intake-panel.spec.ts tests/order-planning-panel.spec.ts tests/order-repair-panel.spec.ts tests/order-commercial-lines.spec.ts tests/order-customer-context.spec.ts tests/order-execution-panel.spec.ts tests/order-documents-workspace.spec.ts",
     "preview": "vite preview",
     "gen:api": "openapi --input ../openapi.json --output ./src/client --client fetch --useUnionTypes"
   },

--- a/manager_frontend/src/components/orders/OrderCustomerContext.vue
+++ b/manager_frontend/src/components/orders/OrderCustomerContext.vue
@@ -1,0 +1,299 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue';
+import { useDebounceFn } from '@vueuse/core';
+import { api } from '../../api';
+import type {
+  ManagerCatalogCustomerItemResponse,
+  ManagerCustomerBranchItemResponse,
+  ManagerOrderDetailResponse,
+} from '../../client';
+import { getApiErrorMessage } from '../../utils/api-errors';
+import AddressSuggestInput from '../ui/AddressSuggestInput.vue';
+import OrderCustomerObjectSummary from './OrderCustomerObjectSummary.vue';
+import OrderDrawerSection from './OrderDrawerSection.vue';
+
+const props = defineProps<{
+  order: ManagerOrderDetailResponse;
+  addressError?: string;
+  commentError?: string;
+}>();
+
+const emit = defineEmits<{
+  toast: [payload: { message: string; type: 'success' | 'error' }];
+  updated: [order: ManagerOrderDetailResponse];
+  reload: [orderId: number];
+}>();
+
+const deliveryAddress = defineModel<string>('deliveryAddress', { required: true });
+const customerBranchId = defineModel<number | null>('customerBranchId', { required: true });
+const comment = defineModel<string>('comment', { required: true });
+const expanded = defineModel<boolean>('expanded', { required: true });
+const newBranchAddress = defineModel<string>('newBranchAddress', { required: true });
+
+const branches = ref<ManagerCustomerBranchItemResponse[]>([]);
+const branchesLoading = ref(false);
+const creatingBranch = ref(false);
+const newBranchName = ref('');
+const showBranchFields = ref(false);
+const savingCustomer = ref(false);
+const showCustomerSearch = ref(false);
+const customerSearchQuery = ref('');
+const customerSearchResults = ref<ManagerCatalogCustomerItemResponse[]>([]);
+const customerSearchLoading = ref(false);
+let branchesRequestId = 0;
+let customerSearchRequestId = 0;
+
+const customer = computed(() => props.order.customer ?? null);
+const selectedBranch = computed(() => (
+  branches.value.find((branch) => branch.id === customerBranchId.value)
+  || props.order.customer_branch
+  || null
+));
+const objectAddress = computed(() => (
+  deliveryAddress.value.trim() || selectedBranch.value?.delivery_address || ''
+));
+const sectionSummary = computed(() => (
+  customerBranchId.value ? 'Филиал и дополнительные данные' : 'Адрес и комментарий'
+));
+
+const notify = (message: string, type: 'success' | 'error') => {
+  emit('toast', { message, type });
+};
+
+const resetBranches = () => {
+  branchesRequestId += 1;
+  branches.value = [];
+  customerBranchId.value = null;
+  branchesLoading.value = false;
+  creatingBranch.value = false;
+  newBranchName.value = '';
+  newBranchAddress.value = '';
+};
+
+const loadBranches = async (customerId: number, preferredBranchId?: number | null) => {
+  const requestId = ++branchesRequestId;
+  branchesLoading.value = true;
+  try {
+    const response = await api.getManagerCustomerBranches(customerId);
+    if (requestId !== branchesRequestId) return;
+    branches.value = response.items || [];
+    if (!branches.value.length || preferredBranchId === null) {
+      customerBranchId.value = null;
+      return;
+    }
+    const preferredFromOrder = typeof preferredBranchId === 'number'
+      ? branches.value.find((branch) => branch.id === preferredBranchId)
+      : null;
+    const preferred = preferredFromOrder
+      || branches.value.find((branch) => branch.is_default)
+      || branches.value[0]
+      || null;
+    customerBranchId.value = preferred?.id || null;
+  } catch (error) {
+    if (requestId !== branchesRequestId) return;
+    console.error('Failed to load customer branches', error);
+    resetBranches();
+  } finally {
+    if (requestId === branchesRequestId) branchesLoading.value = false;
+  }
+};
+
+const onBranchChange = (event: Event) => {
+  const value = (event.target as HTMLSelectElement).value;
+  customerBranchId.value = value ? Number(value) : null;
+  const branch = branches.value.find((item) => item.id === customerBranchId.value) || null;
+  if (branch) deliveryAddress.value = branch.delivery_address;
+};
+
+const createBranch = async () => {
+  const customerId = customer.value?.id;
+  if (!customerId || creatingBranch.value) return;
+  const address = newBranchAddress.value.trim();
+  if (!address) {
+    notify('Введите адрес филиала', 'error');
+    return;
+  }
+  creatingBranch.value = true;
+  try {
+    const created = await api.createManagerCustomerBranch(customerId, {
+      name: newBranchName.value.trim() || undefined,
+      delivery_address: address,
+      is_default: branches.value.length === 0,
+    });
+    branches.value = [created, ...branches.value.filter((branch) => branch.id !== created.id)];
+    customerBranchId.value = created.id;
+    deliveryAddress.value = created.delivery_address;
+    newBranchName.value = '';
+    newBranchAddress.value = '';
+    notify('Филиал создан', 'success');
+  } catch (error) {
+    notify(`Ошибка создания филиала: ${getApiErrorMessage(error)}`, 'error');
+  } finally {
+    creatingBranch.value = false;
+  }
+};
+
+const copyText = async (value: string | null | undefined, label: string) => {
+  const normalized = String(value || '').trim();
+  if (!normalized) {
+    notify(`${label} отсутствует`, 'error');
+    return;
+  }
+  try {
+    await navigator.clipboard.writeText(normalized);
+    notify(`${label} скопирован`, 'success');
+  } catch {
+    notify(`Не удалось скопировать ${label.toLowerCase()}`, 'error');
+  }
+};
+
+const openCustomerProfile = () => {
+  if (!customer.value?.id) return;
+  const returnTo = `${window.location.pathname}${window.location.search}`;
+  const query = new URLSearchParams({
+    customerId: String(customer.value.id),
+    returnTo,
+  });
+  window.history.pushState({}, '', `/manager/customers/profile?${query.toString()}`);
+  window.dispatchEvent(new PopStateEvent('popstate'));
+};
+
+const saveCustomer = async (payload: { name: string; phone: string; email: string }) => {
+  const customerId = customer.value?.id;
+  if (!customerId || savingCustomer.value) return;
+  savingCustomer.value = true;
+  try {
+    await api.patchManagerCustomer(customerId, {
+      name: payload.name,
+      full_legal_name: customer.value?.type === 'company' ? payload.name : undefined,
+      phone: payload.phone || null,
+      email: payload.email || null,
+    });
+    notify('Контакты клиента обновлены', 'success');
+    emit('reload', props.order.id);
+  } catch (error) {
+    notify(`Не удалось обновить клиента: ${getApiErrorMessage(error)}`, 'error');
+  } finally {
+    savingCustomer.value = false;
+  }
+};
+
+const debouncedSearchCustomer = useDebounceFn(async (query: string) => {
+  const requestId = ++customerSearchRequestId;
+  if (query.length < 3) {
+    customerSearchResults.value = [];
+    customerSearchLoading.value = false;
+    return;
+  }
+  customerSearchLoading.value = true;
+  try {
+    const response = await api.getManagerCustomers(1, 10, query);
+    if (requestId !== customerSearchRequestId || query !== customerSearchQuery.value) return;
+    customerSearchResults.value = response.items || [];
+  } catch (error) {
+    if (requestId === customerSearchRequestId) console.error('Customer search error', error);
+  } finally {
+    if (requestId === customerSearchRequestId) customerSearchLoading.value = false;
+  }
+}, 400);
+
+const assignCustomer = async (newCustomer: ManagerCatalogCustomerItemResponse) => {
+  try {
+    const updated = await api.patchManagerOrder(props.order.id, { customer_id: newCustomer.id });
+    showCustomerSearch.value = false;
+    emit('updated', updated);
+    emit('reload', updated.id);
+    notify('Клиент успешно изменен', 'success');
+  } catch (error) {
+    notify(`Ошибка смены клиента: ${getApiErrorMessage(error)}`, 'error');
+  }
+};
+
+watch(
+  () => [props.order.id, props.order.customer?.id, props.order.customer_branch?.id],
+  () => {
+    const customerId = props.order.customer?.id;
+    if (customerId) void loadBranches(customerId, props.order.customer_branch?.id ?? null);
+    else resetBranches();
+  },
+  { immediate: true },
+);
+</script>
+
+<template>
+  <OrderCustomerObjectSummary
+    :customer="customer"
+    :branch="selectedBranch"
+    :address="objectAddress"
+    :has-comment="Boolean(comment.trim())"
+    :saving-customer="savingCustomer"
+    @copy="copyText"
+    @save-customer="saveCustomer"
+    @update:address="deliveryAddress = $event"
+    @open-customer="openCustomerProfile"
+    @change-customer="showCustomerSearch = true"
+    @toggle-branch="showBranchFields = !showBranchFields"
+  />
+
+  <div v-if="showBranchFields && customer?.id" class="mt-2 grid gap-2 rounded-xl border border-slate-200 bg-slate-50 p-3 dark:border-slate-700 dark:bg-slate-900 sm:grid-cols-2">
+    <label class="field-label sm:col-span-2">
+      Филиал клиента
+      <select :value="customerBranchId ?? ''" data-testid="customer-branch" class="field-input mt-1" :disabled="branchesLoading" @change="onBranchChange">
+        <option value="">Без филиала</option>
+        <option v-for="branch in branches" :key="branch.id" :value="branch.id">{{ branch.name || `Филиал #${branch.id}` }} — {{ branch.delivery_address }}</option>
+      </select>
+    </label>
+    <input v-model="newBranchName" class="field-input" placeholder="Название нового филиала" />
+    <AddressSuggestInput v-model="newBranchAddress" placeholder="Адрес нового филиала" />
+    <div class="flex justify-end sm:col-span-2">
+      <button type="button" class="btn-mini-outline text-xs" :disabled="creatingBranch" @click="createBranch">{{ creatingBranch ? 'Создаём...' : 'Создать и выбрать' }}</button>
+    </div>
+  </div>
+
+  <slot />
+
+  <OrderDrawerSection
+    id="order-workspace-object"
+    v-model:expanded="expanded"
+    title="Подробнее об объекте"
+    :summary="sectionSummary"
+    tone="default"
+    :has-error="Boolean(addressError || commentError)"
+  >
+    <div class="grid gap-3 md:grid-cols-2">
+      <AddressSuggestInput v-model="deliveryAddress" class="md:col-span-2" label="Адрес объекта / доставки" placeholder="Введите адрес..." :error="addressError" />
+      <label class="field-label md:col-span-2">
+        Комментарий
+        <textarea v-model="comment" class="field-input min-h-[90px]" :class="commentError ? 'border-red-500 focus:outline-red-400' : ''" />
+        <span v-if="commentError" class="text-xs text-red-300">{{ commentError }}</span>
+      </label>
+    </div>
+  </OrderDrawerSection>
+
+  <Transition name="fade">
+    <div v-if="showCustomerSearch" class="fixed inset-0 z-[60] flex items-center justify-center bg-black/60 p-4 backdrop-blur-sm" @click.self="showCustomerSearch = false">
+      <div class="flex max-h-[85vh] w-full max-w-lg flex-col overflow-hidden rounded-2xl bg-white shadow-2xl">
+        <div class="flex items-center justify-between border-b border-gray-100 bg-slate-50/50 px-6 py-4 shadow-sm">
+          <h3 class="flex items-center gap-2 text-lg font-bold text-slate-800"><span class="material-icons-round text-slate-500">swap_horiz</span>Сменить клиента для заказа</h3>
+          <button class="flex h-8 w-8 items-center justify-center rounded-full bg-slate-100 text-slate-500 transition-colors hover:bg-slate-200" @click="showCustomerSearch = false"><span class="material-icons-round text-[18px]">close</span></button>
+        </div>
+        <div class="overflow-y-auto p-6">
+          <div class="relative mb-4">
+            <span class="material-icons-round absolute left-4 top-1/2 -translate-y-1/2 text-slate-400">search</span>
+            <input v-model="customerSearchQuery" data-testid="customer-search" type="text" class="w-full rounded-xl border-none bg-slate-50 py-3 pl-11 pr-4 text-sm transition-shadow focus:ring-2 focus:ring-teal-500" placeholder="Поиск по телефону, УНП, имени..." autofocus @input="debouncedSearchCustomer(customerSearchQuery)" />
+            <span v-if="customerSearchLoading" class="material-icons-round absolute right-4 top-1/2 -translate-y-1/2 animate-spin text-teal-500">refresh</span>
+          </div>
+          <div v-if="customerSearchQuery.length >= 3 && !customerSearchResults.length && !customerSearchLoading" class="rounded-xl border border-dashed border-slate-100 bg-slate-50 py-6 text-center text-sm text-slate-500">Клиенты не найдены</div>
+          <div v-if="customerSearchQuery.length < 3" class="py-6 text-center text-xs font-semibold uppercase tracking-wider text-slate-400">Введите минимум 3 символа</div>
+          <div class="mt-2 space-y-2">
+            <button v-for="result in customerSearchResults" :key="result.id" type="button" :data-testid="`assign-customer-${result.id}`" class="group flex w-full flex-col gap-1 rounded-xl border border-slate-100 bg-white p-4 text-left outline-none transition-all hover:-translate-y-0.5 hover:border-teal-200 hover:shadow-md focus:ring-2 focus:ring-teal-500" @click="assignCustomer(result)">
+              <span class="text-sm font-bold text-slate-800 transition-colors group-hover:text-teal-700">{{ result.full_legal_name || result.name || `Клиент #${result.id}` }}</span>
+              <span class="flex flex-wrap gap-x-3 gap-y-1 text-xs text-slate-500"><span v-if="result.phone">{{ result.phone }}</span><span v-if="result.inn">УНП: {{ result.inn }}</span></span>
+            </button>
+          </div>
+        </div>
+        <div class="flex justify-end border-t border-gray-100 bg-slate-50/50 px-6 py-4"><button class="rounded-xl px-5 py-2 font-medium text-slate-600 transition-colors hover:bg-slate-200 hover:text-slate-800" @click="showCustomerSearch = false">Отмена</button></div>
+      </div>
+    </div>
+  </Transition>
+</template>

--- a/manager_frontend/src/components/orders/OrderDocumentsWorkspace.vue
+++ b/manager_frontend/src/components/orders/OrderDocumentsWorkspace.vue
@@ -1,0 +1,96 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import type { ManagerOrderDetailResponse } from '../../client';
+import type { ProductLine } from './order-editor-types';
+import OrderDocumentsPanel from './OrderDocumentsPanel.vue';
+import OrderDrawerSection from './OrderDrawerSection.vue';
+
+type BeforeGenerateResult = boolean | void | { proceed?: boolean; mutated?: boolean };
+
+const props = defineProps<{
+  order: ManagerOrderDetailResponse;
+  activeProposalId?: number | null;
+  productLines: ProductLine[];
+  total: number;
+  beforeGenerate?: (type: string) => BeforeGenerateResult | Promise<BeforeGenerateResult>;
+}>();
+
+const emit = defineEmits<{
+  refresh: [];
+  toast: [payload: { message: string; type?: 'success' | 'error' }];
+}>();
+
+const expanded = defineModel<boolean>('expanded', { required: true });
+const panelRef = ref<InstanceType<typeof OrderDocumentsPanel> | null>(null);
+
+const documents = computed(() => props.order.documents || []);
+const isCompanyOrder = computed(() => props.order.customer?.type === 'company' || Boolean(props.order.customer?.inn));
+const hasOrderContract = computed(() => documents.value.some((document) => document.doc_type === 'contract'));
+const hasContract = computed(() => (
+  (isCompanyOrder.value ? Boolean(props.order.customer_contract_id) : false) || hasOrderContract.value
+));
+const hasInvoice = computed(() => documents.value.some((document) => document.doc_type === 'invoice'));
+const hasClosingBaseDocument = computed(() => hasContract.value || hasInvoice.value);
+const summary = computed(() => {
+  const count = documents.value.length;
+  if (!count) return 'Документов нет';
+  const mod100 = count % 100;
+  const mod10 = count % 10;
+  const noun = mod100 >= 11 && mod100 <= 14
+    ? 'документов'
+    : mod10 === 1
+      ? 'документ'
+      : mod10 >= 2 && mod10 <= 4
+        ? 'документа'
+        : 'документов';
+  return `${count} ${noun}${hasContract.value ? '' : ' · договор не создан'}`;
+});
+const hasError = computed(() => (
+  isCompanyOrder.value && !props.order.customer_contract_id && !hasClosingBaseDocument.value
+));
+const customerPhoneDigits = computed(() => String(props.order.customer?.phone || '').replace(/\D/g, ''));
+const whatsappUrl = computed(() => {
+  const name = props.order.customer?.name || '';
+  const total = Number(props.total || 0).toLocaleString('ru-RU');
+  const message = `Здравствуйте, ${name}! Расчет по вашему заказу: Итого к оплате ${total} BYN. Подтверждаем?`;
+  return `https://wa.me/${customerPhoneDigits.value}?text=${encodeURIComponent(message)}`;
+});
+const viberUrl = computed(() => `viber://chat?number=%2B${customerPhoneDigits.value}`);
+
+const openSend = () => panelRef.value?.openSend();
+const openCreate = () => panelRef.value?.openCreate();
+
+defineExpose({ openSend, openCreate });
+</script>
+
+<template>
+  <OrderDrawerSection
+    id="order-workspace-documents"
+    v-model:expanded="expanded"
+    title="Документы"
+    :summary="summary"
+    tone="amber"
+    :has-error="hasError"
+  >
+    <div v-if="order.status === 'negotiation' && order.customer?.type === 'individual'" class="mb-6">
+      <div class="flex flex-wrap gap-2">
+        <a :href="whatsappUrl" target="_blank" class="flex items-center gap-1 rounded-xl bg-[#25D366] px-4 py-2 text-sm font-medium text-white shadow hover:bg-[#20BE5A]">
+          <span class="material-icons-round text-[18px]">chat</span> Отправить в WhatsApp
+        </a>
+        <a :href="viberUrl" target="_blank" class="flex items-center gap-1 rounded-xl bg-[#7360f2] px-4 py-2 text-sm font-medium text-white shadow hover:bg-[#5e4cd1]">
+          <span class="material-icons-round text-[18px]">chat</span> Viber
+        </a>
+      </div>
+    </div>
+
+    <OrderDocumentsPanel
+      ref="panelRef"
+      :order="order"
+      :active-proposal-id="activeProposalId"
+      :product-lines="productLines"
+      :before-generate="beforeGenerate"
+      @refresh="emit('refresh')"
+      @toast="emit('toast', $event)"
+    />
+  </OrderDrawerSection>
+</template>

--- a/manager_frontend/src/components/orders/OrderEditDrawer.vue
+++ b/manager_frontend/src/components/orders/OrderEditDrawer.vue
@@ -2,14 +2,12 @@
 import { computed, nextTick, ref, watch } from 'vue';
 import { useDebounceFn } from '@vueuse/core';
 import { api } from '../../api';
-import CustomerSummaryCard from '../customers/CustomerSummaryCard.vue';
 import DealExecutionTab from './DealExecutionTab.vue';
 import OrderDocumentsPanel from './OrderDocumentsPanel.vue';
 import OrderDrawerSection from './OrderDrawerSection.vue';
 import OrderAttachmentsPanel from '../service-attachments/OrderAttachmentsPanel.vue';
 import OrderEquipmentPanel from '../equipment/OrderEquipmentPanel.vue';
 import OrderWorkspaceHeader from './OrderWorkspaceHeader.vue';
-import OrderCustomerObjectSummary from './OrderCustomerObjectSummary.vue';
 import OrderSalesInstallationWorkspace from './OrderSalesInstallationWorkspace.vue';
 import OrderProposalToolbar from './OrderProposalToolbar.vue';
 import OrderPaymentsPanel from './OrderPaymentsPanel.vue';
@@ -18,13 +16,12 @@ import OrderPlanningPanel from './OrderPlanningPanel.vue';
 import OrderRepairPanel from './OrderRepairPanel.vue';
 import OrderProductLinesEditor from './OrderProductLinesEditor.vue';
 import OrderServiceLinesEditor from './OrderServiceLinesEditor.vue';
-import AddressSuggestInput from '../ui/AddressSuggestInput.vue';
+import OrderCustomerContext from './OrderCustomerContext.vue';
 import { confirmDialog, promptDialog } from '../../services/ui-feedback';
 import type { ServiceAttachmentEquipmentOption } from '../service-attachments/types';
 import type {
   ManagerOrderDetailResponse,
   ManagerOrderUpdatePayload,
-  ManagerCustomerBranchItemResponse,
   ManagerServiceEstimateResponse,
   OrderProductLineResponse,
   OrderProposalResponse,
@@ -118,11 +115,7 @@ const isPaid = ref(false);
 const installerId = ref<number | null>(null);
 
 const customerDeliveryAddress = ref('');
-const customerBranches = ref<ManagerCustomerBranchItemResponse[]>([]);
 const customerBranchId = ref<number | null>(null);
-const customerBranchesLoading = ref(false);
-const creatingCustomerBranch = ref(false);
-const newBranchName = ref('');
 const newBranchAddress = ref('');
 
 const targetCurrency = ref<PaymentCurrency | null>(null);
@@ -205,7 +198,6 @@ const activeServiceSuggestionIndex = ref<number | null>(null);
 const serviceTariffOptions = ref<ManagerQuickTariffResponse[]>([]);
 const serviceTariffLookupLoading = ref(false);
 let serviceTariffSearchRequestId = 0;
-let customerBranchesRequestId = 0;
 const estimateOptions = ref<ManagerServiceEstimateResponse[]>([]);
 const estimateOptionsLoading = ref(false);
 const estimateImportMode = ref<'detailed' | 'collapsed'>('detailed');
@@ -253,139 +245,7 @@ const expandedDrawerSections = ref(createDefaultDrawerSections());
 const initializedOrderId = ref<number | null>(null);
 
 const localFormError = ref('');
-const showCustomerModal = ref(false);
-const savingCustomerInline = ref(false);
 const showManagerLabelInput = ref(false);
-const showBranchFields = ref(false);
-
-const showChangeCustomerModal = ref(false);
-const customerSearchQuery = ref('');
-const customerSearchResults = ref<any[]>([]);
-const isCustomerSearchLoading = ref(false);
-let customerSearchRequestId = 0;
-
-const debouncedSearchCustomer = useDebounceFn(async (query: string) => {
-  const requestId = ++customerSearchRequestId;
-  if (!query || query.length < 3) {
-    customerSearchResults.value = [];
-    isCustomerSearchLoading.value = false;
-    return;
-  }
-  isCustomerSearchLoading.value = true;
-  try {
-    const res = await api.getManagerCustomers(1, 10, query);
-    if (requestId !== customerSearchRequestId || query !== customerSearchQuery.value) return;
-    customerSearchResults.value = res.items || [];
-  } catch (error) {
-    if (requestId !== customerSearchRequestId) return;
-    console.error('Customer search error', error);
-  } finally {
-    if (requestId === customerSearchRequestId) {
-      isCustomerSearchLoading.value = false;
-    }
-  }
-}, 400);
-
-const onCustomerSearchInput = () => {
-  debouncedSearchCustomer(customerSearchQuery.value);
-};
-
-const assignNewCustomer = async (newCustomer: any) => {
-  if (!props.order?.id) return;
-  try {
-    const res = await api.patchManagerOrder(props.order.id, { customer_id: newCustomer.id });
-    emit('updated', res);
-    await initForm(res);
-    showChangeCustomerModal.value = false;
-    setToast('Клиент успешно изменен', 'success');
-    emit('reload', res.id);
-  } catch (error) {
-    setToast(`Ошибка смены клиента: ${getApiErrorMessage(error)}`, 'error');
-  }
-};
-
-const resetCustomerBranches = () => {
-  customerBranchesRequestId += 1;
-  customerBranches.value = [];
-  customerBranchId.value = null;
-  customerBranchesLoading.value = false;
-  creatingCustomerBranch.value = false;
-  newBranchName.value = '';
-  newBranchAddress.value = '';
-};
-
-const loadCustomerBranches = async (customerId: number, preferredBranchId?: number | null) => {
-  const requestId = ++customerBranchesRequestId;
-  customerBranchesLoading.value = true;
-  try {
-    const response = await api.getManagerCustomerBranches(customerId);
-    if (requestId !== customerBranchesRequestId) return;
-    customerBranches.value = response.items || [];
-    if (!customerBranches.value.length) {
-      customerBranchId.value = null;
-      return;
-    }
-    // Keep "Без филиала" when order explicitly stores null branch.
-    if (preferredBranchId === null) {
-      customerBranchId.value = null;
-      return;
-    }
-    const preferredFromOrder = typeof preferredBranchId === 'number'
-      ? customerBranches.value.find((branch) => branch.id === preferredBranchId)
-      : null;
-    const preferred = preferredFromOrder
-      || customerBranches.value.find((branch) => branch.is_default)
-      || customerBranches.value[0]
-      || null;
-    customerBranchId.value = preferred?.id || null;
-  } catch (error) {
-    if (requestId !== customerBranchesRequestId) return;
-    console.error('Failed to load customer branches', error);
-    resetCustomerBranches();
-  } finally {
-    if (requestId === customerBranchesRequestId) {
-      customerBranchesLoading.value = false;
-    }
-  }
-};
-
-const onCustomerBranchChange = (event: Event) => {
-  const value = (event.target as HTMLSelectElement).value;
-  customerBranchId.value = value ? Number(value) : null;
-  const branch = customerBranches.value.find((item) => item.id === customerBranchId.value) || null;
-  if (branch) {
-    customerDeliveryAddress.value = branch.delivery_address;
-  }
-};
-
-const createCustomerBranch = async () => {
-  const customerId = customer.value?.id;
-  if (!customerId || creatingCustomerBranch.value) return;
-  const deliveryAddress = newBranchAddress.value.trim();
-  if (!deliveryAddress) {
-    setToast('Введите адрес филиала', 'error');
-    return;
-  }
-
-  creatingCustomerBranch.value = true;
-  try {
-    const created = await api.createManagerCustomerBranch(customerId, {
-      name: newBranchName.value.trim() || undefined,
-      delivery_address: deliveryAddress,
-      is_default: customerBranches.value.length === 0,
-    });
-    customerBranches.value = [created, ...customerBranches.value.filter((branch) => branch.id !== created.id)];
-    customerBranchId.value = created.id;
-    customerDeliveryAddress.value = created.delivery_address;
-    newBranchName.value = '';
-    newBranchAddress.value = '';
-    setToast('Филиал создан', 'success');
-  } catch (error) {
-    setToast(`Ошибка создания филиала: ${getApiErrorMessage(error)}`, 'error');
-  } finally {
-    creatingCustomerBranch.value = false;
-  }
-};
 
 const customer = computed(() => props.order?.customer ?? null);
 const customerDisplayName = computed(() => (
@@ -404,20 +264,11 @@ const displayOrderTitle = computed(() => (
   || customer.value?.name
   || 'Без названия'
 ));
-const selectedCustomerBranch = computed(() => (
-  customerBranches.value.find((branch) => branch.id === customerBranchId.value)
-  || props.order?.customer_branch
-  || null
-));
 const compactObjectAddress = computed(() => (
   customerDeliveryAddress.value.trim()
-  || selectedCustomerBranch.value?.delivery_address
+  || props.order?.customer_branch?.delivery_address
   || ''
 ));
-const customerDetailsSummary = computed(() => {
-  if (customerBranchId.value) return 'Филиал и дополнительные данные';
-  return 'Адрес и комментарий';
-});
 const orderProposals = computed(() => {
   const proposals = props.order?.proposals || [];
   return [...proposals]
@@ -1113,13 +964,6 @@ const initForm = async (order: ManagerOrderDetailResponse | null) => {
 
   // Payments
   payments.value = [...(order.payments || [])];
-
-  const customerId = order.customer?.id;
-  if (customerId) {
-    await loadCustomerBranches(customerId, order.customer_branch?.id ?? null);
-  } else {
-    resetCustomerBranches();
-  }
 
   productLookupById.value = {};
 
@@ -1974,43 +1818,6 @@ const deleteOrder = async () => {
 };
 const getFieldError = (field: string): string => localServerErrors.value[field] || props.serverErrors?.[field] || '';
 const displayFormError = computed(() => localFormError.value || props.formError || '');
-const closeCustomerModal = () => {
-  showCustomerModal.value = false;
-};
-
-const openCustomerProfile = () => {
-  const customerId = props.order?.customer?.id;
-  if (!customerId) return;
-  showCustomerModal.value = false;
-  const returnTo = `${window.location.pathname}${window.location.search}`;
-  const query = new URLSearchParams({
-    customerId: String(customerId),
-    returnTo,
-  });
-  window.history.pushState({}, '', `/manager/customers/profile?${query.toString()}`);
-  window.dispatchEvent(new PopStateEvent('popstate'));
-};
-
-const saveCustomerInline = async (payload: { name: string; phone: string; email: string }) => {
-  const customerId = customer.value?.id;
-  if (!customerId || savingCustomerInline.value) return;
-  savingCustomerInline.value = true;
-  try {
-    await api.patchManagerCustomer(customerId, {
-      name: payload.name,
-      full_legal_name: customer.value?.type === 'company' ? payload.name : undefined,
-      phone: payload.phone || null,
-      email: payload.email || null,
-    });
-    setToast('Контакты клиента обновлены', 'success');
-    if (props.order?.id) emit('reload', props.order.id);
-  } catch (error) {
-    setToast('Не удалось обновить клиента: ' + getApiErrorMessage(error), 'error');
-  } finally {
-    savingCustomerInline.value = false;
-  }
-};
-
 const openWorkspaceTarget = async (target: OrderWorkspaceTarget, allowToggle = false) => {
   const shouldClose = allowToggle && activeWorkspaceTarget.value === target;
   if (activeWorkspaceTarget.value === 'equipment') equipmentPanelRef.value?.collapse();
@@ -2057,6 +1864,11 @@ const discardUnsavedChanges = async () => {
   clearDraft();
   await initForm(props.order);
   setToast('Изменения отменены', 'success');
+};
+
+const handleCustomerUpdated = async (updatedOrder: ManagerOrderDetailResponse) => {
+  emit('updated', updatedOrder);
+  await initForm(updatedOrder);
 };
 
 watch(
@@ -2142,78 +1954,31 @@ watch(
         <span class="material-icons-round text-[14px]">add</span> Добавить метку
       </button>
 
-      <OrderCustomerObjectSummary
-        :customer="customer"
-        :branch="selectedCustomerBranch"
-        :address="compactObjectAddress"
-        :has-comment="Boolean(comment.trim())"
-        :saving-customer="savingCustomerInline"
-        @copy="copyText"
-        @save-customer="saveCustomerInline"
-        @update:address="customerDeliveryAddress = $event"
-        @open-customer="openCustomerProfile"
-        @change-customer="showChangeCustomerModal = true"
-        @toggle-branch="showBranchFields = !showBranchFields"
-      />
-
-      <div v-if="showBranchFields && customer?.id" class="mt-2 grid gap-2 rounded-xl border border-slate-200 bg-slate-50 p-3 dark:border-slate-700 dark:bg-slate-900 sm:grid-cols-2">
-        <label class="field-label sm:col-span-2">
-          Филиал клиента
-          <select :value="customerBranchId ?? ''" class="field-input mt-1" :disabled="customerBranchesLoading" @change="onCustomerBranchChange">
-            <option value="">Без филиала</option>
-            <option v-for="branch in customerBranches" :key="'compact-branch-' + branch.id" :value="branch.id">
-              {{ branch.name || 'Филиал #' + branch.id }} — {{ branch.delivery_address }}
-            </option>
-          </select>
-        </label>
-        <input v-model="newBranchName" class="field-input" placeholder="Название нового филиала" />
-        <AddressSuggestInput v-model="newBranchAddress" placeholder="Адрес нового филиала" />
-        <div class="sm:col-span-2 flex justify-end">
-          <button type="button" class="btn-mini-outline text-xs" :disabled="creatingCustomerBranch" @click="createCustomerBranch">
-            {{ creatingCustomerBranch ? 'Создаём...' : 'Создать и выбрать' }}
-          </button>
-        </div>
-      </div>
-
-      <OrderSalesInstallationWorkspace
-        v-if="workflowType === 'sales_installation'"
-        :lanes="orderWorkspace.lanes"
-        :active-target="activeWorkspaceTarget"
-        @open="openWorkspaceTarget($event, true)"
-      />
-
-      <p v-if="displayFormError" class="mb-4 rounded-xl border border-red-500/40 bg-red-50 px-3 py-2 text-sm text-red-700">
-        {{ displayFormError }}
-      </p>
-
-      <OrderDrawerSection
-        id="order-workspace-object"
+      <OrderCustomerContext
+        v-if="order"
+        v-model:delivery-address="customerDeliveryAddress"
+        v-model:customer-branch-id="customerBranchId"
+        v-model:comment="comment"
         v-model:expanded="expandedDrawerSections.clientDetails"
-        title="Подробнее об объекте"
-        :summary="customerDetailsSummary"
-        tone="default"
-        :has-error="Boolean(getFieldError('customer_delivery_address') || getFieldError('comment'))"
+        v-model:new-branch-address="newBranchAddress"
+        :order="order"
+        :address-error="getFieldError('customer_delivery_address')"
+        :comment-error="getFieldError('comment')"
+        @toast="setToast($event.message, $event.type)"
+        @updated="handleCustomerUpdated"
+        @reload="emit('reload', $event)"
       >
-        <div class="grid gap-3 md:grid-cols-2">
-          <AddressSuggestInput
-            v-model="customerDeliveryAddress"
-            class="md:col-span-2"
-            label="Адрес объекта / доставки"
-            placeholder="Введите адрес..."
-            :error="getFieldError('customer_delivery_address')"
-          />
+        <OrderSalesInstallationWorkspace
+          v-if="workflowType === 'sales_installation'"
+          :lanes="orderWorkspace.lanes"
+          :active-target="activeWorkspaceTarget"
+          @open="openWorkspaceTarget($event, true)"
+        />
 
-          <label class="field-label md:col-span-2">
-            Комментарий
-            <textarea
-              v-model="comment"
-              class="field-input min-h-[90px]"
-              :class="getFieldError('comment') ? 'border-red-500 focus:outline-red-400' : ''"
-            />
-            <span v-if="getFieldError('comment')" class="text-xs text-red-300">{{ getFieldError('comment') }}</span>
-          </label>
-        </div>
-      </OrderDrawerSection>
+        <p v-if="displayFormError" class="mb-4 rounded-xl border border-red-500/40 bg-red-50 px-3 py-2 text-sm text-red-700">
+          {{ displayFormError }}
+        </p>
+      </OrderCustomerContext>
 
       <OrderEquipmentPanel
         v-if="order"
@@ -2498,88 +2263,5 @@ watch(
       </div>
     </aside>
 
-    <div
-      v-if="showCustomerModal"
-      class="fixed inset-0 z-[60] flex items-center justify-center bg-black/70 px-4"
-      @click.self="closeCustomerModal"
-    >
-      <div class="w-full max-w-3xl rounded-2xl border border-gray-200 bg-white p-5 text-gray-900 shadow-2xl">
-        <div class="mb-4 flex items-center justify-between gap-3">
-          <h3 class="text-lg font-semibold font-['Space_Grotesk']">Карточка клиента</h3>
-          <button class="btn-mini-outline" @click="closeCustomerModal">Закрыть</button>
-        </div>
-        <CustomerSummaryCard :customer="customer" mode="expanded" :show-open-button="false" />
-        <div class="mt-4 flex justify-end gap-2">
-          <button class="btn-mini-outline" @click="showChangeCustomerModal = true">Сменить</button>
-          <button class="btn-mini" :disabled="!customer?.id" @click="openCustomerProfile">Редактировать в карточке клиента</button>
-        </div>
-      </div>
-    </div>
-
-    <!-- Modal for changing order customer -->
-    <Transition name="fade">
-      <div
-        v-if="showChangeCustomerModal"
-        class="fixed inset-0 z-[60] flex items-center justify-center bg-black/60 backdrop-blur-sm p-4"
-        @click.self="showChangeCustomerModal = false"
-      >
-        <div class="w-full max-w-lg rounded-2xl bg-white shadow-2xl overflow-hidden flex flex-col max-h-[85vh]">
-          <div class="px-6 py-4 border-b border-gray-100 flex items-center justify-between shadow-sm bg-slate-50/50">
-            <h3 class="text-lg font-bold text-slate-800 flex items-center gap-2">
-              <span class="material-icons-round text-slate-500">swap_horiz</span>
-              Сменить клиента для заказа
-            </h3>
-            <button class="bg-slate-100 hover:bg-slate-200 text-slate-500 w-8 h-8 flex items-center justify-center rounded-full transition-colors" @click="showChangeCustomerModal = false">
-              <span class="material-icons-round text-[18px]">close</span>
-            </button>
-          </div>
-          
-          <div class="p-6 overflow-y-auto">
-            <div class="relative mb-4">
-              <span class="material-icons-round absolute left-4 top-1/2 -translate-y-1/2 text-slate-400">search</span>
-              <input 
-                v-model="customerSearchQuery" 
-                @input="onCustomerSearchInput"
-                type="text" 
-                class="w-full bg-slate-50 border-none rounded-xl pl-11 pr-4 py-3 text-sm focus:ring-2 focus:ring-teal-500 transition-shadow" 
-                placeholder="Поиск по телефону, УНП, имени..." 
-                autofocus
-              />
-              <span v-if="isCustomerSearchLoading" class="material-icons-round absolute right-4 top-1/2 -translate-y-1/2 text-teal-500 animate-spin">refresh</span>
-            </div>
-
-            <div v-if="customerSearchQuery.length >= 3 && customerSearchResults.length === 0 && !isCustomerSearchLoading" class="text-center py-6 text-slate-500 text-sm bg-slate-50 rounded-xl border border-slate-100 border-dashed">
-              Клиенты не найдены
-            </div>
-
-            <div v-if="customerSearchQuery.length < 3" class="text-center py-6 text-slate-400 text-xs uppercase tracking-wider font-semibold">
-              Введите минимум 3 символа
-            </div>
-
-            <div class="space-y-2 mt-2">
-              <button
-                v-for="res in customerSearchResults"
-                :key="`csearch-${res.id}`"
-                class="w-full text-left p-4 rounded-xl border border-slate-100 bg-white hover:border-teal-200 hover:shadow-md hover:-translate-y-0.5 transition-all outline-none focus:ring-2 focus:ring-teal-500 flex flex-col gap-1 group"
-                @click="assignNewCustomer(res)"
-              >
-                <div class="font-bold text-slate-800 text-sm group-hover:text-teal-700 transition-colors">
-                  {{ res.full_legal_name || res.name || `Клиент #${res.id}` }}
-                </div>
-                <div class="flex flex-wrap gap-x-3 gap-y-1 text-xs text-slate-500">
-                  <span v-if="res.phone" class="flex items-center gap-1"><span class="material-icons-round text-[12px]">phone</span> {{ res.phone }}</span>
-                  <span v-if="res.inn" class="flex items-center gap-1"><span class="font-medium">УНП:</span> {{ res.inn }}</span>
-                </div>
-              </button>
-            </div>
-          </div>
-          <div class="px-6 py-4 border-t border-gray-100 bg-slate-50/50 flex justify-end">
-            <button class="px-5 py-2 rounded-xl text-slate-600 font-medium hover:bg-slate-200 hover:text-slate-800 transition-colors" @click="showChangeCustomerModal = false">
-              Отмена
-            </button>
-          </div>
-        </div>
-      </div>
-    </Transition>
   </div>
 </template>

--- a/manager_frontend/src/components/orders/OrderEditDrawer.vue
+++ b/manager_frontend/src/components/orders/OrderEditDrawer.vue
@@ -34,11 +34,7 @@ import { useSmartStickyHeader } from '../../composables/useSmartStickyHeader';
 import { useOrderCommercialEditor } from '../../composables/useOrderCommercialEditor';
 import { useOrderProposalLifecycle } from '../../composables/useOrderProposalLifecycle';
 import { useOrderDrawerForm } from '../../composables/useOrderDrawerForm';
-import type {
-  OrderDrawerDraft,
-  OrderLogisticsComponent,
-  ProductLogisticsTemplateComponent,
-} from './order-editor-types';
+import { useOrderDrawerPersistence } from '../../composables/useOrderDrawerPersistence';
 
 const props = defineProps<{
   modelValue: boolean;
@@ -80,7 +76,6 @@ function setToast(message: string, type: 'success' | 'error' = 'success') {
 
 const savedLinesSnapshot = ref('');
 const savedFormSnapshot = ref('');
-const pendingDraftClearOrderId = ref<number | null>(null);
 const {
   activeServiceSuggestionIndex,
   activeSuggestionIndex,
@@ -203,20 +198,6 @@ const orderEmails = ref<OutgoingEmailResponse[]>([]);
 const orderEmailsLoaded = ref(false);
 let orderEmailsRequestId = 0;
 
-const createDefaultDrawerSections = () => ({
-  website: false,
-  clientDetails: false,
-  planningDetails: false,
-  repair: true,
-  proposals: false,
-  documents: false,
-  payments: false,
-  execution: false,
-});
-type DrawerSectionsState = ReturnType<typeof createDefaultDrawerSections>;
-const expandedDrawerSections = ref(createDefaultDrawerSections());
-const initializedOrderId = ref<number | null>(null);
-
 const showManagerLabelInput = ref(false);
 
 const {
@@ -254,6 +235,26 @@ const {
   setToast,
   onUpdated: (updatedOrder) => emit('updated', updatedOrder),
   onReload: (orderId) => emit('reload', orderId),
+});
+
+const {
+  clearDraft,
+  expandedDrawerSections,
+  hasUnsavedChanges,
+  initializedOrderId,
+  pendingDraftClearOrderId,
+  persistDraft,
+  restoreDraft,
+  restoreDrawerSections,
+} = useOrderDrawerPersistence({
+  order: computed(() => props.order),
+  activeProposalId,
+  productLines,
+  serviceLines,
+  savedLinesSnapshot,
+  savedFormSnapshot,
+  currentLinesSnapshot: () => buildCurrentLinesSnapshot(activeProposalId.value),
+  currentFormSnapshot: () => buildCurrentFormSnapshot(proposalStatus.value),
 });
 
 const customer = computed(() => props.order?.customer ?? null);
@@ -358,12 +359,6 @@ const orderWorkspace = computed(() => buildOrderWorkspaceViewModel({
   paid: totalPaymentsPreview.value,
   balance: balanceDuePreview.value,
 }));
-const draftKey = computed(() => (
-  props.order ? `manager_order_drawer_draft_${props.order.id}_${activeProposalId.value || 'default'}` : ''
-));
-const drawerSectionsKey = computed(() => (
-  props.order ? `manager_order_drawer_sections_${props.order.id}` : ''
-));
 const loadOrderEmails = async (orderId: number) => {
   const requestId = ++orderEmailsRequestId;
   try {
@@ -453,107 +448,6 @@ const refreshOrderFromDocumentsPanel = () => {
   }
 };
 
-const currentLinesSnapshot = () => buildCurrentLinesSnapshot(activeProposalId.value);
-const currentFormSnapshot = () => buildCurrentFormSnapshot(proposalStatus.value);
-const hasUnsavedChanges = computed(() => (
-  Boolean(props.order?.id)
-  && (
-    (Boolean(savedLinesSnapshot.value) && currentLinesSnapshot() !== savedLinesSnapshot.value)
-    || (Boolean(savedFormSnapshot.value) && currentFormSnapshot() !== savedFormSnapshot.value)
-  )
-));
-
-function persistDraft() {
-  if (!draftKey.value) return;
-  try {
-    const payload: OrderDrawerDraft = {
-      productLines: productLines.value.map((line) => ({ ...line })),
-      serviceLines: serviceLines.value.map((line) => ({ ...line })),
-    };
-    window.sessionStorage.setItem(draftKey.value, JSON.stringify(payload));
-  } catch (error) {
-    console.warn('Failed to persist order drawer draft', error);
-  }
-}
-
-const restoreDraft = () => {
-  if (!draftKey.value) return;
-  try {
-    const raw = window.sessionStorage.getItem(draftKey.value);
-    if (!raw) return;
-    const payload = JSON.parse(raw) as Partial<OrderDrawerDraft>;
-    if (Array.isArray(payload.productLines)) {
-      productLines.value = payload.productLines.map((line) => ({
-        link_id: Number((line as any).link_id || 0) || null,
-        product_id: Number(line.product_id || 0),
-        product_query: String(line.product_query || ''),
-        quantity: Number(line.quantity || 1),
-        price: Number(line.price || 0),
-        cost: Number(line.cost || 0),
-        product_country: (line as any).product_country || null,
-        product_logistics_components: Array.isArray((line as any).product_logistics_components)
-          ? [...((line as any).product_logistics_components as ProductLogisticsTemplateComponent[])]
-          : [],
-        logistics_components: Array.isArray((line as any).logistics_components)
-          ? [...((line as any).logistics_components as OrderLogisticsComponent[])]
-          : null,
-      }));
-    }
-    if (Array.isArray(payload.serviceLines)) {
-      serviceLines.value = payload.serviceLines.map((line) => ({
-        service_id: line.service_id ?? null,
-        title: String(line.title || ''),
-        quantity: Number(line.quantity || 1),
-        price: Number(line.price || 0),
-        cost: Number(line.cost || 0),
-        tariff_id: Number(line.tariff_id || 0) || null,
-        template_short_name: line.template_short_name || null,
-        template_full_description: line.template_full_description || null,
-        template_applied_text: line.template_applied_text || null,
-        description_mode: line.description_mode === 'full' ? 'full' : 'short',
-      }));
-    }
-  } catch (error) {
-    console.warn('Failed to restore order drawer draft', error);
-  }
-};
-
-const persistDrawerSections = () => {
-  if (!drawerSectionsKey.value) return;
-  try {
-    window.sessionStorage.setItem(drawerSectionsKey.value, JSON.stringify(expandedDrawerSections.value));
-  } catch (error) {
-    console.warn('Failed to persist order drawer sections', error);
-  }
-};
-
-const restoreDrawerSections = (): DrawerSectionsState => {
-  if (!drawerSectionsKey.value) return createDefaultDrawerSections();
-  try {
-    const raw = window.sessionStorage.getItem(drawerSectionsKey.value);
-    if (!raw) return createDefaultDrawerSections();
-    const stored = JSON.parse(raw) as Partial<DrawerSectionsState>;
-    return {
-      ...createDefaultDrawerSections(),
-      ...Object.fromEntries(
-        Object.entries(stored).filter(([, value]) => typeof value === 'boolean'),
-      ),
-    } as DrawerSectionsState;
-  } catch (error) {
-    console.warn('Failed to restore order drawer sections', error);
-    return createDefaultDrawerSections();
-  }
-};
-
-function clearDraft() {
-  if (!draftKey.value) return;
-  try {
-    window.sessionStorage.removeItem(draftKey.value);
-  } catch (error) {
-    console.warn('Failed to clear order drawer draft', error);
-  }
-}
-
 const initForm = async (order: ManagerOrderDetailResponse | null) => {
   if (!order) return;
   localServerErrors.value = {};
@@ -577,12 +471,12 @@ const initForm = async (order: ManagerOrderDetailResponse | null) => {
     clearDraft();
     pendingDraftClearOrderId.value = null;
   }
-  savedLinesSnapshot.value = currentLinesSnapshot();
+  savedLinesSnapshot.value = buildCurrentLinesSnapshot(activeProposalId.value);
   showEstimateImport.value = false;
   await loadEstimateOptions();
 
   resetLookupState();
-  savedFormSnapshot.value = currentFormSnapshot();
+  savedFormSnapshot.value = buildCurrentFormSnapshot(proposalStatus.value);
   restoreDraft();
   syncProductLookupFromLines();
   await Promise.all([
@@ -774,29 +668,6 @@ const handleCustomerUpdated = async (updatedOrder: ManagerOrderDetailResponse) =
   await initForm(updatedOrder);
 };
 
-watch(
-  () => productLines.value,
-  () => {
-    persistDraft();
-  },
-  { deep: true },
-);
-
-watch(
-  () => serviceLines.value,
-  () => {
-    persistDraft();
-  },
-  { deep: true },
-);
-
-watch(
-  () => expandedDrawerSections.value,
-  () => {
-    persistDrawerSections();
-  },
-  { deep: true },
-);
 </script>
 
 <template>

--- a/manager_frontend/src/components/orders/OrderEditDrawer.vue
+++ b/manager_frontend/src/components/orders/OrderEditDrawer.vue
@@ -14,6 +14,7 @@ import OrderWorkspaceHeader from './OrderWorkspaceHeader.vue';
 import OrderCustomerObjectSummary from './OrderCustomerObjectSummary.vue';
 import OrderSalesInstallationWorkspace from './OrderSalesInstallationWorkspace.vue';
 import OrderProposalToolbar from './OrderProposalToolbar.vue';
+import OrderPaymentsPanel from './OrderPaymentsPanel.vue';
 import AddressSuggestInput from '../ui/AddressSuggestInput.vue';
 import { confirmDialog, promptDialog } from '../../services/ui-feedback';
 import type { ServiceAttachmentEquipmentOption } from '../service-attachments/types';
@@ -29,7 +30,6 @@ import type {
   ManagerQuickTariffResponse,
   PaymentResponse,
   PaymentCurrency,
-  BankReceiptResponse,
   FxRateResponse,
   ManagerRepairComplaintPresetResponse,
   EquipmentServiceEventType,
@@ -182,7 +182,6 @@ const newBranchAddress = ref('');
 
 const targetCurrency = ref<PaymentCurrency | null>(null);
 const targetCurrencyAmount = ref<number | null>(null);
-const targetCurrencyPayments = ref<number>(0);
 const enableCurrency = ref(false);
 const currentFxRate = ref<FxRateResponse | null>(null);
 
@@ -204,7 +203,6 @@ watch(enableCurrency, async (val) => {
   if (!val) {
     targetCurrency.value = null;
     targetCurrencyAmount.value = null;
-    targetCurrencyPayments.value = 0;
   } else if (!targetCurrency.value) {
     targetCurrency.value = 'USD';
     try {
@@ -299,8 +297,6 @@ const recordingRepairHistory = ref(false);
 const repairHistoryEventType = ref<EquipmentServiceEventType | ''>('');
 const repairHistoryNotes = ref('');
 const payments = ref<PaymentResponse[]>([]);
-const bankReceipts = ref<BankReceiptResponse[]>([]);
-const bankReceiptsLoading = ref(false);
 const linkedEquipmentOptions = ref<ServiceAttachmentEquipmentOption[]>([]);
 const equipmentPanelRef = ref<InstanceType<typeof OrderEquipmentPanel> | null>(null);
 const documentsPanelRef = ref<InstanceType<typeof OrderDocumentsPanel> | null>(null);
@@ -317,7 +313,6 @@ const executorOptions = computed(() => {
   if (measurerId.value !== null) selectedIds.add(measurerId.value);
   return installersList.value.filter((inst) => inst.is_active || selectedIds.has(inst.id));
 });
-const attachingReceiptId = ref<number | null>(null);
 const localServerErrors = ref<Record<string, string>>({});
 
 const createDefaultDrawerSections = () => ({
@@ -664,9 +659,6 @@ const activeProposalLineLabel = computed(() => {
   const noun = mod100 >= 11 && mod100 <= 14 ? 'позиций' : mod10 === 1 ? 'позиция' : mod10 >= 2 && mod10 <= 4 ? 'позиции' : 'позиций';
   return `${proposal.name} · ${proposalStatusLabel(proposal.status)} · ${count} ${noun} · ${formatMoney(proposal.total_amount || 0)}`;
 });
-const paymentsSectionSummary = computed(() => (
-  `оплачено ${formatMoney(totalPaymentsPreview.value)} · остаток ${formatMoney(balanceDuePreview.value)} · итого ${formatMoney(totalPreview.value)} · маржа ${formatMoney(marginPreview.value)}`
-));
 const documentEmailStatus = computed<'unknown' | 'none' | 'pending' | 'sent' | 'failed'>(() => {
   if (!orderEmailsLoaded.value) return 'unknown';
   const latestDocumentEmail = [...orderEmails.value]
@@ -750,8 +742,6 @@ const orderWorkspace = computed(() => buildOrderWorkspaceViewModel({
   paid: totalPaymentsPreview.value,
   balance: balanceDuePreview.value,
 }));
-const candidateBankReceipts = computed(() => bankReceipts.value.filter((receipt) => receipt.status === 'requires_review'));
-const hasDebtForBankReceipts = computed(() => balanceDuePreview.value > 0 && Boolean(props.order?.customer?.inn));
 const draftKey = computed(() => (
   props.order ? `manager_order_drawer_draft_${props.order.id}_${activeProposalId.value || 'default'}` : ''
 ));
@@ -1121,134 +1111,6 @@ const refreshOrderFromDocumentsPanel = () => {
   }
 };
 
-const newPaymentAmount = ref<number | null>(null);
-const newPaymentType = ref<string>('prepayment');
-const isAddingPayment = ref(false);
-
-const addPayment = async () => {
-  if (!props.order?.id || !newPaymentAmount.value) return;
-  if (enableCurrency.value) {
-    if (!targetCurrency.value) {
-      setToast('Сначала выберите валюту сделки', 'error');
-      return;
-    }
-    if (!getActiveFxRate(targetCurrency.value)) {
-      setToast('Для выбранной валюты нет доступного курса', 'error');
-      return;
-    }
-  }
-  isAddingPayment.value = true;
-  try {
-    const res = await ManagerOrdersService.addManagerOrderPayment(props.order.id, {
-        amount: newPaymentAmount.value,
-        type: newPaymentType.value,
-        currency: enableCurrency.value ? (targetCurrency.value || 'USD') : 'BYN',
-    });
-    payments.value = res;
-    newPaymentAmount.value = null;
-    setToast('Платеж добавлен', 'success');
-  } catch (error) {
-    setToast(`Ошибка: ${getApiErrorMessage(error)}`, 'error');
-  } finally {
-    isAddingPayment.value = false;
-  }
-};
-
-const loadCandidateBankReceipts = async (order: ManagerOrderDetailResponse | null) => {
-  const inn = order?.customer?.inn;
-  if (!inn) {
-    bankReceipts.value = [];
-    return;
-  }
-  bankReceiptsLoading.value = true;
-  try {
-    const response = await ManagerMailService.listManagerBankReceipts(1, 20, 'requires_review', inn);
-    bankReceipts.value = response.items || [];
-  } catch (error) {
-    console.error('Failed to load bank receipts', error);
-    bankReceipts.value = [];
-  } finally {
-    bankReceiptsLoading.value = false;
-  }
-};
-
-const attachBankReceipt = async (receipt: BankReceiptResponse) => {
-  if (!props.order?.id || !receipt.id) return;
-  attachingReceiptId.value = receipt.id;
-  try {
-    await ManagerMailService.attachManagerBankReceipt(receipt.id, {
-      order_id: props.order.id,
-      payment_type: 'postpayment',
-    });
-    setToast('Поступление прикреплено к заказу', 'success');
-    await loadCandidateBankReceipts(props.order);
-    emit('reload', props.order.id);
-  } catch (error) {
-    setToast(`Ошибка привязки: ${getApiErrorMessage(error)}`, 'error');
-  } finally {
-    attachingReceiptId.value = null;
-  }
-};
-
-const receiptCandidateHint = (receipt: BankReceiptResponse) => {
-  const meta = receipt.match_meta as any;
-  const docs = Array.isArray(meta?.document_candidates) ? meta.document_candidates : [];
-  if (docs.length) {
-    const doc = docs[0];
-    return `${doc.doc_type || 'документ'} ${doc.number || ''} · заказ #${doc.order_id}`;
-  }
-  const ids = Array.isArray(meta?.candidate_order_ids) ? meta.candidate_order_ids : [];
-  if (ids.length) return `кандидат: заказ #${ids[0]}`;
-  return '';
-};
-
-const formatReceiptDate = (value?: string | null) => {
-  if (!value) return 'дата не указана';
-  return new Date(value).toLocaleString('ru-RU', { day: '2-digit', month: '2-digit', hour: '2-digit', minute: '2-digit' });
-};
-
-const formatPaymentType = (value?: string | null) => (value === 'prepayment' ? 'Аванс' : 'Доплата');
-
-const formatBankPaymentDate = (value?: string | null) => {
-  if (!value) return 'дата не указана';
-  return new Date(value).toLocaleString('ru-RU', {
-    day: '2-digit',
-    month: '2-digit',
-    year: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-  });
-};
-
-const openBankReceiptJournal = (payment: PaymentResponse) => {
-  if (!props.order?.id || !payment.bank_receipt_id) return;
-  window.history.pushState({}, '', `/manager/payments?orderId=${props.order.id}`);
-  window.dispatchEvent(new PopStateEvent('popstate'));
-};
-
-const deletingPaymentId = ref<number | null>(null);
-
-const confirmDeletePayment = (paymentId: number) => {
-  deletingPaymentId.value = paymentId;
-};
-
-const cancelDeletePayment = () => {
-  deletingPaymentId.value = null;
-};
-
-const deletePayment = async (paymentId: number) => {
-  if (!props.order?.id) return;
-  try {
-    const res = await ManagerOrdersService.deleteManagerOrderPayment(props.order.id, paymentId);
-    payments.value = res;
-    deletingPaymentId.value = null;
-    setToast('Платеж удален', 'success');
-  } catch (error) {
-    setToast(`Ошибка: ${getApiErrorMessage(error)}`, 'error');
-  }
-};
-
-
 const totalPreview = computed(() => {
   const pTotal = productLines.value.reduce((sum, line) => sum + line.price * line.quantity, 0);
   const sTotal = serviceLines.value.reduce((sum, line) => sum + line.price * line.quantity, 0);
@@ -1609,7 +1471,6 @@ const initForm = async (order: ManagerOrderDetailResponse | null) => {
   autoCloseOnPayment.value = Boolean(order.auto_close_on_payment);
   targetCurrency.value = order.target_currency || null;
   targetCurrencyAmount.value = order.target_currency_amount || null;
-  targetCurrencyPayments.value = order.target_currency_payments || 0;
 
   // Set default currency toggle state
   enableCurrency.value = !!order.target_currency;
@@ -1643,7 +1504,6 @@ const initForm = async (order: ManagerOrderDetailResponse | null) => {
 
   // Payments
   payments.value = [...(order.payments || [])];
-  await loadCandidateBankReceipts(order);
 
   const customerId = order.customer?.id;
   if (customerId) {
@@ -3963,158 +3823,25 @@ watch(
         class="mt-4"
       />
 
-      <!-- Оплаты и Валюта (Объединенный блок) -->
-      <OrderDrawerSection
+      <OrderPaymentsPanel
         v-if="order && status !== 'execution'"
-        id="order-workspace-payments"
         v-model:expanded="expandedDrawerSections.payments"
-        title="Оплаты"
-        :summary="paymentsSectionSummary"
-        icon="account_balance_wallet"
-        tone="default"
-      >
-      <section class="rounded-2xl border border-slate-200 bg-slate-50 p-3 shadow-sm sm:p-5">
-        <div v-if="isB2cCustomer" class="mb-4 flex justify-end">
-            <label v-if="isB2cCustomer" class="flex items-center gap-2 cursor-pointer text-sm font-medium text-slate-600 bg-white border border-slate-200 px-3 py-1.5 rounded-lg shadow-sm hover:bg-slate-50 transition-colors">
-                <input type="checkbox" v-model="enableCurrency" class="rounded text-blue-600 focus:ring-blue-500 border-slate-300 w-4 h-4" />
-                Считать в валюте
-            </label>
-        </div>
-
-        <!-- Поля валюты (показываются если включен чекбокс) -->
-        <div v-if="enableCurrency" class="mb-5 rounded-xl border border-blue-100 bg-blue-50/30 p-3 sm:p-4">
-            <div class="mb-4 flex flex-col gap-3 sm:flex-row sm:items-end sm:gap-4">
-                <label class="field-label !mb-0 text-xs sm:w-1/3">Валюта
-                    <select v-model="targetCurrency" class="field-input mt-1">
-                        <option value="USD">USD ($)</option>
-                        <option value="EUR" :disabled="!hasManualEurRate">EUR (€)</option>
-                    </select>
-                </label>
-                <label class="field-label !mb-0 text-xs flex-1">Зафиксировать сумму
-                    <div class="relative">
-                        <input v-model.number="targetCurrencyAmount" type="number" step="0.01" min="0" class="field-input mt-1 w-full" placeholder="Итоговая сумма в валюте" />
-                        <span v-if="currentFxRate?.usd_byn && targetCurrency === 'USD'" class="absolute right-3 top-[50%] -translate-y-[50%] text-[10px] text-blue-400 font-medium bg-blue-50/80 px-1 rounded" title="Текущий курс NBRB">Курс: {{ currentFxRate.usd_byn }}</span>
-                        <span v-else-if="currentFxRate?.eur_byn && targetCurrency === 'EUR'" class="absolute right-3 top-[50%] -translate-y-[50%] text-[10px] text-blue-400 font-medium bg-blue-50/80 px-1 rounded" title="Текущий курс NBRB">Курс: {{ currentFxRate.eur_byn }}</span>
-                    </div>
-                </label>
-            </div>
-            <p v-if="targetCurrency === 'EUR' && !hasManualEurRate" class="text-xs text-amber-700">
-                EUR недоступен при ручном источнике курса. Переключите источник курса на NBRB.
-            </p>
-
-            <div class="flex flex-col gap-3 border-t border-blue-100 pt-3 sm:flex-row sm:items-center sm:justify-between">
-                 <div class="sm:w-1/2">
-                    <p class="text-xs text-slate-500 uppercase tracking-wide mb-1">Внесено оплат ({{ targetCurrency || 'USD' }})</p>
-                    <p class="text-xl font-bold text-gray-800">{{ calculatedTargetCurrencyPayments.toFixed(2) }}</p>
-                 </div>
-                 <div class="sm:text-right">
-                    <p class="text-xs text-slate-500 uppercase tracking-wide mb-1">Остаток долга ({{ targetCurrency || 'USD' }})</p>
-                    <p class="text-2xl font-bold" :class="targetCurrencyBalanceDue > 0 ? 'text-red-500' : 'text-blue-600'">
-                        {{ targetCurrencyBalanceDue.toFixed(2) }}
-                    </p>
-                 </div>
-            </div>
-        </div>
-
-        <div class="mt-3 flex flex-col gap-2 rounded-xl border border-slate-200 bg-white p-3 shadow-sm sm:flex-row sm:items-end">
-            <label class="flex-1 field-label !mb-0 text-xs">Внести платеж ({{ enableCurrency ? (targetCurrency || 'USD') : 'BYN' }})
-                <input v-model.number="newPaymentAmount" type="number" step="0.01" min="0" class="field-input mt-1 shadow-sm" placeholder="0.00" />
-            </label>
-            <label class="field-label !mb-0 text-xs sm:w-1/3">Тип
-                <select v-model="newPaymentType" class="field-input mt-1 shadow-sm">
-                    <option value="prepayment">Аванс</option>
-                    <option value="postpayment">Доплата</option>
-                </select>
-            </label>
-            <button class="btn-mini h-[38px] w-full sm:w-[100px]" :disabled="!newPaymentAmount || isAddingPayment" @click="addPayment">Внести</button>
-        </div>
-
-        <div v-if="hasDebtForBankReceipts" class="mt-4 rounded-xl border border-amber-200 bg-amber-50/60 p-3">
-          <div class="mb-3 flex items-center justify-between gap-3">
-            <div>
-              <p class="text-sm font-semibold text-amber-900">Банковские поступления по УНП</p>
-              <p class="text-xs text-amber-700">Можно прикрепить поступление, которое требует ручной проверки.</p>
-            </div>
-            <span v-if="bankReceiptsLoading" class="material-icons-round animate-spin text-amber-600">refresh</span>
-          </div>
-          <div v-if="candidateBankReceipts.length" class="space-y-2">
-            <div
-              v-for="receipt in candidateBankReceipts"
-              :key="receipt.id"
-              class="rounded-lg border border-amber-100 bg-white p-3 text-xs shadow-sm"
-            >
-              <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                <div class="min-w-0">
-                  <div class="flex flex-wrap items-center gap-2">
-                    <span class="font-bold text-slate-900">{{ formatMoney(receipt.amount) }}</span>
-                    <span class="text-slate-500">{{ formatReceiptDate(receipt.received_at) }}</span>
-                    <span v-if="receipt.payment_document_number" class="rounded bg-slate-100 px-1.5 py-0.5 font-medium text-slate-500">№ {{ receipt.payment_document_number }}</span>
-                  </div>
-                  <p v-if="receiptCandidateHint(receipt)" class="mt-1 text-amber-700">{{ receiptCandidateHint(receipt) }}</p>
-                  <p class="mt-1 line-clamp-2 text-slate-500">{{ receipt.payment_purpose || 'Назначение не указано' }}</p>
-                </div>
-                <button
-                  class="btn-mini h-8 shrink-0"
-                  :disabled="attachingReceiptId === receipt.id"
-                  @click="attachBankReceipt(receipt)"
-                >
-                  {{ attachingReceiptId === receipt.id ? '...' : 'Прикрепить' }}
-                </button>
-              </div>
-            </div>
-          </div>
-          <div v-else-if="!bankReceiptsLoading" class="rounded-lg border border-dashed border-amber-200 bg-white/70 p-3 text-center text-xs text-amber-700">
-            Нет неподтвержденных поступлений по УНП {{ order?.customer?.inn }}
-          </div>
-        </div>
-
-        <div class="mt-4 space-y-2 max-h-56 overflow-y-auto pr-1">
-            <div v-for="p in payments" :key="p.id" class="rounded-lg border border-slate-100 bg-white px-3 py-2 text-xs shadow-sm">
-                <div class="flex flex-wrap items-center justify-between gap-2">
-                    <div class="flex flex-wrap items-center gap-2">
-                        <span class="text-slate-500">{{ new Date(p.date).toLocaleDateString() }}</span>
-                        <span
-                          v-if="p.bank_receipt"
-                          class="inline-flex items-center gap-1 rounded-full border border-emerald-200 bg-emerald-50 px-2 py-0.5 font-semibold text-emerald-700"
-                        >
-                          <span class="material-icons-round text-[13px]">account_balance</span>
-                          Банк
-                        </span>
-                    </div>
-                    <span class="font-bold text-slate-800" :class="p.currency !== 'BYN' ? 'text-blue-600' : ''">
-                        <template v-if="p.currency !== 'BYN'">{{ p.amount.toFixed(2) }} {{ p.currency }}</template>
-                        <template v-else>{{ formatMoney(p.amount) }}</template>
-                    </span>
-                    <span class="text-slate-400 w-16 text-right">{{ formatPaymentType(p.type) }}</span>
-                    <div v-if="deletingPaymentId === p.id" class="flex gap-2 ml-2 items-center">
-                        <button class="text-slate-500 hover:text-slate-800 font-medium" @click="cancelDeletePayment()">Отмена</button>
-                        <button class="text-red-500 hover:text-red-700 font-bold" @click="deletePayment(p.id)">Да, удалить</button>
-                    </div>
-                    <button v-else class="flex h-6 w-6 ml-2 items-center justify-center rounded text-red-400 hover:bg-red-50 hover:text-red-600 transition-colors" @click="confirmDeletePayment(p.id)" title="Удалить платеж">
-                        <span class="material-icons-round text-[14px]">delete</span>
-                    </button>
-                </div>
-                <div v-if="p.bank_receipt" class="mt-2 rounded-lg border border-emerald-100 bg-emerald-50/40 p-2 text-[11px] text-slate-600">
-                    <div class="flex flex-wrap items-center gap-2">
-                        <span class="font-semibold text-emerald-800">ПП № {{ p.bank_receipt.payment_document_number || p.bank_receipt.payment_document_raw || p.bank_receipt.id }}</span>
-                        <span>{{ formatBankPaymentDate(p.bank_receipt.received_at || p.date) }}</span>
-                        <span v-if="p.bank_receipt.payer_unp">УНП {{ p.bank_receipt.payer_unp }}</span>
-                    </div>
-                    <p v-if="p.bank_receipt.payer_name" class="mt-1 truncate font-medium text-slate-700">{{ p.bank_receipt.payer_name }}</p>
-                    <p v-if="p.bank_receipt.payment_purpose" class="mt-1 line-clamp-2 text-slate-500">{{ p.bank_receipt.payment_purpose }}</p>
-                    <button class="mt-1 inline-flex items-center gap-1 font-semibold text-emerald-700 hover:text-emerald-900" @click="openBankReceiptJournal(p)">
-                        <span class="material-icons-round text-[13px]">receipt_long</span>
-                        Открыть в журнале
-                    </button>
-                </div>
-                <p v-else-if="p.comment" class="mt-1 text-[11px] text-slate-500">{{ p.comment }}</p>
-            </div>
-            <div v-if="!payments.length" class="text-sm text-gray-500 italic py-3 text-center rounded-xl border border-dashed border-gray-200">
-                Нет оплат
-            </div>
-        </div>
-      </section>
-      </OrderDrawerSection>
+        v-model:payments="payments"
+        v-model:enable-currency="enableCurrency"
+        v-model:target-currency="targetCurrency"
+        v-model:target-currency-amount="targetCurrencyAmount"
+        :order="order"
+        :current-fx-rate="currentFxRate"
+        :is-b2c-customer="isB2cCustomer"
+        :total="totalPreview"
+        :total-payments="totalPaymentsPreview"
+        :balance-due="balanceDuePreview"
+        :margin="marginPreview"
+        :calculated-target-currency-payments="calculatedTargetCurrencyPayments"
+        :target-currency-balance-due="targetCurrencyBalanceDue"
+        @toast="setToast($event.message, $event.type)"
+        @reload="emit('reload', $event)"
+      />
 
       </div>
     </aside>

--- a/manager_frontend/src/components/orders/OrderEditDrawer.vue
+++ b/manager_frontend/src/components/orders/OrderEditDrawer.vue
@@ -6,7 +6,6 @@ import CustomerSummaryCard from '../customers/CustomerSummaryCard.vue';
 import DealExecutionTab from './DealExecutionTab.vue';
 import OrderDocumentsPanel from './OrderDocumentsPanel.vue';
 import OrderDrawerSection from './OrderDrawerSection.vue';
-import ServiceDescriptionModeSwitch from './ServiceDescriptionModeSwitch.vue';
 import OrderAttachmentsPanel from '../service-attachments/OrderAttachmentsPanel.vue';
 import OrderEquipmentPanel from '../equipment/OrderEquipmentPanel.vue';
 import OrderWorkspaceHeader from './OrderWorkspaceHeader.vue';
@@ -17,6 +16,8 @@ import OrderPaymentsPanel from './OrderPaymentsPanel.vue';
 import OrderWebsiteIntakePanel from './OrderWebsiteIntakePanel.vue';
 import OrderPlanningPanel from './OrderPlanningPanel.vue';
 import OrderRepairPanel from './OrderRepairPanel.vue';
+import OrderProductLinesEditor from './OrderProductLinesEditor.vue';
+import OrderServiceLinesEditor from './OrderServiceLinesEditor.vue';
 import AddressSuggestInput from '../ui/AddressSuggestInput.vue';
 import { confirmDialog, promptDialog } from '../../services/ui-feedback';
 import type { ServiceAttachmentEquipmentOption } from '../service-attachments/types';
@@ -53,12 +54,20 @@ import { emptyRepairMeta, normalizeRepairMeta, type RepairMeta } from './repair-
 import { fromLocalDateTimeInput, toLocalDateTimeInput } from '../../utils/datetime';
 import {
   useServiceDescriptionMode,
-  type ServiceDescriptionLine,
   type ServiceDescriptionMode,
 } from './service-description-mode';
 
 import { getApiErrorMessage } from '../../utils/api-errors';
 import { useSmartStickyHeader } from '../../composables/useSmartStickyHeader';
+import type {
+  LogisticsComponentKind,
+  OrderDrawerDraft,
+  OrderLogisticsComponent,
+  ProductLine,
+  ProductLogisticsTemplateComponent,
+  ProductOption,
+  ServiceLine,
+} from './order-editor-types';
 
 const props = defineProps<{
   modelValue: boolean;
@@ -79,48 +88,6 @@ const emit = defineEmits<{
 const drawerScrollContainer = ref<HTMLElement | null>(null);
 const { compact: compactWorkspaceHeader, reset: resetWorkspaceHeader } = useSmartStickyHeader(drawerScrollContainer);
 
-type ProductOption = {
-  id: number;
-  title: string;
-  price: number;
-  cost?: number;
-  is_inverter: boolean;
-  power_cooling: number | null;
-  availability_status: string;
-  vitebsk_qty: number;
-  minsk_qty: number;
-  specs?: Record<string, any>;
-};
-type LogisticsComponentKind = 'indoor' | 'outdoor' | 'accessory' | 'other';
-type ProductLogisticsTemplateComponent = {
-  title: string;
-  country?: string | null;
-  unit?: string | null;
-  quantity_per_parent?: number | null;
-  price_weight?: number | null;
-  kind?: LogisticsComponentKind | null;
-};
-type OrderLogisticsComponent = {
-  title: string;
-  country?: string | null;
-  unit: string;
-  quantity_per_parent: number;
-  unit_price: number;
-  kind?: LogisticsComponentKind | null;
-};
-type ProductLine = {
-  link_id?: number | null;
-  product_id: number;
-  product_query: string;
-  quantity: number;
-  price: number;
-  cost: number;
-  product_country?: string | null;
-  product_logistics_components?: ProductLogisticsTemplateComponent[];
-  logistics_components?: OrderLogisticsComponent[] | null;
-};
-type ServiceLine = ServiceDescriptionLine;
-
 const serviceKindLabels: Record<string, string> = {
   installation: 'монтаж',
   pre_install: 'закладка трассы',
@@ -130,11 +97,6 @@ const serviceKindLabels: Record<string, string> = {
 };
 
 const formatServiceKind = (kind?: string | null) => serviceKindLabels[String(kind || '')] || kind || '';
-type OrderDrawerDraft = {
-  productLines: ProductLine[];
-  serviceLines: ServiceLine[];
-};
-
 const productOptions = ref<ProductOption[]>([]);
 const productLookupById = ref<Record<number, ProductOption>>({});
 const activeSuggestionIndex = ref<number | null>(null);
@@ -455,15 +417,6 @@ const compactObjectAddress = computed(() => (
 const customerDetailsSummary = computed(() => {
   if (customerBranchId.value) return 'Филиал и дополнительные данные';
   return 'Адрес и комментарий';
-});
-const filteredEstimateOptions = computed(() => {
-  const query = estimateSearchQuery.value.trim().toLowerCase();
-  if (!query) return estimateOptions.value;
-  return estimateOptions.value.filter((estimate) => {
-    const byTitle = (estimate.title || '').toLowerCase().includes(query);
-    const byId = String(estimate.id).includes(query);
-    return byTitle || byId;
-  });
 });
 const orderProposals = computed(() => {
   const proposals = props.order?.proposals || [];
@@ -1231,11 +1184,6 @@ const onProductChanged = (index: number, applyCatalogPrice = false) => {
   }
 };
 
-const getProductSuggestions = (index: number) => {
-  if (activeSuggestionIndex.value !== index) return [];
-  return productOptions.value.slice(0, 10);
-};
-
 const onProductQueryInput = (index: number) => {
   const row = productLines.value[index];
   if (!row) return;
@@ -1623,11 +1571,6 @@ const debouncedLoadServiceTariffOptions = useDebounceFn(async (index: number, q:
   }
 }, 300);
 
-const getServiceTariffSuggestions = (index: number) => {
-  if (activeServiceSuggestionIndex.value !== index) return [];
-  return serviceTariffOptions.value.slice(0, 10);
-};
-
 const onServiceTitleInput = (index: number) => {
   const row = serviceLines.value[index];
   if (!row) return;
@@ -1826,12 +1769,6 @@ const removeServiceLine = async (index: number) => {
   }
 };
 
-const currentCatalogPrice = (productId: number) => productLookupById.value[productId]?.price ?? null;
-const isPriceDifferentFromCatalog = (line: { product_id: number; price: number }) => {
-  const catalog = currentCatalogPrice(line.product_id);
-  return catalog !== null && Number(catalog) !== Number(line.price || 0);
-};
-const lineTotal = (line: { quantity: number; price: number }) => Number(line.quantity || 0) * Number(line.price || 0);
 const toIntegerMoney = (value: number | null | undefined): number | null => {
   if (value == null || Number.isNaN(Number(value))) return null;
   return Math.round(Number(value));
@@ -2386,326 +2323,55 @@ watch(
 
         <fieldset :disabled="activeProposalLocked" :class="activeProposalLocked ? 'opacity-60' : ''">
 
-        <section v-if="showProductLinesSection" class="mt-2">
-          <div class="mb-2 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-            <div class="flex flex-wrap items-center gap-3">
-              <h4 class="text-md font-semibold text-gray-800">Товары</h4>
-              <div class="flex items-center gap-2">
-                <label class="flex items-center gap-1 text-xs text-gray-600 bg-white border border-gray-200 px-2 py-1 rounded shadow-sm cursor-pointer hover:bg-gray-50 transition-colors">
-                  <input type="checkbox" v-model="searchInStock" class="rounded text-teal-600 focus:ring-teal-500 w-3 h-3 border-gray-300" />
-                  В наличии
-                </label>
-              </div>
-            </div>
-        </div>
-        <p v-if="getFieldError('products')" class="mb-2 text-xs text-red-300">{{ getFieldError('products') }}</p>
-        <div class="space-y-2">
-          <div
-            v-for="(line, index) in productLines"
-            :key="`product-${index}`"
-            class="relative rounded-xl border border-gray-200 bg-white p-3 shadow-sm"
-          >
-            <button
-              type="button"
-              class="absolute -right-2 -top-2 z-10 inline-flex h-8 w-8 items-center justify-center rounded-full border border-red-200 bg-red-50 text-lg font-bold text-red-600 shadow-sm transition-colors hover:bg-red-100"
-              :aria-label="`Удалить товар #${index + 1}`"
-              title="Удалить товар"
-              @click="removeProductLine(index)"
-            >
-              ×
-            </button>
-            <div class="grid grid-cols-6 gap-2 md:grid-cols-12 md:items-start">
-              <label class="relative col-span-6 space-y-1 md:col-span-5">
-                <span class="flex items-center justify-between gap-2 px-1 text-xs font-medium text-gray-500 md:h-6">
-                  <span>Название</span>
-                  <button
-                    v-if="line.product_id"
-                    class="text-xs font-semibold text-teal-700 hover:text-teal-900"
-                    type="button"
-                    @click="openSelectedProduct(index)"
-                  >
-                    Открыть ↗
-                  </button>
-                </span>
-                <textarea
-                  v-model="line.product_query"
-                  class="field-input min-h-[44px] resize-none overflow-hidden text-sm leading-snug focus:min-h-[120px] focus:resize-y focus:overflow-auto sm:text-base"
-                  rows="1"
-                  placeholder="Поиск и выбор товара"
-                  @focus="onProductInputFocus(index)"
-                  @input="onProductQueryInput(index)"
-                  @blur="onProductInputBlur(index)"
-                />
-                <div
-                  v-if="!line.product_id && line.product_query.trim().length >= 2 && (productLookupLoading || getProductSuggestions(index).length)"
-                  class="absolute left-0 right-0 top-full z-20 mt-1 max-h-56 overflow-auto rounded-[12px] border border-gray-200 bg-white p-1 shadow-xl"
-                >
-                  <div v-if="productLookupLoading" class="px-3 py-2 text-xs text-gray-500">Поиск товаров...</div>
-                  <button
-                    v-for="item in getProductSuggestions(index)"
-                    :key="`product-suggest-${index}-${item.id}`"
-                    type="button"
-                    class="mb-1 block w-full rounded-[12px] px-3 py-2 text-left text-xs text-gray-700 hover:bg-slate-100 dark:hover:bg-slate-800 last:mb-0"
-                    @mousedown.prevent
-                    @click="selectProductForLine(index, item)"
-                  >
-                    <p class="truncate font-medium text-gray-900 dark:text-slate-100">{{ item.title }}</p>
-                    <p class="mt-1 flex flex-wrap items-center gap-1 text-[11px] text-gray-500 dark:text-slate-300">
-                      <span>{{ formatMoney(item.price) }}</span>
-                      <span>·</span>
-                      <span>{{ item.is_inverter ? 'Инвертор' : 'On/Off' }}</span>
-                      <span>·</span>
-                      <template v-if="item.vitebsk_qty > 0 || item.minsk_qty > 0">
-                        <span v-if="item.vitebsk_qty > 0" class="font-medium text-emerald-600 bg-emerald-50 px-1 rounded">Вит: {{item.vitebsk_qty}}</span>
-                        <span v-if="item.minsk_qty > 0" class="font-medium text-blue-500 bg-blue-50 px-1 rounded">Минск: {{item.minsk_qty}}</span>
-                      </template>
-                      <template v-else>
-                        <span v-if="item.availability_status === 'check_availability'" class="font-medium text-amber-500">Уточнять</span>
-                        <span v-else class="text-gray-400">Нет в наличии</span>
-                      </template>
-                    </p>
-                  </button>
-                </div>
-              </label>
-              <label class="col-span-4 space-y-1 md:col-span-2">
-                <span class="flex h-auto items-center px-1 text-xs font-medium text-gray-500 md:h-6">Цена</span>
-                <input v-model.number="line.price" type="number" min="0" class="field-input" placeholder="0" />
-              </label>
-              <label class="col-span-2 space-y-1 md:col-span-1">
-                <span class="flex h-auto items-center whitespace-nowrap px-1 text-xs font-medium text-gray-500 md:h-6 md:text-[11px]">Кол-во</span>
-                <input v-model.number="line.quantity" type="number" min="1" class="field-input" placeholder="1" />
-              </label>
-              <label class="col-span-3 space-y-1 md:col-span-2">
-                <span class="flex h-auto items-center px-1 text-xs font-medium text-gray-500 md:h-6">Себест.</span>
-                <input v-model.number="line.cost" type="number" min="0" class="field-input" placeholder="0" />
-              </label>
-              <div class="col-span-3 space-y-1 md:col-span-2">
-                <span class="flex h-auto items-center px-1 text-xs font-medium text-gray-500 md:h-6">Итого</span>
-                <div class="rounded-lg bg-gray-50 px-3 py-2">
-                  <p class="whitespace-nowrap text-base font-semibold leading-tight text-gray-900">{{ formatMoney(lineTotal(line)) }}</p>
-                </div>
-              </div>
-              <p
-                v-if="isPriceDifferentFromCatalog(line)"
-                class="col-span-6 rounded-md border border-amber-300 bg-amber-50 px-2 py-1 text-xs text-amber-700 md:col-span-12"
-              >
-                Цена строки отличается от каталожной ({{ formatMoney(currentCatalogPrice(line.product_id) || 0) }}).
-              </p>
-              <div class="col-span-6 flex flex-wrap items-center gap-2 border-t border-gray-100 pt-2 md:col-span-12">
-                <span
-                  v-if="supplyBadgeForLine(line)"
-                  class="inline-flex items-center gap-1 rounded-full bg-teal-50 px-2 py-1 text-xs font-semibold text-teal-700"
-                >
-                  Поставка: {{ supplyBadgeForLine(line)?.label }}
-                </span>
-                <span v-else-if="line.link_id" class="text-xs text-gray-500">Поставка не создана</span>
-                <button
-                  type="button"
-                  class="rounded-lg border border-teal-200 px-3 py-1.5 text-xs font-semibold text-teal-700 hover:bg-teal-50 disabled:opacity-50"
-                  :disabled="!line.product_id || supplyActionLoadingLineId === line.link_id"
-                  @click="createSupplyFromProductLine(line, 'order')"
-                >
-                  В поставку
-                </button>
-                <button
-                  type="button"
-                  class="rounded-lg border border-indigo-200 px-3 py-1.5 text-xs font-semibold text-indigo-700 hover:bg-indigo-50 disabled:opacity-50"
-                  :disabled="!line.product_id || supplyActionLoadingLineId === line.link_id"
-                  @click="createSupplyFromProductLine(line, 'reserve')"
-                >
-                  Забронировать
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-        <button type="button" class="btn-mini mt-3 w-full justify-center" @click="addProductLine">+ товар</button>
-      </section>
+        <OrderProductLinesEditor
+          v-if="showProductLinesSection"
+          v-model:lines="productLines"
+          v-model:search-in-stock="searchInStock"
+          :product-options="productOptions"
+          :product-lookup-by-id="productLookupById"
+          :product-lookup-loading="productLookupLoading"
+          :active-suggestion-index="activeSuggestionIndex"
+          :supply-action-loading-line-id="supplyActionLoadingLineId"
+          :products-error="getFieldError('products')"
+          :supply-badge-for-line="supplyBadgeForLine"
+          @focus="onProductInputFocus"
+          @input="onProductQueryInput"
+          @blur="onProductInputBlur"
+          @select="selectProductForLine($event.index, $event.option)"
+          @open="openSelectedProduct"
+          @remove="removeProductLine"
+          @add="addProductLine"
+          @supply="createSupplyFromProductLine($event.line, $event.intent)"
+        />
 
-        <section class="mt-6">
-          <div class="mb-2">
-            <h4 class="text-md font-semibold text-gray-800">Услуги</h4>
-          </div>
-          <p v-if="getFieldError('services')" class="mb-2 text-xs text-red-300">{{ getFieldError('services') }}</p>
-          <div class="space-y-2">
-            <div
-              v-for="(line, index) in serviceLines"
-              :key="`service-${index}`"
-              class="relative rounded-xl border border-gray-200 bg-white p-3 shadow-sm"
-            >
-              <button
-                v-if="editingServiceLineIndex === index"
-                type="button"
-                class="absolute -right-2 -top-2 z-10 inline-flex h-8 w-8 items-center justify-center rounded-full border border-red-200 bg-red-50 text-lg font-bold text-red-600 shadow-sm transition-colors hover:bg-red-100"
-                :aria-label="`Удалить услугу #${index + 1}`"
-                title="Удалить услугу"
-                @click="removeServiceLine(index)"
-              >
-                ×
-              </button>
-              <div v-if="editingServiceLineIndex !== index" class="flex min-w-0 items-start gap-3">
-                <div class="min-w-0 flex-1">
-                  <p class="break-words text-sm font-semibold leading-snug text-slate-900 dark:text-slate-100">{{ line.title || 'Новая услуга' }}</p>
-                  <div class="mt-1 flex flex-wrap items-center justify-between gap-x-3 gap-y-1 text-xs text-slate-500 dark:text-slate-400">
-                    <span>{{ line.quantity }} × {{ formatMoney(line.price) }}</span>
-                    <span class="font-semibold text-slate-800 dark:text-slate-200">{{ formatMoney(lineTotal(line)) }}</span>
-                  </div>
-                </div>
-                <button
-                  type="button"
-                  class="btn-mini-outline h-9 w-9 shrink-0 justify-center p-0"
-                  :aria-label="`Редактировать услугу #${index + 1}`"
-                  title="Редактировать"
-                  @click="editingServiceLineIndex = index"
-                >
-                  <span class="material-icons-round text-[17px]">edit</span>
-                </button>
-              </div>
-              <div v-else class="grid grid-cols-6 gap-2 md:grid-cols-12 md:items-start">
-                <div class="relative col-span-6 space-y-1 md:col-span-5">
-                  <span class="flex min-h-6 items-center justify-between gap-2 px-1 text-xs font-medium text-gray-500">
-                    <span>Название</span>
-                    <ServiceDescriptionModeSwitch
-                      v-if="line.template_full_description"
-                      :model-value="line.description_mode || 'short'"
-                      @update:model-value="setServiceLineDescriptionMode(index, $event)"
-                    />
-                  </span>
-                  <textarea
-                    v-model="line.title"
-                    class="field-input min-h-[64px] resize-none overflow-hidden text-sm leading-snug focus:min-h-[120px] focus:resize-y focus:overflow-auto sm:text-base"
-                    rows="2"
-                    placeholder="Название услуги"
-                    @focus="onServiceTitleFocus(index)"
-                    @input="onServiceTitleInput(index)"
-                    @blur="onServiceTitleBlur(index)"
-                  />
-                  <div
-                    v-if="line.title.trim().length >= 2 && activeServiceSuggestionIndex === index && (serviceTariffLookupLoading || getServiceTariffSuggestions(index).length)"
-                    class="absolute left-0 right-0 top-full z-20 mt-1 max-h-64 overflow-auto rounded-[12px] border border-gray-200 bg-white p-1 shadow-xl"
-                  >
-                    <div v-if="serviceTariffLookupLoading" class="px-3 py-2 text-xs text-gray-500">Ищем тарифы...</div>
-                    <button
-                      v-for="item in getServiceTariffSuggestions(index)"
-                      :key="`service-tariff-suggest-${index}-${item.tariff_id}`"
-                      type="button"
-                      class="mb-1 block w-full rounded-[12px] px-3 py-2 text-left text-xs text-gray-700 hover:bg-slate-100 last:mb-0"
-                      @mousedown.prevent
-                      @click="selectServiceTariffForLine(index, item)"
-                    >
-                      <p class="line-clamp-2 font-medium text-gray-900">{{ item.short_name || item.title }}</p>
-                      <p
-                        v-if="item.full_description && item.full_description !== item.short_name"
-                        class="mt-0.5 line-clamp-2 text-[11px] leading-snug text-gray-500"
-                      >
-                        {{ item.full_description }}
-                      </p>
-                      <p class="mt-1 flex flex-wrap items-center gap-1 text-[11px] text-gray-500">
-                        <span>{{ formatMoney(item.price) }}</span>
-                        <span v-if="item.service_kind">· {{ formatServiceKind(item.service_kind) }}</span>
-                        <span v-if="item.category">· {{ item.category }}</span>
-                        <span v-if="item.included_route_meters">· трасса до {{ item.included_route_meters }} м</span>
-                      </p>
-                    </button>
-                  </div>
-                </div>
-                <label class="col-span-4 space-y-1 md:col-span-2">
-                  <span class="flex h-auto items-center px-1 text-xs font-medium text-gray-500 md:h-6">Цена</span>
-                  <input v-model.number="line.price" type="number" min="0" class="field-input" placeholder="0" />
-                </label>
-                <label class="col-span-2 space-y-1 md:col-span-1">
-                  <span class="flex h-auto items-center whitespace-nowrap px-1 text-xs font-medium text-gray-500 md:h-6 md:text-[11px]">Кол-во</span>
-                  <input v-model.number="line.quantity" type="number" min="1" class="field-input" placeholder="1" />
-                </label>
-                <label class="col-span-3 space-y-1 md:col-span-2">
-                  <span class="flex h-auto items-center px-1 text-xs font-medium text-gray-500 md:h-6">Себест.</span>
-                  <input v-model.number="line.cost" type="number" min="0" class="field-input" placeholder="0" />
-                </label>
-                <div class="col-span-3 space-y-1 md:col-span-2">
-                  <span class="flex h-auto items-center px-1 text-xs font-medium text-gray-500 md:h-6">Итого</span>
-                  <div class="rounded-lg bg-gray-50 px-3 py-2">
-                    <p class="whitespace-nowrap text-base font-semibold leading-tight text-gray-900">{{ formatMoney(lineTotal(line)) }}</p>
-                  </div>
-                </div>
-                <div class="col-span-6 flex justify-end md:col-span-12">
-                  <button type="button" class="btn-mini-outline h-8 px-3 text-xs" @click="editingServiceLineIndex = null">Готово</button>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class="mt-3 grid grid-cols-2 gap-2">
-            <button type="button" class="btn-mini justify-center" @click="addServiceLine">+ услуга</button>
-            <button
-              type="button"
-              class="btn-mini-outline justify-center"
-              :class="showEstimateImport ? 'border-teal-200 bg-teal-50 text-teal-700' : ''"
-              @click="toggleEstimateImport"
-            >
-              Из сметы
-            </button>
-          </div>
-          <div v-if="showEstimateImport" class="mt-3 grid gap-2 rounded-xl border border-gray-200 bg-gray-50 p-3">
-            <div class="grid gap-2 md:grid-cols-3">
-              <label class="space-y-1 md:col-span-3">
-                <span class="px-1 text-xs font-medium text-gray-500">Смета</span>
-                <select
-                  v-model="selectedEstimateId"
-                  class="field-input min-w-0"
-                  :disabled="estimateOptionsLoading"
-                >
-                  <option :value="null">Выберите смету</option>
-                  <option v-for="estimate in filteredEstimateOptions" :key="estimate.id" :value="estimate.id">
-                    #{{ estimate.id }} · {{ estimate.title }} · {{ formatMoney(estimate.total) }} {{ estimate.currency }}
-                  </option>
-                </select>
-              </label>
-              <label class="space-y-1">
-                <span class="px-1 text-xs font-medium text-gray-500">Поиск</span>
-                <input
-                  v-model="estimateSearchQuery"
-                  class="field-input"
-                  placeholder="ID или название"
-                />
-              </label>
-              <label class="space-y-1">
-                <span class="px-1 text-xs font-medium text-gray-500">Структура</span>
-                <select v-model="estimateImportMode" class="field-input">
-                  <option value="detailed">По строкам</option>
-                  <option value="collapsed">Одной строкой</option>
-                </select>
-              </label>
-              <div class="space-y-1">
-                <span class="block px-1 text-xs font-medium text-gray-500">Текст позиции</span>
-                <ServiceDescriptionModeSwitch
-                  :model-value="serviceDescriptionMode"
-                  @update:model-value="setDefaultServiceDescriptionMode"
-                />
-              </div>
-            </div>
-            <div class="flex flex-col gap-2 sm:flex-row">
-              <button
-                type="button"
-                class="btn-mini justify-center whitespace-nowrap"
-                :disabled="importingEstimate || !selectedEstimateId"
-                @click="applyEstimateToServices"
-              >
-                {{ importingEstimate ? 'Добавляю...' : 'Добавить из сметы' }}
-              </button>
-              <button
-                type="button"
-                class="btn-mini-outline justify-center whitespace-nowrap"
-                :disabled="estimateOptionsLoading"
-                @click="loadEstimateOptions"
-                title="Обновить список смет"
-              >
-                Обновить
-              </button>
-            </div>
-            <p class="text-xs text-gray-500">
-              Показываем 10 последних смет. Структура определяет количество строк, а формат текста — краткую или подробную формулировку.
-            </p>
-          </div>
-        </section>
+        <OrderServiceLinesEditor
+          v-model:lines="serviceLines"
+          v-model:editing-index="editingServiceLineIndex"
+          v-model:show-estimate-import="showEstimateImport"
+          v-model:selected-estimate-id="selectedEstimateId"
+          v-model:estimate-search-query="estimateSearchQuery"
+          v-model:estimate-import-mode="estimateImportMode"
+          v-model:description-mode="serviceDescriptionMode"
+          :service-options="serviceTariffOptions"
+          :service-lookup-loading="serviceTariffLookupLoading"
+          :active-suggestion-index="activeServiceSuggestionIndex"
+          :services-error="getFieldError('services')"
+          :estimate-options="estimateOptions"
+          :estimate-options-loading="estimateOptionsLoading"
+          :importing-estimate="importingEstimate"
+          :format-service-kind="formatServiceKind"
+          @focus="onServiceTitleFocus"
+          @input="onServiceTitleInput"
+          @blur="onServiceTitleBlur"
+          @select="selectServiceTariffForLine($event.index, $event.option)"
+          @description-mode="setServiceLineDescriptionMode($event.index, $event.mode)"
+          @remove="removeServiceLine"
+          @add="addServiceLine"
+          @toggle-estimate="toggleEstimateImport"
+          @import-estimate="applyEstimateToServices"
+          @load-estimates="loadEstimateOptions"
+          @remember-description-mode="setDefaultServiceDescriptionMode"
+        />
         </fieldset>
       </div>
       </OrderDrawerSection>

--- a/manager_frontend/src/components/orders/OrderEditDrawer.vue
+++ b/manager_frontend/src/components/orders/OrderEditDrawer.vue
@@ -1,21 +1,19 @@
 <script setup lang="ts">
 import { computed, nextTick, ref, watch } from 'vue';
 import DealExecutionTab from './DealExecutionTab.vue';
-import OrderDrawerSection from './OrderDrawerSection.vue';
 import OrderAttachmentsPanel from '../service-attachments/OrderAttachmentsPanel.vue';
 import OrderEquipmentPanel from '../equipment/OrderEquipmentPanel.vue';
 import OrderWorkspaceHeader from './OrderWorkspaceHeader.vue';
 import OrderSalesInstallationWorkspace from './OrderSalesInstallationWorkspace.vue';
-import OrderProposalToolbar from './OrderProposalToolbar.vue';
 import OrderPaymentsPanel from './OrderPaymentsPanel.vue';
 import OrderWebsiteIntakePanel from './OrderWebsiteIntakePanel.vue';
 import OrderPlanningPanel from './OrderPlanningPanel.vue';
 import OrderRepairPanel from './OrderRepairPanel.vue';
-import OrderProductLinesEditor from './OrderProductLinesEditor.vue';
-import OrderServiceLinesEditor from './OrderServiceLinesEditor.vue';
 import OrderCustomerContext from './OrderCustomerContext.vue';
 import OrderExecutionPanel from './OrderExecutionPanel.vue';
 import OrderDocumentsWorkspace from './OrderDocumentsWorkspace.vue';
+import OrderManagerLabels from './OrderManagerLabels.vue';
+import OrderProposalWorkspace from './OrderProposalWorkspace.vue';
 import type { ServiceAttachmentEquipmentOption } from '../service-attachments/types';
 import type {
   ManagerOrderDetailResponse,
@@ -74,64 +72,30 @@ function setToast(message: string, type: 'success' | 'error' = 'success') {
 
 const savedLinesSnapshot = ref('');
 const savedFormSnapshot = ref('');
-const {
-  activeServiceSuggestionIndex,
-  activeSuggestionIndex,
-  addProductLine,
-  addServiceLine,
-  applyEstimateToServices,
-  applyTariffTemplateToLine,
-  buildLinesPayload,
-  createSupplyFromProductLine,
-  currentLinesSnapshot: buildCurrentLinesSnapshot,
-  editingServiceLineIndex,
-  estimateImportMode,
-  estimateOptions,
-  estimateOptionsLoading,
-  estimateSearchQuery,
-  importingEstimate,
-  loadEstimateOptions,
-  loadLines,
-  loadOrderSupplyRequests,
-  margin: marginPreview,
-  onProductInputBlur,
-  onProductInputFocus,
-  onProductQueryInput,
-  onServiceTitleBlur,
-  onServiceTitleFocus,
-  onServiceTitleInput,
-  openSelectedProduct,
-  productLines,
-  productLookupById,
-  productLookupLoading,
-  productOptions,
-  removeProductLine,
-  removeServiceLine,
-  resetLookupState,
-  searchInStock,
-  selectProductForLine,
-  selectServiceTariffForLine,
-  selectedEstimateId,
-  serviceDescriptionMode,
-  serviceLines,
-  serviceTariffLookupLoading,
-  serviceTariffOptions,
-  setDefaultServiceDescriptionMode,
-  setServiceLineDescriptionMode,
-  showEstimateImport,
-  supplyActionLoadingLineId,
-  supplyBadgeForLine,
-  syncProductLookupFromLines,
-  toggleEstimateImport,
-  total: totalPreview,
-  validateLines: validateProposalLines,
-} = useOrderCommercialEditor({
+const commercialEditor = useOrderCommercialEditor({
   order: computed(() => props.order),
   setToast,
   persistDraft: () => persistDraft(),
 });
 const {
-  addManagerLabel,
+  activeServiceSuggestionIndex,
+  applyTariffTemplateToLine,
+  buildLinesPayload,
+  currentLinesSnapshot: buildCurrentLinesSnapshot,
+  loadEstimateOptions,
+  loadLines,
+  loadOrderSupplyRequests,
+  margin: marginPreview,
+  productLines,
+  resetLookupState,
+  serviceLines,
+  serviceTariffOptions,
+  showEstimateImport,
+  syncProductLookupFromLines,
+  total: totalPreview,
+  validateLines: validateProposalLines,
+} = commercialEditor;
+const {
   assessmentDate,
   autoCloseOnPayment,
   autoExecutionOnPayment,
@@ -156,7 +120,6 @@ const {
   isRepairWorkflow,
   localFormError,
   localServerErrors,
-  managerLabelDraft,
   managerLabels,
   measurementRequired,
   measurementResult,
@@ -165,7 +128,6 @@ const {
   newBranchAddress,
   orderTitle,
   payments,
-  removeManagerLabel,
   repairMeta,
   setWorkflowType,
   showProductLinesSection,
@@ -189,30 +151,9 @@ const {
 const linkedEquipmentOptions = ref<ServiceAttachmentEquipmentOption[]>([]);
 const equipmentPanelRef = ref<InstanceType<typeof OrderEquipmentPanel> | null>(null);
 const documentsWorkspaceRef = ref<InstanceType<typeof OrderDocumentsWorkspace> | null>(null);
-const proposalToolbarRef = ref<InstanceType<typeof OrderProposalToolbar> | null>(null);
+const proposalWorkspaceRef = ref<InstanceType<typeof OrderProposalWorkspace> | null>(null);
 
-const showManagerLabelInput = ref(false);
-
-const {
-  activeProposal,
-  activeProposalId,
-  activeProposalLineLabel,
-  activeProposalLocked,
-  activeProposalStatus,
-  archiveProposal,
-  changeActiveProposalStatus,
-  createProposal,
-  duplicateProposal,
-  loadProposalLines,
-  onProposalClick,
-  proposalActionLoading,
-  proposalStatus,
-  proposals: orderProposals,
-  renameProposal,
-  saveCurrentProposalLines,
-  selectProposalForOrder,
-  selectedProposal: selectedOrderProposal,
-} = useOrderProposalLifecycle({
+const proposalLifecycle = useOrderProposalLifecycle({
   order: computed(() => props.order),
   negotiationStatus,
   total: totalPreview,
@@ -229,6 +170,18 @@ const {
   onUpdated: (updatedOrder) => emit('updated', updatedOrder),
   onReload: (orderId) => emit('reload', orderId),
 });
+const {
+  activeProposal,
+  activeProposalId,
+  activeProposalLocked,
+  changeActiveProposalStatus,
+  createProposal,
+  duplicateProposal,
+  loadProposalLines,
+  proposalStatus,
+  saveCurrentProposalLines,
+  selectedProposal: selectedOrderProposal,
+} = proposalLifecycle;
 
 const {
   clearDraft,
@@ -451,7 +404,7 @@ const handleWorkspaceNextAction = async () => {
   if (action.command === 'record_proposal_response') {
     openWorkspaceTarget('proposal');
     await nextTick();
-    proposalToolbarRef.value?.openResponse();
+    proposalWorkspaceRef.value?.openResponse();
     return;
   }
   if (action.command === 'create_proposal_variant') return duplicateProposal();
@@ -516,29 +469,7 @@ const handleCustomerUpdated = async (updatedOrder: ManagerOrderDetailResponse) =
       />
 
       <div class="p-4 sm:p-6">
-      <div v-if="managerLabels.length || showManagerLabelInput" class="mt-3 flex flex-wrap items-center gap-1.5">
-        <span
-          v-for="label in managerLabels"
-          :key="label"
-          class="inline-flex items-center gap-1 rounded-full border border-teal-200 bg-teal-50 px-2 py-1 text-xs font-medium text-teal-800 dark:border-teal-500/30 dark:bg-teal-500/10 dark:text-teal-200"
-        >
-          {{ label }}
-          <button type="button" class="rounded-full p-0.5 hover:bg-teal-100 dark:hover:bg-teal-800" :aria-label="'Удалить метку ' + label" @click="removeManagerLabel(label)">
-            <span class="material-icons-round block text-[13px]">close</span>
-          </button>
-        </span>
-        <button v-if="!showManagerLabelInput" type="button" class="inline-flex items-center gap-1 rounded-full border border-dashed border-slate-300 px-2 py-1 text-xs font-medium text-slate-500 hover:border-teal-300 hover:text-teal-700 dark:border-slate-700 dark:text-slate-400" @click="showManagerLabelInput = true">
-          <span class="material-icons-round text-[13px]">add</span> Добавить метку
-        </button>
-        <div v-if="showManagerLabelInput" class="flex min-w-[190px] gap-1.5">
-          <input v-model="managerLabelDraft" class="field-input h-8 text-xs" placeholder="Новая метка" @keydown.enter.prevent="addManagerLabel" @keydown.esc.prevent="showManagerLabelInput = false" />
-          <button type="button" class="btn-mini h-8 px-2 text-xs" @click="addManagerLabel">Добавить</button>
-        </div>
-      </div>
-      <button v-else type="button" class="mt-2 inline-flex items-center gap-1 text-xs font-medium text-slate-500 hover:text-teal-700 dark:text-slate-400 dark:hover:text-teal-300" @click="showManagerLabelInput = true">
-        <span class="material-icons-round text-[14px]">add</span> Добавить метку
-      </button>
-
+      <OrderManagerLabels v-model="managerLabels" />
       <OrderCustomerContext
         v-if="order"
         v-model:delivery-address="customerDeliveryAddress"
@@ -637,95 +568,18 @@ const handleCustomerUpdated = async (updatedOrder: ManagerOrderDetailResponse) =
 
 
 
-      <!-- Смета -->
-      <OrderDrawerSection
-        id="order-workspace-proposal"
+      <OrderProposalWorkspace
+        ref="proposalWorkspaceRef"
         v-model:expanded="expandedDrawerSections.proposals"
+        :commercial="commercialEditor"
+        :proposal="proposalLifecycle"
         :title="isRepairWorkflow ? 'Смета ремонта' : 'Предложения'"
-        :summary="activeProposalLineLabel"
-        tone="default"
-        :has-error="Boolean(getFieldError('products') || getFieldError('services'))"
-      >
-        <div class="min-w-0">
-        <OrderProposalToolbar
-          ref="proposalToolbarRef"
-          class="mb-4"
-          :proposals="orderProposals"
-          :active-proposal-id="activeProposal?.id"
-          :loading="proposalActionLoading"
-          @open="onProposalClick"
-          @select="selectProposalForOrder"
-          @create="createProposal"
-          @duplicate="duplicateProposal"
-          @rename="renameProposal"
-          @archive="archiveProposal"
-          @change-status="changeActiveProposalStatus"
-          @send="openProposalSend"
-        />
-
-        <div v-if="activeProposalLocked" class="mb-3 flex flex-col gap-2 rounded-xl border border-amber-200 bg-amber-50 p-3 text-xs text-amber-900 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-100 sm:flex-row sm:items-center sm:justify-between">
-          <span>Эта редакция уже {{ activeProposalStatus === 'approved' ? 'принята клиентом' : 'отправлена' }}. Чтобы изменить состав или стоимость, создайте копию либо верните её в черновик.</span>
-          <div class="flex shrink-0 gap-2">
-            <button type="button" class="btn-mini-outline h-8 px-2 text-xs" @click="duplicateProposal">Создать копию</button>
-            <button type="button" class="btn-mini-outline h-8 px-2 text-xs" @click="changeActiveProposalStatus('draft')">В черновик</button>
-          </div>
-        </div>
-
-        <fieldset :disabled="activeProposalLocked" :class="activeProposalLocked ? 'opacity-60' : ''">
-
-        <OrderProductLinesEditor
-          v-if="showProductLinesSection"
-          v-model:lines="productLines"
-          v-model:search-in-stock="searchInStock"
-          :product-options="productOptions"
-          :product-lookup-by-id="productLookupById"
-          :product-lookup-loading="productLookupLoading"
-          :active-suggestion-index="activeSuggestionIndex"
-          :supply-action-loading-line-id="supplyActionLoadingLineId"
-          :products-error="getFieldError('products')"
-          :supply-badge-for-line="supplyBadgeForLine"
-          @focus="onProductInputFocus"
-          @input="onProductQueryInput"
-          @blur="onProductInputBlur"
-          @select="selectProductForLine($event.index, $event.option)"
-          @open="openSelectedProduct"
-          @remove="removeProductLine"
-          @add="addProductLine"
-          @supply="createSupplyFromProductLine($event.line, $event.intent)"
-        />
-
-        <OrderServiceLinesEditor
-          v-model:lines="serviceLines"
-          v-model:editing-index="editingServiceLineIndex"
-          v-model:show-estimate-import="showEstimateImport"
-          v-model:selected-estimate-id="selectedEstimateId"
-          v-model:estimate-search-query="estimateSearchQuery"
-          v-model:estimate-import-mode="estimateImportMode"
-          v-model:description-mode="serviceDescriptionMode"
-          :service-options="serviceTariffOptions"
-          :service-lookup-loading="serviceTariffLookupLoading"
-          :active-suggestion-index="activeServiceSuggestionIndex"
-          :services-error="getFieldError('services')"
-          :estimate-options="estimateOptions"
-          :estimate-options-loading="estimateOptionsLoading"
-          :importing-estimate="importingEstimate"
-          :format-service-kind="formatServiceKind"
-          @focus="onServiceTitleFocus"
-          @input="onServiceTitleInput"
-          @blur="onServiceTitleBlur"
-          @select="selectServiceTariffForLine($event.index, $event.option)"
-          @description-mode="setServiceLineDescriptionMode($event.index, $event.mode)"
-          @remove="removeServiceLine"
-          @add="addServiceLine"
-          @toggle-estimate="toggleEstimateImport"
-          @import-estimate="applyEstimateToServices"
-          @load-estimates="loadEstimateOptions"
-          @remember-description-mode="setDefaultServiceDescriptionMode"
-        />
-        </fieldset>
-      </div>
-      </OrderDrawerSection>
-
+        :show-product-lines="showProductLinesSection"
+        :products-error="getFieldError('products')"
+        :services-error="getFieldError('services')"
+        :format-service-kind="formatServiceKind"
+        @send="openProposalSend"
+      />
       <OrderDocumentsWorkspace
         v-if="order"
         ref="documentsWorkspaceRef"

--- a/manager_frontend/src/components/orders/OrderEditDrawer.vue
+++ b/manager_frontend/src/components/orders/OrderEditDrawer.vue
@@ -16,6 +16,7 @@ import OrderProposalToolbar from './OrderProposalToolbar.vue';
 import OrderPaymentsPanel from './OrderPaymentsPanel.vue';
 import OrderWebsiteIntakePanel from './OrderWebsiteIntakePanel.vue';
 import OrderPlanningPanel from './OrderPlanningPanel.vue';
+import OrderRepairPanel from './OrderRepairPanel.vue';
 import AddressSuggestInput from '../ui/AddressSuggestInput.vue';
 import { confirmDialog, promptDialog } from '../../services/ui-feedback';
 import type { ServiceAttachmentEquipmentOption } from '../service-attachments/types';
@@ -32,14 +33,9 @@ import type {
   PaymentResponse,
   PaymentCurrency,
   FxRateResponse,
-  ManagerRepairComplaintPresetResponse,
-  EquipmentServiceEventType,
-  ManagerEquipmentDetailResponse,
-  ManagerEquipmentItemResponse,
-  ManagerEquipmentHistoryFromRepairOrderPayload,
   OutgoingEmailResponse,
 } from '../../client';
-import { ManagerOrdersService, ManagerSettingsService, ManagerMailService, ManagerRepairComplaintsService, ManagerEquipmentService } from '../../client';
+import { ManagerOrdersService, ManagerSettingsService, ManagerMailService } from '../../client';
 import { EXECUTION_STATUS_OPTIONS, formatMoney } from './order-utils';
 import {
   buildOrderWorkspaceViewModel,
@@ -53,20 +49,7 @@ import {
   proposalStatusLabel,
   type ProposalLifecycleStatus,
 } from './proposal-lifecycle';
-import {
-  CUSTOMER_APPROVAL_STATUS_OPTIONS,
-  EQUIPMENT_EVENT_OPTIONS,
-  PARTS_STATUS_OPTIONS,
-  REFRIGERANT_PRICING_MODE_OPTIONS,
-  REPAIR_AI_DEFECT_TYPES,
-  REPAIR_CHOICE_OPTIONS,
-  REPAIR_WORKFLOW_STATUS_OPTIONS,
-  emptyRepairMeta,
-  labeledOptionsWithCurrent,
-  normalizeRepairMeta,
-  selectOptionsWithCurrent,
-  type RepairMeta,
-} from './repair-meta';
+import { emptyRepairMeta, normalizeRepairMeta, type RepairMeta } from './repair-meta';
 import { fromLocalDateTimeInput, toLocalDateTimeInput } from '../../utils/datetime';
 import {
   useServiceDescriptionMode,
@@ -274,24 +257,6 @@ const selectedEstimateId = ref<number | null>(null);
 const estimateSearchQuery = ref('');
 const importingEstimate = ref(false);
 const showEstimateImport = ref(false);
-const repairComplaintPresets = ref<ManagerRepairComplaintPresetResponse[]>([]);
-const repairComplaintSearch = ref('');
-const repairComplaintsLoading = ref(false);
-const repairAiDefectType = ref(REPAIR_AI_DEFECT_TYPES[0]?.value || '');
-const repairAiExtraContext = ref('');
-const repairAiAllowAssumptions = ref(false);
-const repairAiPolishExisting = ref(true);
-const repairAiGenerating = ref(false);
-const repairEquipment = ref<ManagerEquipmentItemResponse[]>([]);
-const repairEquipmentLoading = ref(false);
-const repairEquipmentError = ref('');
-const selectedRepairEquipmentId = ref<number | null>(null);
-const selectedRepairEquipmentDetail = ref<ManagerEquipmentDetailResponse | null>(null);
-const repairEquipmentHistoryLoading = ref(false);
-const creatingRepairEquipment = ref(false);
-const recordingRepairHistory = ref(false);
-const repairHistoryEventType = ref<EquipmentServiceEventType | ''>('');
-const repairHistoryNotes = ref('');
 const payments = ref<PaymentResponse[]>([]);
 const linkedEquipmentOptions = ref<ServiceAttachmentEquipmentOption[]>([]);
 const equipmentPanelRef = ref<InstanceType<typeof OrderEquipmentPanel> | null>(null);
@@ -460,132 +425,6 @@ const createCustomerBranch = async () => {
   }
 };
 
-const resetRepairEquipment = () => {
-  repairEquipment.value = [];
-  selectedRepairEquipmentId.value = null;
-  selectedRepairEquipmentDetail.value = null;
-  repairEquipmentError.value = '';
-  repairHistoryEventType.value = '';
-  repairHistoryNotes.value = '';
-};
-
-const loadRepairEquipmentDetail = async (equipmentId: number) => {
-  repairEquipmentHistoryLoading.value = true;
-  repairEquipmentError.value = '';
-  try {
-    selectedRepairEquipmentDetail.value = await ManagerEquipmentService.getManagerEquipment(equipmentId, 10);
-  } catch (error) {
-    selectedRepairEquipmentDetail.value = null;
-    repairEquipmentError.value = `Не удалось загрузить историю оборудования: ${getApiErrorMessage(error)}`;
-  } finally {
-    repairEquipmentHistoryLoading.value = false;
-  }
-};
-
-const selectRepairEquipment = async (equipmentId: number) => {
-  selectedRepairEquipmentId.value = equipmentId;
-  await loadRepairEquipmentDetail(equipmentId);
-};
-
-const loadRepairEquipment = async () => {
-  const customerId = customer.value?.id;
-  if (!customerId || !isRepairWorkflow.value) {
-    resetRepairEquipment();
-    return;
-  }
-  repairEquipmentLoading.value = true;
-  repairEquipmentError.value = '';
-  try {
-    const branchId = customerBranchId.value || null;
-    const response = await ManagerEquipmentService.listManagerEquipment(customerId, branchId, 1, 50, false);
-    repairEquipment.value = response.items || [];
-    if (selectedRepairEquipmentId.value && !repairEquipment.value.some((item) => item.id === selectedRepairEquipmentId.value)) {
-      selectedRepairEquipmentId.value = null;
-      selectedRepairEquipmentDetail.value = null;
-    }
-    if (!selectedRepairEquipmentId.value && repairEquipment.value.length) {
-      await selectRepairEquipment(repairEquipment.value[0]!.id);
-    } else if (selectedRepairEquipmentId.value) {
-      await loadRepairEquipmentDetail(selectedRepairEquipmentId.value);
-    }
-  } catch (error) {
-    repairEquipment.value = [];
-    selectedRepairEquipmentDetail.value = null;
-    repairEquipmentError.value = `Не удалось загрузить оборудование клиента: ${getApiErrorMessage(error)}`;
-  } finally {
-    repairEquipmentLoading.value = false;
-  }
-};
-
-const createRepairEquipmentFromMeta = async () => {
-  const customerId = customer.value?.id;
-  if (!customerId || creatingRepairEquipment.value) return;
-  const meta = repairMeta.value;
-  const displayName = trimOrNull(meta.equipment_name) || trimOrNull(orderTitle.value) || trimOrNull(props.order?.title || '');
-  const hasPassportData = Boolean(
-    displayName
-    || trimOrNull(meta.equipment_brand)
-    || trimOrNull(meta.equipment_model)
-    || trimOrNull(meta.equipment_serial_number)
-    || trimOrNull(meta.equipment_inventory_number),
-  );
-  if (!hasPassportData) {
-    repairEquipmentError.value = 'Заполните название, бренд, модель, серийный или инвентарный номер';
-    return;
-  }
-  creatingRepairEquipment.value = true;
-  repairEquipmentError.value = '';
-  try {
-    const notes = [
-      meta.equipment_power ? `Мощность: ${meta.equipment_power}` : '',
-      meta.equipment_commissioning_date ? `Ввод в эксплуатацию: ${meta.equipment_commissioning_date}` : '',
-    ].filter(Boolean).join('\n') || null;
-    const created = await ManagerEquipmentService.createManagerEquipment({
-      customer_id: customerId,
-      customer_branch_id: customerBranchId.value || null,
-      equipment_type: 'hvac',
-      display_name: displayName,
-      brand: trimOrNull(meta.equipment_brand),
-      model: trimOrNull(meta.equipment_model),
-      serial: trimOrNull(meta.equipment_serial_number),
-      inventory_number: trimOrNull(meta.equipment_inventory_number),
-      location_hint: trimOrNull(compactObjectAddress.value),
-      refrigerant_type: trimOrNull(meta.refrigerant_type),
-      notes,
-    });
-    selectedRepairEquipmentId.value = created.id;
-    await loadRepairEquipment();
-    await loadRepairEquipmentDetail(created.id);
-    setToast('Оборудование создано из полей ремонта', 'success');
-  } catch (error) {
-    repairEquipmentError.value = `Не удалось создать оборудование: ${getApiErrorMessage(error)}`;
-  } finally {
-    creatingRepairEquipment.value = false;
-  }
-};
-
-const recordRepairHistoryFromOrder = async () => {
-  if (!props.order?.id || !selectedRepairEquipmentId.value || recordingRepairHistory.value) return;
-  recordingRepairHistory.value = true;
-  repairEquipmentError.value = '';
-  try {
-    const payload: ManagerEquipmentHistoryFromRepairOrderPayload = {
-      order_id: props.order.id,
-      event_type: repairHistoryEventType.value || null,
-      notes: trimOrNull(repairHistoryNotes.value),
-    };
-    await ManagerEquipmentService.createManagerEquipmentHistoryFromRepairOrder(selectedRepairEquipmentId.value, payload);
-    repairHistoryEventType.value = '';
-    repairHistoryNotes.value = '';
-    await loadRepairEquipmentDetail(selectedRepairEquipmentId.value);
-    setToast('Событие записано в историю оборудования', 'success');
-  } catch (error) {
-    repairEquipmentError.value = `Не удалось записать историю: ${getApiErrorMessage(error)}`;
-  } finally {
-    recordingRepairHistory.value = false;
-  }
-};
-
 const customer = computed(() => props.order?.customer ?? null);
 const customerDisplayName = computed(() => (
   customer.value?.full_legal_name
@@ -607,9 +446,6 @@ const selectedCustomerBranch = computed(() => (
   customerBranches.value.find((branch) => branch.id === customerBranchId.value)
   || props.order?.customer_branch
   || null
-));
-const selectedRepairEquipment = computed(() => (
-  repairEquipment.value.find((item) => item.id === selectedRepairEquipmentId.value) || null
 ));
 const compactObjectAddress = computed(() => (
   customerDeliveryAddress.value.trim()
@@ -849,62 +685,6 @@ const removeManagerLabel = (label: string) => {
   managerLabels.value = managerLabels.value.filter((item) => item !== label);
 };
 
-const formatDateTime = (value?: string | null) => {
-  if (!value) return null;
-  const parsed = new Date(value);
-  if (Number.isNaN(parsed.getTime())) return null;
-  return parsed.toLocaleString('ru-RU', {
-    day: '2-digit',
-    month: '2-digit',
-    year: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-  });
-};
-
-const trimOrNull = (value: string) => {
-  const normalized = value.trim();
-  return normalized || null;
-};
-
-const equipmentEventLabel = (value?: EquipmentServiceEventType | null) => (
-  EQUIPMENT_EVENT_OPTIONS.find((option) => option.value === value)?.label || 'Другое'
-);
-
-const equipmentTitle = (item?: Pick<ManagerEquipmentItemResponse, 'display_name' | 'brand' | 'model' | 'serial' | 'inventory_number'> | null) => {
-  if (!item) return 'Оборудование';
-  const name = item.display_name?.trim();
-  if (name) return name;
-  const parts = [item.brand, item.model, item.serial || item.inventory_number].map((value) => value?.trim()).filter(Boolean);
-  return parts.join(' ') || 'Оборудование';
-};
-
-const equipmentSubtitle = (item: ManagerEquipmentItemResponse | ManagerEquipmentDetailResponse) => {
-  const parts = [
-    item.brand,
-    item.model,
-    item.serial ? `SN ${item.serial}` : '',
-    item.inventory_number ? `Инв. ${item.inventory_number}` : '',
-    item.location_hint,
-    item.refrigerant_type,
-  ].map((value) => value?.trim()).filter(Boolean);
-  return parts.join(' · ') || 'Паспортные данные не заполнены';
-};
-
-const repairHistoryLine = (item: NonNullable<ManagerEquipmentDetailResponse['recent_history']>[number]) => {
-  const parts = [
-    item.complaint_snapshot,
-    item.diagnostic_result,
-    item.repair_recommendation,
-    item.refrigerant_type ? `Хладагент ${item.refrigerant_type}` : '',
-    item.refrigerant_amount,
-    item.not_repairable ? 'Не ремонтируется' : '',
-    item.not_repairable_reason,
-    item.notes,
-  ].map((value) => value?.trim()).filter(Boolean);
-  return parts.join(' · ') || 'Без подробностей';
-};
-
 const copyText = async (value: string | null | undefined, label: string) => {
   const normalized = String(value || '').trim();
   if (!normalized) {
@@ -955,58 +735,10 @@ const hasOrderInvoice = computed(() => orderDocuments.value.some((doc) => doc.do
 const hasClosingBaseDocument = computed(() => hasContract.value || hasOrderInvoice.value);
 const isRepairWorkflow = computed(() => workflowType.value === 'repair');
 const showProductLinesSection = computed(() => workflowType.value === 'sales_installation');
-const repairWorkflowStatusLabel = computed(() => (
-  REPAIR_WORKFLOW_STATUS_OPTIONS.find((item) => item.value === repairMeta.value.repair_status)?.label || ''
-));
-const repairSectionSummary = computed(() => {
-  const parts = [];
-  if (repairWorkflowStatusLabel.value) parts.push(repairWorkflowStatusLabel.value);
-  if (repairMeta.value.equipment_name.trim()) parts.push(repairMeta.value.equipment_name.trim());
-  const serial = repairMeta.value.equipment_serial_number.trim() || repairMeta.value.equipment_inventory_number.trim();
-  if (serial) parts.push(serial);
-  if (repairMeta.value.customer_complaint.trim()) parts.push('есть жалоба');
-  if (repairMeta.value.diagnostic_result.trim()) parts.push('есть диагностика');
-  if (repairMeta.value.repair_recommendation.trim() || repairMeta.value.technical_conclusion.trim()) parts.push('есть вывод');
-  return parts.join(' · ') || 'данные для диагностики и дефектного акта';
-});
-const filteredRepairComplaintPresets = computed(() => {
-  const q = repairComplaintSearch.value.trim().toLowerCase();
-  const items = repairComplaintPresets.value.filter((item) => {
-    if (!q) return true;
-    return [
-      item.customer_phrase,
-      item.document_wording,
-      item.likely_diagnosis,
-      item.complaint_group,
-    ].some((value) => String(value || '').toLowerCase().includes(q));
-  });
-  return items.slice(0, 12);
-});
-const selectedRepairAiDefect = computed(() => (
-  REPAIR_AI_DEFECT_TYPES.find((item) => item.value === repairAiDefectType.value) || REPAIR_AI_DEFECT_TYPES[0]
-));
-const repairStructuredJson = computed(() => {
-  const payload = {
-    structured_diagnosis: repairMeta.value.structured_diagnosis || {},
-    defect_act_blocks: repairMeta.value.defect_act_blocks || {},
-    risks: repairMeta.value.risks || [],
-    recommended_actions: repairMeta.value.recommended_actions || [],
-  };
-  return JSON.stringify(payload, null, 2);
-});
-const repairPossibleOptions = computed(() => selectOptionsWithCurrent(REPAIR_CHOICE_OPTIONS, repairMeta.value.repair_possible));
-const repairNotViableOptions = computed(() => selectOptionsWithCurrent(REPAIR_CHOICE_OPTIONS, repairMeta.value.repair_not_viable));
-const customerApprovalStatusOptions = computed(() => labeledOptionsWithCurrent(CUSTOMER_APPROVAL_STATUS_OPTIONS, repairMeta.value.customer_approval_status));
-const partsStatusOptions = computed(() => labeledOptionsWithCurrent(PARTS_STATUS_OPTIONS, repairMeta.value.parts_status));
-watch(repairAiDefectType, (value) => {
-  if (isRepairWorkflow.value) {
-    repairMeta.value.fault_type = value;
-  }
-});
-const buildRepairMetaPayload = () => normalizeRepairMeta({
-  ...repairMeta.value,
-  fault_type: repairMeta.value.fault_type || repairAiDefectType.value,
-}, { defaultRepairStatus: isRepairWorkflow.value });
+const buildRepairMetaPayload = () => normalizeRepairMeta(
+  repairMeta.value,
+  { defaultRepairStatus: isRepairWorkflow.value },
+);
 const documentSectionSummary = computed(() => {
   const count = orderDocuments.value.length;
   if (!count) return 'Документов нет';
@@ -1372,18 +1104,6 @@ const initForm = async (order: ManagerOrderDetailResponse | null) => {
   repairMeta.value = normalizeRepairMeta(((order as any).repair_meta || {}) as Partial<RepairMeta>, {
     defaultRepairStatus: workflowType.value === 'repair',
   });
-  if (workflowType.value === 'repair') {
-    const savedFaultType = repairMeta.value.fault_type || (repairMeta.value.structured_diagnosis || {}).fault_type;
-    if (savedFaultType && REPAIR_AI_DEFECT_TYPES.some((item) => item.value === savedFaultType)) {
-      repairAiDefectType.value = savedFaultType;
-    } else {
-      repairMeta.value.fault_type = repairAiDefectType.value;
-    }
-  }
-  repairComplaintSearch.value = '';
-  if (workflowType.value === 'repair' && !repairComplaintPresets.value.length) {
-    void loadRepairComplaintPresets();
-  }
   managerLabels.value = [...(order.manager_labels ?? [])];
   managerLabelDraft.value = '';
   nextFollowupDate.value = toLocalDateTimeInput(order.next_followup_date);
@@ -1447,11 +1167,6 @@ const initForm = async (order: ManagerOrderDetailResponse | null) => {
   } else {
     resetCustomerBranches();
   }
-  if (workflowType.value === 'repair') {
-    await loadRepairEquipment();
-  } else {
-    resetRepairEquipment();
-  }
 
   productLookupById.value = {};
 
@@ -1504,12 +1219,6 @@ watch(
     if (props.modelValue) await initForm(value);
   },
 );
-
-watch(customerBranchId, () => {
-  if (props.modelValue && isRepairWorkflow.value && customer.value?.id) {
-    void loadRepairEquipment();
-  }
-});
 
 const onProductChanged = (index: number, applyCatalogPrice = false) => {
   const row = productLines.value[index];
@@ -2034,69 +1743,7 @@ const setWorkflowType = async (next: OrderWorkflowType) => {
   activeServiceSuggestionIndex.value = null;
   if (next === 'repair') {
     repairMeta.value = normalizeRepairMeta(repairMeta.value, { defaultRepairStatus: true });
-    void loadRepairComplaintPresets();
-    void loadRepairEquipment();
     await addDefaultRepairDiagnostic(requestId);
-  } else {
-    resetRepairEquipment();
-  }
-};
-
-const loadRepairComplaintPresets = async () => {
-  if (repairComplaintsLoading.value) return;
-  repairComplaintsLoading.value = true;
-  try {
-    const response = await ManagerRepairComplaintsService.listManagerRepairComplaintPresets('', null, false, false, 100);
-    repairComplaintPresets.value = response.items || [];
-  } catch (error) {
-    console.warn('Failed to load repair complaint presets', error);
-  } finally {
-    repairComplaintsLoading.value = false;
-  }
-};
-
-const applyRepairComplaintPreset = (preset: ManagerRepairComplaintPresetResponse) => {
-  repairMeta.value.customer_complaint = preset.customer_phrase || repairMeta.value.customer_complaint;
-  repairMeta.value.complaint_official = preset.document_wording || repairMeta.value.complaint_official;
-  repairMeta.value.likely_diagnosis = preset.likely_diagnosis || repairMeta.value.likely_diagnosis;
-};
-
-const generateRepairAiDraft = async () => {
-  const defect = selectedRepairAiDefect.value;
-  if (!defect || repairAiGenerating.value) return;
-  repairAiGenerating.value = true;
-  try {
-    const response = await ManagerRepairComplaintsService.generateManagerRepairActAiDraft({
-      defect_type: defect.value,
-      defect_label: defect.label,
-      allow_assumptions: repairAiAllowAssumptions.value,
-      polish_existing: repairAiPolishExisting.value,
-      equipment_name: repairMeta.value.equipment_name || orderTitle.value || props.order?.title || '',
-      equipment_brand: repairMeta.value.equipment_brand,
-      equipment_model: repairMeta.value.equipment_model,
-      equipment_power: repairMeta.value.equipment_power,
-      customer_complaint: repairMeta.value.customer_complaint,
-      complaint_official: repairMeta.value.complaint_official,
-      likely_diagnosis: repairMeta.value.likely_diagnosis,
-      diagnostic_notes: repairMeta.value.diagnostic_notes,
-      refrigerant_type: repairMeta.value.refrigerant_type,
-      refrigerant_amount: repairMeta.value.refrigerant_amount,
-      extra_context: repairMeta.value.diagnostic_notes || repairAiExtraContext.value || defect.hint,
-      current_meta: repairMeta.value as any,
-    });
-    repairMeta.value = normalizeRepairMeta({ ...repairMeta.value, ...((response.repair_meta || {}) as Partial<RepairMeta>) });
-    if (props.order?.id) {
-      await ManagerOrdersService.patchManagerOrder(props.order.id, {
-        repair_meta: buildRepairMetaPayload() as any,
-        measurement_result: measurementResult.value,
-      });
-      emit('reload', props.order.id);
-    }
-    setToast('Черновик дефектного акта заполнен и сохранен', 'success');
-  } catch (error) {
-    setToast(`AI не смог подготовить черновик: ${getApiErrorMessage(error)}`, 'error');
-  } finally {
-    repairAiGenerating.value = false;
   }
 };
 
@@ -2688,453 +2335,18 @@ watch(
       />
 
 
-      <OrderDrawerSection
-        v-if="isRepairWorkflow"
+      <OrderRepairPanel
+        v-if="isRepairWorkflow && order"
         v-model:expanded="expandedDrawerSections.repair"
-        title="Ремонт / диагностика"
-        :summary="repairSectionSummary"
-        tone="default"
-      >
-        <div class="grid gap-3 md:grid-cols-2">
-          <div class="md:col-span-2 rounded-xl border border-teal-100 bg-teal-50/50 p-3">
-            <div class="mb-2 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-              <div>
-                <p class="text-sm font-semibold text-teal-900">Библиотека жалоб</p>
-                <p class="text-xs text-teal-700/80">Выберите типовую жалобу, чтобы заполнить формулировку и вероятный диагноз.</p>
-              </div>
-              <button
-                type="button"
-                class="btn-mini-outline justify-center whitespace-nowrap text-xs"
-                :disabled="repairComplaintsLoading"
-                @click="loadRepairComplaintPresets"
-              >
-                <span class="material-icons-round text-[15px]" :class="{ 'animate-spin': repairComplaintsLoading }">refresh</span>
-                Обновить
-              </button>
-            </div>
-            <input
-              v-model="repairComplaintSearch"
-              type="search"
-              class="field-input mb-2"
-              placeholder="Найти: не холодит, капает, шумит..."
-            />
-            <div v-if="filteredRepairComplaintPresets.length" class="flex max-h-44 flex-wrap gap-2 overflow-auto pr-1">
-              <button
-                v-for="preset in filteredRepairComplaintPresets"
-                :key="preset.id"
-                type="button"
-                class="rounded-lg border bg-white px-3 py-2 text-left text-xs shadow-sm transition hover:border-teal-300 hover:text-teal-800"
-                :class="preset.is_favorite ? 'border-teal-200 text-teal-900' : 'border-slate-200 text-slate-700'"
-                @click="applyRepairComplaintPreset(preset)"
-              >
-                <span class="flex items-center gap-1 font-semibold">
-                  <span v-if="preset.is_favorite" class="material-icons-round text-[14px] text-amber-500">star</span>
-                  {{ preset.customer_phrase }}
-                </span>
-                <span v-if="preset.document_wording" class="mt-1 line-clamp-2 block max-w-[260px] opacity-75">{{ preset.document_wording }}</span>
-              </button>
-            </div>
-            <p v-else class="rounded-lg border border-dashed border-teal-200 bg-white/70 px-3 py-3 text-xs text-teal-700">
-              {{ repairComplaintsLoading ? 'Загружаем пресеты...' : 'Подходящих пресетов пока нет.' }}
-            </p>
-          </div>
-          <div class="md:col-span-2 rounded-xl border border-violet-100 bg-violet-50/60 p-3">
-            <div class="mb-2 flex flex-col gap-2 lg:flex-row lg:items-end">
-              <div class="min-w-0 flex-1">
-                <p class="text-sm font-semibold text-violet-950">AI-черновик по выбранной неисправности</p>
-                <p class="mt-1 truncate text-xs text-violet-700/80">
-                  {{ selectedRepairAiDefect?.label || 'Базовая неисправность не выбрана' }}
-                </p>
-              </div>
-              <button
-                type="button"
-                class="btn-mini h-[42px] justify-center whitespace-nowrap bg-violet-600 hover:bg-violet-700"
-                :disabled="repairAiGenerating"
-                @click="generateRepairAiDraft"
-              >
-                <span v-if="repairAiGenerating" class="material-icons-round animate-spin text-[16px]">loop</span>
-                <span v-else class="material-icons-round text-[16px]">auto_awesome</span>
-                AI-черновик
-              </button>
-            </div>
-            <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-              <p class="text-xs text-violet-700/80">{{ selectedRepairAiDefect?.hint }}</p>
-              <div class="flex flex-col gap-2 sm:flex-row sm:items-center">
-                <label class="inline-flex items-center gap-2 rounded-lg bg-white/70 px-2.5 py-1.5 text-xs font-semibold text-violet-800">
-                  <input v-model="repairAiPolishExisting" type="checkbox" class="h-4 w-4 rounded border-violet-300 text-violet-600 focus:ring-violet-500" />
-                  Причесать заполненное
-                </label>
-                <label class="inline-flex items-center gap-2 rounded-lg bg-white/70 px-2.5 py-1.5 text-xs font-semibold text-violet-800">
-                  <input v-model="repairAiAllowAssumptions" type="checkbox" class="h-4 w-4 rounded border-violet-300 text-violet-600 focus:ring-violet-500" />
-                  Заполнить на усмотрение
-                </label>
-              </div>
-            </div>
-          </div>
-          <details class="md:col-span-2 rounded-xl border border-slate-200 bg-slate-50 p-3">
-            <summary class="cursor-pointer select-none text-sm font-semibold text-slate-900">
-              Статусы, согласование и запчасти
-              <span class="ml-2 text-xs font-normal text-slate-500">{{ repairWorkflowStatusLabel || 'не указано' }}</span>
-            </summary>
-            <div class="mt-3 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
-              <label class="field-label">
-                Этап ремонта
-                <select v-model="repairMeta.repair_status" class="field-input bg-white">
-                  <option v-for="option in REPAIR_WORKFLOW_STATUS_OPTIONS" :key="option.value" :value="option.value">
-                    {{ option.label }}
-                  </option>
-                </select>
-              </label>
-              <label class="field-label">
-                Согласование клиента
-                <select v-model="repairMeta.customer_approval_status" class="field-input bg-white">
-                  <option v-for="option in customerApprovalStatusOptions" :key="`approval-${option.value || 'empty'}`" :value="option.value">
-                    {{ option.label }}
-                  </option>
-                </select>
-              </label>
-              <label class="field-label">
-                Запчасти
-                <select v-model="repairMeta.parts_status" class="field-input bg-white">
-                  <option v-for="option in partsStatusOptions" :key="`parts-${option.value || 'empty'}`" :value="option.value">
-                    {{ option.label }}
-                  </option>
-                </select>
-              </label>
-              <label class="field-label">
-                Комментарий согласования
-                <textarea
-                  v-model="repairMeta.customer_approval_note"
-                  class="field-input min-h-[64px] bg-white"
-                  placeholder="Кто согласовал, когда, условия"
-                />
-              </label>
-              <label class="field-label">
-                Комментарий по запчастям
-                <textarea
-                  v-model="repairMeta.parts_note"
-                  class="field-input min-h-[64px] bg-white"
-                  placeholder="Что нужно, сроки, поставщик"
-                />
-              </label>
-              <label class="field-label">
-                Итог ремонта
-                <textarea
-                  v-model="repairMeta.repair_completion_note"
-                  class="field-input min-h-[64px] bg-white"
-                  placeholder="Что выполнено или почему закрыто"
-                />
-              </label>
-            </div>
-          </details>
-          <label class="field-label md:col-span-2">
-            Жалоба клиента
-            <textarea
-              v-model="repairMeta.customer_complaint"
-              class="field-input min-h-[72px]"
-              placeholder="Например: не охлаждает, шумит, течет вода..."
-            />
-          </label>
-          <label class="field-label">
-            Базовая неисправность
-            <select v-model="repairAiDefectType" class="field-input">
-              <option v-for="item in REPAIR_AI_DEFECT_TYPES" :key="`main-${item.value}`" :value="item.value">
-                {{ item.label }}
-              </option>
-            </select>
-          </label>
-          <label class="field-label md:col-span-2">
-            Детали диагностики / заметки инженера
-            <textarea
-              v-model="repairMeta.diagnostic_notes"
-              class="field-input min-h-[72px]"
-              placeholder="Что увидел инженер: симптомы, проверки, ограничения, важные нюансы"
-            />
-          </label>
-          <label class="field-label">
-            Результат диагностики
-            <textarea
-              v-model="repairMeta.diagnostic_result"
-              class="field-input min-h-[88px]"
-              placeholder="Что выявлено при диагностике, без лишних чисел и предположений"
-            />
-          </label>
-          <label class="field-label">
-            Рекомендация по ремонту
-            <textarea
-              v-model="repairMeta.repair_recommendation"
-              class="field-input min-h-[88px]"
-              placeholder="Что сделать: устранить утечку, заменить узел, дозаправить..."
-            />
-          </label>
-          <label class="field-label md:col-span-2">
-            Формулировка для сметы ремонта
-            <textarea
-              v-model="repairMeta.repair_estimate_text"
-              class="field-input min-h-[72px]"
-              placeholder="Короткая строка работ для сметы"
-            />
-          </label>
-          <label class="field-label">
-            Возможен ремонт
-            <select v-model="repairMeta.repair_possible" class="field-input">
-              <option v-for="option in repairPossibleOptions" :key="`repair-possible-${option || 'empty'}`" :value="option">
-                {{ option || 'Не указано' }}
-              </option>
-            </select>
-          </label>
-          <label class="field-label">
-            Ремонт невозможен / нецелесообразен
-            <select v-model="repairMeta.repair_not_viable" class="field-input">
-              <option v-for="option in repairNotViableOptions" :key="`repair-not-viable-${option || 'empty'}`" :value="option">
-                {{ option || 'Не указано' }}
-              </option>
-            </select>
-          </label>
-          <label class="field-label">
-            Хладагент
-            <input v-model="repairMeta.refrigerant_type" class="field-input" placeholder="R32, R410A..." />
-          </label>
-          <label class="field-label">
-            Количество хладагента
-            <input v-model="repairMeta.refrigerant_amount" class="field-input" placeholder="0,45 кг или по факту" />
-          </label>
-          <label class="field-label md:col-span-2">
-            Расчет хладагента
-            <input
-              v-model="repairMeta.refrigerant_pricing_mode"
-              list="refrigerant-pricing-mode-options"
-              class="field-input"
-              placeholder="по фактической массе, включен в стоимость..."
-            />
-            <datalist id="refrigerant-pricing-mode-options">
-              <option v-for="option in REFRIGERANT_PRICING_MODE_OPTIONS" :key="option" :value="option" />
-            </datalist>
-          </label>
-          <label class="field-label md:col-span-2">
-            Причина неремонтопригодности
-            <textarea
-              v-model="repairMeta.repair_not_viable_reason"
-              class="field-input min-h-[72px]"
-              placeholder="Заполняйте, если ремонт невозможен или экономически нецелесообразен"
-            />
-          </label>
-
-          <details class="md:col-span-2 rounded-xl border border-slate-200 bg-slate-50 p-3">
-            <summary class="cursor-pointer select-none text-sm font-semibold text-slate-900">
-              Оборудование и паспортные данные
-              <span class="ml-2 text-xs font-normal text-slate-500">{{ repairMeta.equipment_model || repairMeta.equipment_name || 'не заполнено' }}</span>
-            </summary>
-            <div class="mt-3 grid gap-3 md:grid-cols-2">
-          <label class="field-label">
-            Оборудование
-            <input v-model="repairMeta.equipment_name" class="field-input" placeholder="Кондиционер настенный" />
-          </label>
-          <label class="field-label">
-            Бренд
-            <input v-model="repairMeta.equipment_brand" class="field-input" placeholder="LG, Gree, Mitsubishi..." />
-          </label>
-          <label class="field-label">
-            Модель
-            <input v-model="repairMeta.equipment_model" class="field-input" placeholder="Модель внутреннего/наружного блока" />
-          </label>
-          <label class="field-label">
-            Мощность
-            <input v-model="repairMeta.equipment_power" class="field-input" placeholder="2,5 кВт" />
-          </label>
-          <label class="field-label">
-            Серийный номер
-            <input v-model="repairMeta.equipment_serial_number" class="field-input" placeholder="SN..." />
-          </label>
-          <label class="field-label">
-            Инвентарный номер
-            <input v-model="repairMeta.equipment_inventory_number" class="field-input" placeholder="Инв. номер заказчика" />
-          </label>
-          <label class="field-label md:col-span-2">
-            Дата ввода в эксплуатацию
-            <input v-model="repairMeta.equipment_commissioning_date" class="field-input" placeholder="Например: 2021 г. или 12.05.2021" />
-          </label>
-
-          <div class="md:col-span-2 rounded-xl border border-slate-200 bg-slate-50 p-3">
-            <div class="mb-3 flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-              <div class="min-w-0">
-                <p class="text-sm font-semibold text-slate-900">Карточка оборудования и история</p>
-                <p class="mt-1 text-xs text-slate-600">
-                  История оборудования записывается отдельным действием и не меняет CRM/Kanban статус заказа.
-                </p>
-              </div>
-              <div class="flex flex-wrap gap-2">
-                <button
-                  type="button"
-                  class="btn-mini-outline justify-center whitespace-nowrap text-xs"
-                  :disabled="repairEquipmentLoading"
-                  @click="loadRepairEquipment"
-                >
-                  Обновить
-                </button>
-                <button
-                  type="button"
-                  class="btn-mini justify-center whitespace-nowrap text-xs"
-                  :disabled="creatingRepairEquipment || !customer?.id"
-                  @click="createRepairEquipmentFromMeta"
-                >
-                  {{ creatingRepairEquipment ? 'Создаем...' : 'Создать из полей' }}
-                </button>
-              </div>
-            </div>
-
-            <p v-if="repairEquipmentError" class="mb-3 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700">
-              {{ repairEquipmentError }}
-            </p>
-
-            <div v-if="!customer?.id" class="rounded-lg border border-dashed border-slate-200 bg-white px-3 py-4 text-center text-xs text-slate-500">
-              Выберите клиента, чтобы вести оборудование.
-            </div>
-            <div v-else-if="repairEquipmentLoading" class="rounded-lg border border-dashed border-slate-200 bg-white px-3 py-4 text-xs text-slate-500">
-              Загружаем оборудование клиента...
-            </div>
-            <div v-else class="grid gap-3 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
-              <div class="space-y-2">
-                <button
-                  v-for="item in repairEquipment"
-                  :key="item.id"
-                  type="button"
-                  class="w-full rounded-lg border px-3 py-2 text-left text-xs transition"
-                  :class="selectedRepairEquipmentId === item.id
-                    ? 'border-teal-400 bg-white text-teal-900 shadow-sm'
-                    : 'border-slate-200 bg-white text-slate-700 hover:border-teal-200'"
-                  @click="selectRepairEquipment(item.id)"
-                >
-                  <span class="block break-words font-semibold">{{ equipmentTitle(item) }}</span>
-                  <span class="mt-1 block break-words text-slate-500">{{ equipmentSubtitle(item) }}</span>
-                </button>
-                <div v-if="!repairEquipment.length" class="rounded-lg border border-dashed border-slate-200 bg-white px-3 py-4 text-center text-xs text-slate-500">
-                  {{ customerBranchId ? 'Для выбранного филиала оборудование не найдено.' : 'Оборудование клиента пока не заведено.' }}
-                </div>
-              </div>
-
-              <div class="rounded-lg border border-slate-200 bg-white p-3">
-                <div v-if="repairEquipmentHistoryLoading" class="text-xs text-slate-500">Загружаем историю...</div>
-                <template v-else-if="selectedRepairEquipment">
-                  <div class="mb-3">
-                    <p class="break-words text-sm font-semibold text-slate-900">{{ equipmentTitle(selectedRepairEquipment) }}</p>
-                    <p class="mt-1 break-words text-xs text-slate-500">{{ equipmentSubtitle(selectedRepairEquipment) }}</p>
-                  </div>
-                  <div class="grid gap-2 sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
-                    <label class="field-label !mb-0">
-                      Тип записи из заказа
-                      <select v-model="repairHistoryEventType" class="field-input bg-white">
-                        <option value="">Определить автоматически</option>
-                        <option v-for="option in EQUIPMENT_EVENT_OPTIONS" :key="option.value" :value="option.value">{{ option.label }}</option>
-                      </select>
-                    </label>
-                    <label class="field-label !mb-0">
-                      Заметка
-                      <input v-model="repairHistoryNotes" class="field-input bg-white" placeholder="Например: закрыто после согласования" />
-                    </label>
-                  </div>
-                  <button
-                    type="button"
-                    class="btn-mini mt-2 w-full justify-center text-xs"
-                    :disabled="recordingRepairHistory || !selectedRepairEquipmentId || !order?.id"
-                    @click="recordRepairHistoryFromOrder"
-                  >
-                    {{ recordingRepairHistory ? 'Записываем...' : 'Записать историю из этого ремонта' }}
-                  </button>
-                  <p class="mt-2 text-[11px] text-slate-500">
-                    Действие создаст запись истории оборудования из repair meta текущего заказа. Статус заказа и этап ремонта останутся отдельными.
-                  </p>
-
-                  <div class="mt-3 max-h-56 space-y-2 overflow-y-auto pr-1">
-                    <div
-                      v-for="entry in selectedRepairEquipmentDetail?.recent_history || []"
-                      :key="entry.id"
-                      class="rounded-lg border border-slate-100 bg-slate-50 px-3 py-2 text-xs"
-                    >
-                      <div class="flex flex-wrap items-center gap-2">
-                        <span class="rounded-full bg-teal-50 px-2 py-0.5 font-semibold text-teal-700">{{ equipmentEventLabel(entry.event_type) }}</span>
-                        <span class="text-slate-500">{{ formatDateTime(entry.event_date) || 'Без даты' }}</span>
-                        <span v-if="entry.order_id" class="text-slate-500">Заказ #{{ entry.order_id }}</span>
-                      </div>
-                      <p class="mt-1 break-words text-slate-600">{{ repairHistoryLine(entry) }}</p>
-                    </div>
-                    <div v-if="!(selectedRepairEquipmentDetail?.recent_history || []).length" class="rounded-lg border border-dashed border-slate-200 px-3 py-3 text-center text-xs text-slate-500">
-                      История пока пустая
-                    </div>
-                  </div>
-                </template>
-                <div v-else class="text-xs text-slate-500">Выберите оборудование слева или создайте карточку из полей ремонта.</div>
-              </div>
-            </div>
-          </div>
-            </div>
-          </details>
-
-          <details class="md:col-span-2 rounded-xl border border-amber-200 bg-amber-50/60 p-3">
-            <summary class="cursor-pointer select-none text-sm font-semibold text-amber-900">
-              Экспертный режим: JSON и ручные override-поля
-            </summary>
-            <div class="mt-3 grid gap-3 md:grid-cols-2">
-              <label class="field-label md:col-span-2">
-                Структурированные выводы AI
-                <textarea :value="repairStructuredJson" readonly class="field-input min-h-[180px] font-mono text-xs" />
-              </label>
-              <label class="field-label">
-                Формулировка для акта
-                <textarea
-                  v-model="repairMeta.complaint_official"
-                  class="field-input min-h-[72px]"
-                  placeholder="Override официальной формулировки жалобы"
-                />
-              </label>
-              <label class="field-label">
-                Вероятный диагноз
-                <textarea
-                  v-model="repairMeta.likely_diagnosis"
-                  class="field-input min-h-[72px]"
-                  placeholder="Override предварительной причины"
-                />
-              </label>
-          <label class="field-label">
-            Техническое состояние
-            <textarea v-model="repairMeta.technical_condition" class="field-input min-h-[80px]" placeholder="Общее состояние, износ, загрязнение, следы вмешательства..." />
-          </label>
-          <label class="field-label">
-            Проверка запуска
-            <textarea v-model="repairMeta.startup_check_result" class="field-input min-h-[80px]" placeholder="Запускается / не запускается, ошибки, симптомы..." />
-          </label>
-          <label class="field-label">
-            Проверка компрессора
-            <textarea v-model="repairMeta.compressor_check_result" class="field-input min-h-[80px]" placeholder="Токи, сопротивления, срабатывание защиты..." />
-          </label>
-          <label class="field-label">
-            Замеры / диагностика
-            <textarea v-model="repairMeta.measurement_result" class="field-input min-h-[80px]" placeholder="Давление, температура, утечки, электрические замеры..." />
-          </label>
-          <label class="field-label">
-            Возможность дальнейшей эксплуатации
-            <textarea v-model="repairMeta.further_use_assessment" class="field-input min-h-[80px]" placeholder="Допускается / не допускается / с ограничениями..." />
-          </label>
-          <label class="field-label">
-            Ограничения эксплуатации
-            <textarea v-model="repairMeta.operation_restrictions" class="field-input min-h-[80px]" placeholder="Что нельзя делать до ремонта или замены" />
-          </label>
-          <label class="field-label">
-            Целесообразность ремонта
-            <textarea v-model="repairMeta.repair_feasibility" class="field-input min-h-[80px]" placeholder="Ремонт целесообразен / нецелесообразен..." />
-          </label>
-          <label class="field-label">
-            Рекомендованное решение
-            <textarea v-model="repairMeta.recommended_decision" class="field-input min-h-[80px]" placeholder="Ремонт, замена узла, списание, замена оборудования..." />
-          </label>
-          <label class="field-label md:col-span-2">
-            Техническое заключение
-            <textarea v-model="repairMeta.technical_conclusion" class="field-input min-h-[96px]" placeholder="Итоговый вывод для дефектного акта" />
-          </label>
-            </div>
-          </details>
-        </div>
-      </OrderDrawerSection>
+        v-model:repair-meta="repairMeta"
+        :order="order"
+        :order-title="orderTitle"
+        :measurement-result="measurementResult"
+        :customer-branch-id="customerBranchId"
+        :object-address="compactObjectAddress"
+        @toast="setToast($event.message, $event.type)"
+        @reload="emit('reload', $event)"
+      />
 
 
 

--- a/manager_frontend/src/components/orders/OrderEditDrawer.vue
+++ b/manager_frontend/src/components/orders/OrderEditDrawer.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { computed, nextTick, ref, watch } from 'vue';
-import { api } from '../../api';
 import DealExecutionTab from './DealExecutionTab.vue';
 import OrderDrawerSection from './OrderDrawerSection.vue';
 import OrderAttachmentsPanel from '../service-attachments/OrderAttachmentsPanel.vue';
@@ -17,7 +16,6 @@ import OrderServiceLinesEditor from './OrderServiceLinesEditor.vue';
 import OrderCustomerContext from './OrderCustomerContext.vue';
 import OrderExecutionPanel from './OrderExecutionPanel.vue';
 import OrderDocumentsWorkspace from './OrderDocumentsWorkspace.vue';
-import { confirmDialog } from '../../services/ui-feedback';
 import type { ServiceAttachmentEquipmentOption } from '../service-attachments/types';
 import type {
   ManagerOrderDetailResponse,
@@ -27,7 +25,6 @@ import { ManagerOrdersService } from '../../client';
 import {
   buildOrderWorkspaceViewModel,
 } from './order-workspace';
-import { getApiErrorMessage } from '../../utils/api-errors';
 import { useSmartStickyHeader } from '../../composables/useSmartStickyHeader';
 import { useOrderCommercialEditor } from '../../composables/useOrderCommercialEditor';
 import { useOrderProposalLifecycle } from '../../composables/useOrderProposalLifecycle';
@@ -35,6 +32,7 @@ import { useOrderDrawerForm } from '../../composables/useOrderDrawerForm';
 import { useOrderDrawerPersistence } from '../../composables/useOrderDrawerPersistence';
 import { useOrderDocumentStatus } from '../../composables/useOrderDocumentStatus';
 import { useOrderWorkspaceNavigation } from '../../composables/useOrderWorkspaceNavigation';
+import { useOrderDrawerActions } from '../../composables/useOrderDrawerActions';
 
 const props = defineProps<{
   modelValue: boolean;
@@ -295,6 +293,26 @@ const displayOrderTitle = computed(() => (
   || customer.value?.name
   || 'Без названия'
 ));
+const {
+  closeDrawer,
+  copyText,
+  deleteOrder,
+  toggleHold,
+} = useOrderDrawerActions({
+  order: computed(() => props.order),
+  displayOrderTitle,
+  hasUnsavedChanges,
+  localFormError,
+  persistDraft,
+  clearDraft,
+  setToast,
+  onBeforeClose: () => {
+    pendingDraftClearOrderId.value = null;
+  },
+  onModelValue: (open) => emit('update:modelValue', open),
+  onUpdated: (updatedOrder) => emit('updated', updatedOrder),
+  onDeleted: (orderId) => emit('deleted', orderId),
+});
 const compactObjectAddress = computed(() => (
   customerDeliveryAddress.value.trim()
   || props.order?.customer_branch?.delivery_address
@@ -324,48 +342,6 @@ const orderWorkspace = computed(() => buildOrderWorkspaceViewModel({
   paid: totalPaymentsPreview.value,
   balance: balanceDuePreview.value,
 }));
-const copyText = async (value: string | null | undefined, label: string) => {
-  const normalized = String(value || '').trim();
-  if (!normalized) {
-    setToast(`${label} отсутствует`, 'error');
-    return;
-  }
-
-  try {
-    if (navigator.clipboard?.writeText) {
-      await navigator.clipboard.writeText(normalized);
-    } else {
-      const textarea = document.createElement('textarea');
-      textarea.value = normalized;
-      textarea.setAttribute('readonly', 'true');
-      textarea.style.position = 'absolute';
-      textarea.style.left = '-9999px';
-      document.body.appendChild(textarea);
-      textarea.select();
-      document.execCommand('copy');
-      document.body.removeChild(textarea);
-    }
-    setToast(`${label} скопирован`, 'success');
-  } catch (error) {
-    setToast(`Не удалось скопировать ${label.toLowerCase()}`, 'error');
-  }
-};
-
-const toggleHold = async () => {
-    if (!props.order) return;
-    const hold = !props.order.is_on_hold;
-    try {
-        const updatedOrder = await api.patchManagerOrder(
-            props.order.id,
-            { is_on_hold: hold, on_hold_reason: hold ? 'Переговоры / Ручная пауза' : '' },
-        );
-        emit('updated', updatedOrder);
-        setToast(hold ? 'Сделка поставлена на паузу' : 'Сделка снята с паузы', 'success');
-    } catch {
-        setToast('Ошибка паузы', 'error');
-    }
-};
-
 const beforeDocumentGenerate = async (type: string) => {
   if (!props.order?.id) return false;
   let mutated = false;
@@ -488,51 +464,6 @@ const handleSave = () => {
   if (!payload) return;
   pendingDraftClearOrderId.value = props.order.id;
   emit('save', { orderId: props.order.id, data: payload });
-};
-const closeDrawer = async (options?: { force?: boolean } | Event) => {
-  const isDomEvent = typeof Event !== 'undefined' && options instanceof Event;
-  const force = Boolean(options && !isDomEvent && (options as { force?: boolean }).force);
-  if (!force && hasUnsavedChanges.value) {
-    persistDraft();
-    const discard = await confirmDialog({
-      title: 'Закрыть без сохранения?',
-      description: 'В карточке есть несохранённые изменения. Они будут потеряны.',
-      confirmText: 'Закрыть без сохранения',
-      variant: 'warning',
-    });
-    if (!discard) return;
-  }
-  pendingDraftClearOrderId.value = null;
-  clearDraft();
-  emit('update:modelValue', false);
-};
-
-const isDeleting = ref(false);
-const deleteOrder = async () => {
-  if (!props.order?.id) return;
-  const orderLabel = `Заказ №${props.order.id}${displayOrderTitle.value ? ` «${displayOrderTitle.value}»` : ''}`;
-  const proceed = await confirmDialog({
-    title: `Удалить ${orderLabel}?`,
-    description: 'Заказ будет безвозвратно удалён вместе со связанными документами, выездами и платежами.',
-    confirmText: 'Удалить заказ',
-    variant: 'danger',
-  });
-  if (!proceed) return;
-
-  isDeleting.value = true;
-  try {
-    await ManagerOrdersService.deleteManagerOrder(props.order.id);
-    toast.value = 'Заказ успешно удален';
-    setTimeout(() => {
-      toast.value = '';
-      emit('deleted', props.order!.id);
-      void closeDrawer({ force: true });
-    }, 1500);
-  } catch (err: any) {
-    localFormError.value = getApiErrorMessage(err) || 'Ошибка при удалении заказа';
-  } finally {
-    isDeleting.value = false;
-  }
 };
 const getFieldError = (field: string): string => localServerErrors.value[field] || props.serverErrors?.[field] || '';
 const displayFormError = computed(() => localFormError.value || props.formError || '');

--- a/manager_frontend/src/components/orders/OrderEditDrawer.vue
+++ b/manager_frontend/src/components/orders/OrderEditDrawer.vue
@@ -2,7 +2,6 @@
 import { computed, nextTick, ref, watch } from 'vue';
 import { useDebounceFn } from '@vueuse/core';
 import { api } from '../../api';
-import DateTimeField from '../ui/DateTimeField.vue';
 import CustomerSummaryCard from '../customers/CustomerSummaryCard.vue';
 import DealExecutionTab from './DealExecutionTab.vue';
 import OrderDocumentsPanel from './OrderDocumentsPanel.vue';
@@ -15,6 +14,8 @@ import OrderCustomerObjectSummary from './OrderCustomerObjectSummary.vue';
 import OrderSalesInstallationWorkspace from './OrderSalesInstallationWorkspace.vue';
 import OrderProposalToolbar from './OrderProposalToolbar.vue';
 import OrderPaymentsPanel from './OrderPaymentsPanel.vue';
+import OrderWebsiteIntakePanel from './OrderWebsiteIntakePanel.vue';
+import OrderPlanningPanel from './OrderPlanningPanel.vue';
 import AddressSuggestInput from '../ui/AddressSuggestInput.vue';
 import { confirmDialog, promptDialog } from '../../services/ui-feedback';
 import type { ServiceAttachmentEquipmentOption } from '../service-attachments/types';
@@ -39,9 +40,8 @@ import type {
   OutgoingEmailResponse,
 } from '../../client';
 import { ManagerOrdersService, ManagerSettingsService, ManagerMailService, ManagerRepairComplaintsService, ManagerEquipmentService } from '../../client';
-import { EXECUTION_STATUS_OPTIONS, NEGOTIATION_STATUS_OPTIONS, formatMoney } from './order-utils';
+import { EXECUTION_STATUS_OPTIONS, formatMoney } from './order-utils';
 import {
-  buildMeasurementSummary,
   buildOrderWorkspaceViewModel,
   normalizeOrderWorkflowType,
   type OrderWorkflowType,
@@ -241,10 +241,6 @@ const proposalActionLoading = ref(false);
 const executionStatusLabel = computed(() => (
   EXECUTION_STATUS_OPTIONS.find((option) => option.value === executionStatus.value)?.label || 'Назначить работы'
 ));
-
-const setNegotiationStatus = (value: string) => {
-  negotiationStatus.value = value;
-};
 
 const setExecutionStatus = (value: string) => {
   executionStatus.value = value;
@@ -936,26 +932,6 @@ const copyText = async (value: string | null | undefined, label: string) => {
   }
 };
 
-const websiteProductSummaryLines = computed(() => {
-  return (props.order?.product_lines ?? []).map((line) => ({
-    id: line.id,
-    title: line.product_title || `Товар #${line.product_id}`,
-    quantity: line.quantity,
-    lineTotal: line.line_total,
-    installationIncluded: Boolean(line.is_installation_included),
-    installationPrice: Number(line.installation_price || 0),
-  }));
-});
-
-const websiteServiceSummaryLines = computed(() => {
-  return (props.order?.service_lines ?? []).map((line) => ({
-    id: line.id,
-    title: line.service_title || 'Услуга',
-    quantity: line.quantity,
-    lineTotal: line.line_total,
-  }));
-});
-
 const toggleHold = async () => {
     if (!props.order) return;
     const hold = !props.order.is_on_hold;
@@ -977,48 +953,8 @@ const hasOrderContract = computed(() => orderDocuments.value.some((doc) => doc.d
 const hasContract = computed(() => (isCompanyOrder.value ? !!props.order?.customer_contract_id : false) || hasOrderContract.value);
 const hasOrderInvoice = computed(() => orderDocuments.value.some((doc) => doc.doc_type === 'invoice'));
 const hasClosingBaseDocument = computed(() => hasContract.value || hasOrderInvoice.value);
-const websiteOrderSummary = computed(() => {
-  const lines = websiteProductSummaryLines.value.length + websiteServiceSummaryLines.value.length;
-  const parts = [];
-  const createdAt = formatDateTime(props.order?.created_at);
-  if (createdAt) parts.push(`создан ${createdAt}`);
-  parts.push(`${lines} поз.`);
-  if (customerDeliveryAddress.value) parts.push(customerDeliveryAddress.value);
-  return parts.join(' · ');
-});
-const planningSummary = computed(() => {
-  const parts = [buildMeasurementSummary({
-    required: measurementRequired.value,
-    date: assessmentDate.value,
-    result: measurementResult.value,
-    kind: workflowType.value === 'repair' ? 'diagnostic' : 'measurement',
-    formatDate: formatDateTime,
-  })];
-  if (installationDate.value) parts.push(`${workDateLabel.value.toLowerCase()} ${formatDateTime(installationDate.value)}`);
-  return parts.join(' · ');
-});
-const planningDetailsSummary = computed(() => {
-  const parts = [];
-  if (measurerId.value) parts.push('замерщик назначен');
-  if (measurementResult.value.trim()) parts.push('есть результат замера');
-  if (customerBranchId.value) parts.push('выбран филиал');
-  if (newBranchAddress.value.trim()) parts.push('готовится новый филиал');
-  return parts.join(' · ') || 'дополнительные поля не заполнены';
-});
 const isRepairWorkflow = computed(() => workflowType.value === 'repair');
 const showProductLinesSection = computed(() => workflowType.value === 'sales_installation');
-const planningTitle = computed(() => {
-  if (workflowType.value === 'repair') return 'Диагностика и выезд';
-  if (workflowType.value === 'maintenance') return 'Планирование обслуживания';
-  if (workflowType.value === 'service_work') return 'Планирование работ';
-  return 'Планирование';
-});
-const workDateLabel = computed(() => {
-  if (workflowType.value === 'repair') return 'Дата диагностики / ремонта';
-  if (workflowType.value === 'maintenance') return 'Дата обслуживания';
-  if (workflowType.value === 'service_work') return 'Дата работ';
-  return 'Дата монтажа';
-});
 const repairWorkflowStatusLabel = computed(() => (
   REPAIR_WORKFLOW_STATUS_OPTIONS.find((item) => item.value === repairMeta.value.repair_status)?.label || ''
 ));
@@ -2721,197 +2657,35 @@ watch(
         @error="setToast($event, 'error')"
       />
 
-      <OrderDrawerSection
+      <OrderWebsiteIntakePanel
         v-if="isWebsiteOrder"
         v-model:expanded="expandedDrawerSections.website"
-        title="Входящий заказ с сайта"
-        :summary="websiteOrderSummary"
-        tone="emerald"
-      >
-        <div class="mb-4 flex flex-wrap items-start justify-between gap-3">
-          <div>
-            <p class="text-[11px] font-semibold uppercase tracking-[0.14em] text-emerald-700">Входящий заказ с сайта</p>
-            <p class="mt-1 text-sm text-gray-500">
-              <span v-if="formatDateTime(order?.created_at)">Создан: {{ formatDateTime(order?.created_at) }}</span>
-              <span v-if="order?.status" class="ml-2 inline-flex items-center rounded-full bg-white px-2 py-0.5 text-[11px] font-medium text-gray-600 ring-1 ring-gray-200">
-                {{ order.status }}
-              </span>
-            </p>
-          </div>
-          <div class="flex flex-wrap gap-2">
-            <button
-              type="button"
-              class="inline-flex items-center gap-1 rounded-lg bg-white px-3 py-2 text-xs font-medium text-gray-700 shadow-sm ring-1 ring-gray-200 transition hover:bg-gray-50"
-              @click="copyText(customer?.phone, 'Телефон')"
-            >
-              <span class="material-icons-round text-[16px]">content_copy</span>
-              Телефон
-            </button>
-            <button
-              type="button"
-              class="inline-flex items-center gap-1 rounded-lg bg-white px-3 py-2 text-xs font-medium text-gray-700 shadow-sm ring-1 ring-gray-200 transition hover:bg-gray-50"
-              @click="copyText(customerDeliveryAddress, 'Адрес')"
-            >
-              <span class="material-icons-round text-[16px]">content_copy</span>
-              Адрес
-            </button>
-          </div>
-        </div>
-
-        <div class="grid gap-3 md:grid-cols-2">
-          <div class="rounded-xl bg-white/90 p-3 ring-1 ring-emerald-100">
-            <p class="text-[11px] font-semibold uppercase tracking-[0.12em] text-gray-500">Клиент</p>
-            <p class="mt-2 text-sm font-semibold text-gray-900">{{ customer?.full_legal_name || customer?.name || 'Без имени' }}</p>
-            <p v-if="customer?.phone" class="mt-1 text-sm text-gray-700">{{ customer.phone }}</p>
-            <p v-if="customer?.email" class="mt-1 text-sm text-gray-500">{{ customer.email }}</p>
-          </div>
-
-          <div class="rounded-xl bg-white/90 p-3 ring-1 ring-emerald-100">
-            <p class="text-[11px] font-semibold uppercase tracking-[0.12em] text-gray-500">Адрес доставки</p>
-            <p class="mt-2 text-sm font-medium text-gray-900">{{ customerDeliveryAddress || 'Адрес не указан' }}</p>
-          </div>
-
-          <div class="rounded-xl bg-white/90 p-3 ring-1 ring-emerald-100 md:col-span-2">
-            <div class="flex items-center justify-between gap-3">
-              <p class="text-[11px] font-semibold uppercase tracking-[0.12em] text-gray-500">Состав заказа</p>
-              <span class="text-xs font-medium text-emerald-700">
-                {{ websiteProductSummaryLines.length + websiteServiceSummaryLines.length }} поз.
-              </span>
-            </div>
-            <div class="mt-3 space-y-2">
-              <div
-                v-for="line in websiteProductSummaryLines"
-                :key="`website-product-${line.id}`"
-                class="rounded-xl border border-gray-100 bg-gray-50 px-3 py-2"
-              >
-                <div class="flex items-start justify-between gap-3">
-                  <div>
-                    <p class="text-sm font-medium text-gray-900">{{ line.title }}</p>
-                    <div class="mt-1 flex flex-wrap gap-2 text-xs text-gray-500">
-                      <span>Кол-во: {{ line.quantity }}</span>
-                      <span v-if="line.installationIncluded" class="inline-flex items-center gap-1 rounded-full bg-blue-50 px-2 py-0.5 text-blue-700">
-                        <span class="material-icons-round text-[14px]">construction</span>
-                        Монтаж включен
-                        <span v-if="line.installationPrice > 0">+ {{ formatMoney(line.installationPrice) }}</span>
-                      </span>
-                    </div>
-                  </div>
-                  <span class="whitespace-nowrap text-sm font-semibold text-gray-800">{{ formatMoney(line.lineTotal) }}</span>
-                </div>
-              </div>
-
-              <div
-                v-for="line in websiteServiceSummaryLines"
-                :key="`website-service-${line.id}`"
-                class="flex items-start justify-between gap-3 rounded-xl border border-gray-100 bg-gray-50 px-3 py-2"
-              >
-                <div>
-                  <p class="text-sm font-medium text-gray-900">{{ line.title }}</p>
-                  <p class="mt-1 text-xs text-gray-500">Кол-во: {{ line.quantity }}</p>
-                </div>
-                <span class="whitespace-nowrap text-sm font-semibold text-gray-800">{{ formatMoney(line.lineTotal) }}</span>
-              </div>
-
-              <p
-                v-if="!websiteProductSummaryLines.length && !websiteServiceSummaryLines.length"
-                class="rounded-xl border border-dashed border-gray-200 px-3 py-4 text-sm text-gray-500"
-              >
-                Позиции заказа отсутствуют.
-              </p>
-            </div>
-          </div>
-
-          <div v-if="comment?.trim()" class="rounded-xl bg-white/90 p-3 ring-1 ring-emerald-100 md:col-span-2">
-            <p class="text-[11px] font-semibold uppercase tracking-[0.12em] text-gray-500">Комментарий клиента</p>
-            <p class="mt-2 whitespace-pre-line text-sm text-gray-800">{{ comment }}</p>
-          </div>
-        </div>
-      </OrderDrawerSection>
+        :order="order!"
+        :delivery-address="customerDeliveryAddress"
+        :comment="comment"
+        @copy="copyText($event.value, $event.label)"
+      />
 
 
 
-      <!-- Планирование (Measurement & Logistics) -->
-      <section v-if="status === 'negotiation'" id="order-workspace-planning" class="mt-4 rounded-2xl border border-blue-100 bg-blue-50/30 p-3 dark:border-blue-500/30 dark:bg-blue-500/10">
-        <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-          <div class="min-w-0">
-            <h3 class="text-sm font-semibold text-blue-900 dark:text-blue-100">{{ planningTitle }}</h3>
-            <p class="mt-0.5 truncate text-xs text-blue-700/70 dark:text-blue-200/70">{{ planningSummary }}</p>
-          </div>
-          <button
-            v-if="!measurementRequired"
-            type="button"
-            class="btn-mini-outline justify-center whitespace-nowrap text-xs"
-            @click="measurementRequired = true"
-          >
-            <span class="material-icons-round text-[15px]">add_location_alt</span>
-            {{ isRepairWorkflow ? 'Назначить диагностику' : 'Назначить замер' }}
-          </button>
-          <label v-else class="inline-flex items-center gap-2 rounded-xl bg-white px-3 py-2 text-xs font-medium text-blue-900 ring-1 ring-blue-100 dark:bg-slate-900 dark:text-blue-100 dark:ring-blue-500/30">
-            <input type="checkbox" v-model="measurementRequired" class="h-4 w-4 rounded border-gray-300 text-teal-600 focus:ring-teal-600" />
-            {{ isRepairWorkflow ? 'Диагностика нужна' : 'Замер нужен' }}
-          </label>
-        </div>
-
-        <div class="mt-3 rounded-xl border border-blue-100 bg-white p-3 shadow-sm dark:border-blue-500/30 dark:bg-slate-900">
-          <label class="block">
-            <span class="text-xs font-semibold uppercase tracking-[0.12em] text-blue-900/70 dark:text-blue-200/80">Состояние переговоров</span>
-            <select :value="negotiationStatus" class="field-input mt-2 bg-white dark:bg-slate-950" @change="setNegotiationStatus(($event.target as HTMLSelectElement).value)">
-              <option v-for="option in NEGOTIATION_STATUS_OPTIONS" :key="option.value" :value="option.value">{{ option.label }}</option>
-            </select>
-          </label>
-          <label class="mt-3 flex items-start gap-2 rounded-xl border border-emerald-100 bg-emerald-50/70 px-3 py-2 text-xs text-emerald-900 dark:border-emerald-500/30 dark:bg-emerald-500/10 dark:text-emerald-100">
-            <input v-model="autoExecutionOnPayment" type="checkbox" class="mt-0.5 h-4 w-4 rounded border-gray-300 text-teal-600 focus:ring-teal-600" />
-            <span>
-              <span class="block font-semibold">После полной оплаты автоматически перевести заказ в этап «Работы»</span>
-              <span class="mt-0.5 block text-emerald-700/80 dark:text-emerald-200/70">Сработает автоматически, когда долг по заказу станет нулевым.</span>
-            </span>
-          </label>
-        </div>
-
-        <div v-if="measurementRequired" class="mt-3 rounded-xl border border-blue-100 bg-white p-3 shadow-sm dark:border-blue-500/30 dark:bg-slate-900">
-          <DateTimeField v-model="assessmentDate" :label="isRepairWorkflow ? 'Дата и время диагностики' : 'Дата и время замера'" :error="getFieldError('measurement_date')" />
-        </div>
-
-        <OrderDrawerSection
-          v-model:expanded="expandedDrawerSections.planningDetails"
-          :title="isRepairWorkflow ? 'Детали диагностики и ремонта' : 'Детали выезда и монтажа'"
-          :summary="planningDetailsSummary"
-          tone="blue"
-          :has-error="Boolean(getFieldError('measurement_date') || getFieldError('installation_date'))"
-        >
-          <div class="grid gap-3 md:grid-cols-2">
-            <template v-if="measurementRequired">
-              <label class="field-label">
-                {{ isRepairWorkflow ? 'Специалист' : 'Замерщик' }}
-                <select v-model="measurerId" class="field-input">
-                  <option :value="null">Не назначен</option>
-                  <option v-for="inst in executorOptions" :key="inst.id" :value="inst.id">
-                    {{ inst.name }} {{ !inst.is_active ? '(в архиве)' : '' }}
-                  </option>
-                </select>
-              </label>
-              <label class="field-label md:col-span-2">
-                Результат замера
-                <textarea
-                  v-model="measurementResult"
-                  class="field-input min-h-[60px]"
-                  :placeholder="isRepairWorkflow ? 'Краткий результат диагностики...' : 'Резюме после выезда (длины трасс, доп. работы)...'"
-                />
-              </label>
-            </template>
-            <DateTimeField v-model="installationDate" :label="workDateLabel" :error="getFieldError('installation_date')" />
-            <label class="field-label">
-              {{ isRepairWorkflow ? 'Исполнитель ремонта' : 'Монтажник' }}
-              <select v-model="installerId" class="field-input">
-                <option :value="null">Не назначен</option>
-                <option v-for="inst in executorOptions" :key="inst.id" :value="inst.id">
-                  {{ inst.name }} {{ !inst.is_active ? '(в архиве)' : '' }}
-                </option>
-              </select>
-            </label>
-          </div>
-        </OrderDrawerSection>
-      </section>
+      <OrderPlanningPanel
+        v-if="status === 'negotiation'"
+        v-model:measurement-required="measurementRequired"
+        v-model:assessment-date="assessmentDate"
+        v-model:negotiation-status="negotiationStatus"
+        v-model:auto-execution-on-payment="autoExecutionOnPayment"
+        v-model:details-expanded="expandedDrawerSections.planningDetails"
+        v-model:measurer-id="measurerId"
+        v-model:measurement-result="measurementResult"
+        v-model:installation-date="installationDate"
+        v-model:installer-id="installerId"
+        :workflow-type="workflowType"
+        :executor-options="executorOptions"
+        :customer-branch-id="customerBranchId"
+        :new-branch-address="newBranchAddress"
+        :measurement-error="getFieldError('measurement_date')"
+        :installation-error="getFieldError('installation_date')"
+      />
 
 
       <OrderDrawerSection

--- a/manager_frontend/src/components/orders/OrderEditDrawer.vue
+++ b/manager_frontend/src/components/orders/OrderEditDrawer.vue
@@ -22,30 +22,22 @@ import type { ServiceAttachmentEquipmentOption } from '../service-attachments/ty
 import type {
   ManagerOrderDetailResponse,
   ManagerOrderUpdatePayload,
-  ManagerInstallerResponse,
-  PaymentResponse,
-  PaymentCurrency,
-  FxRateResponse,
   OutgoingEmailResponse,
 } from '../../client';
-import { ManagerOrdersService, ManagerSettingsService, ManagerMailService } from '../../client';
+import { ManagerOrdersService, ManagerMailService } from '../../client';
 import {
   buildOrderWorkspaceViewModel,
-  normalizeOrderWorkflowType,
-  type OrderWorkflowType,
   type OrderWorkspaceTarget,
 } from './order-workspace';
-import { emptyRepairMeta, normalizeRepairMeta, type RepairMeta } from './repair-meta';
-import { fromLocalDateTimeInput, toLocalDateTimeInput } from '../../utils/datetime';
 import { getApiErrorMessage } from '../../utils/api-errors';
 import { useSmartStickyHeader } from '../../composables/useSmartStickyHeader';
 import { useOrderCommercialEditor } from '../../composables/useOrderCommercialEditor';
 import { useOrderProposalLifecycle } from '../../composables/useOrderProposalLifecycle';
+import { useOrderDrawerForm } from '../../composables/useOrderDrawerForm';
 import type {
   OrderDrawerDraft,
   OrderLogisticsComponent,
   ProductLogisticsTemplateComponent,
-  ServiceLine,
 } from './order-editor-types';
 
 const props = defineProps<{
@@ -85,73 +77,6 @@ function setToast(message: string, type: 'success' | 'error' = 'success') {
     if (toast.value === message) toast.value = '';
   }, 3000);
 }
-
-const status = ref('new_lead');
-const orderTitle = ref('');
-const workflowType = ref<OrderWorkflowType>('sales_installation');
-const repairMeta = ref<RepairMeta>(emptyRepairMeta());
-const managerLabels = ref<string[]>([]);
-const managerLabelDraft = ref('');
-const nextFollowupDate = ref('');
-const assessmentDate = ref('');
-const installationDate = ref('');
-const comment = ref('');
-const isPaid = ref(false);
-const installerId = ref<number | null>(null);
-
-const customerDeliveryAddress = ref('');
-const customerBranchId = ref<number | null>(null);
-const newBranchAddress = ref('');
-
-const targetCurrency = ref<PaymentCurrency | null>(null);
-const targetCurrencyAmount = ref<number | null>(null);
-const enableCurrency = ref(false);
-const currentFxRate = ref<FxRateResponse | null>(null);
-
-const syncTargetCurrencyAmountFromRate = () => {
-  const rate = getActiveFxRate(targetCurrency.value);
-  if (!enableCurrency.value || !rate || totalPreview.value <= 0) return;
-  targetCurrencyAmount.value = Number((totalPreview.value / rate).toFixed(2));
-};
-
-watch(enableCurrency, async (val) => {
-  if (!val) {
-    targetCurrency.value = null;
-    targetCurrencyAmount.value = null;
-  } else if (!targetCurrency.value) {
-    targetCurrency.value = 'USD';
-    try {
-       currentFxRate.value = await ManagerSettingsService.getFxRate();
-       syncTargetCurrencyAmountFromRate();
-    } catch (e) {
-       console.warn('Failed to fetch FX rate', e);
-       enableCurrency.value = false;
-       setToast('Не удалось загрузить курс валют', 'error');
-    }
-  }
-});
-
-watch(targetCurrency, (newCurrency) => {
-  if (newCurrency === 'EUR' && !hasManualEurRate.value) {
-    targetCurrency.value = 'USD';
-    return;
-  }
-  syncTargetCurrencyAmountFromRate();
-});
-
-// Negotiation stage properties
-const measurementRequired = ref(false);
-const measurerId = ref<number | null>(null);
-const measurementResult = ref('');
-const additionalConditions = ref('');
-const negotiationStatus = ref('awaiting_offer');
-const executionStatus = ref('needs_schedule');
-const executionWithoutPayment = ref(false);
-const executionWithoutPaymentReason = ref('');
-const autoExecutionOnPayment = ref(false);
-const autoCloseOnPayment = ref(false);
-
-const installersList = ref<ManagerInstallerResponse[]>([]);
 
 const savedLinesSnapshot = ref('');
 const savedFormSnapshot = ref('');
@@ -212,7 +137,62 @@ const {
   setToast,
   persistDraft: () => persistDraft(),
 });
-const payments = ref<PaymentResponse[]>([]);
+const {
+  addManagerLabel,
+  assessmentDate,
+  autoCloseOnPayment,
+  autoExecutionOnPayment,
+  balanceDue: balanceDuePreview,
+  buildRepairMetaPayload,
+  buildSavePayload,
+  calculatedTargetCurrencyPayments,
+  comment,
+  currentFormSnapshot: buildCurrentFormSnapshot,
+  currentFxRate,
+  customerBranchId,
+  customerDeliveryAddress,
+  enableCurrency,
+  executionStatus,
+  executionWithoutPayment,
+  executionWithoutPaymentReason,
+  executorOptions,
+  hydrateOrder,
+  installationDate,
+  installerId,
+  isB2cCustomer: buildIsB2cCustomer,
+  isRepairWorkflow,
+  localFormError,
+  localServerErrors,
+  managerLabelDraft,
+  managerLabels,
+  measurementRequired,
+  measurementResult,
+  measurerId,
+  negotiationStatus,
+  newBranchAddress,
+  orderTitle,
+  payments,
+  removeManagerLabel,
+  repairMeta,
+  setWorkflowType,
+  showProductLinesSection,
+  status,
+  targetCurrency,
+  targetCurrencyAmount,
+  targetCurrencyBalanceDue,
+  totalPayments: totalPaymentsPreview,
+  workflowType,
+} = useOrderDrawerForm({
+  total: totalPreview,
+  productLines,
+  serviceLines,
+  serviceTariffOptions,
+  activeServiceSuggestionIndex,
+  applyTariffTemplateToLine,
+  buildLinesPayload: () => buildLinesPayload(activeProposalId.value),
+  validateLines: validateProposalLines,
+  setToast,
+});
 const linkedEquipmentOptions = ref<ServiceAttachmentEquipmentOption[]>([]);
 const equipmentPanelRef = ref<InstanceType<typeof OrderEquipmentPanel> | null>(null);
 const documentsWorkspaceRef = ref<InstanceType<typeof OrderDocumentsWorkspace> | null>(null);
@@ -222,14 +202,6 @@ const activeWorkspaceTarget = ref<OrderWorkspaceTarget | null>(null);
 const orderEmails = ref<OutgoingEmailResponse[]>([]);
 const orderEmailsLoaded = ref(false);
 let orderEmailsRequestId = 0;
-
-const executorOptions = computed(() => {
-  const selectedIds = new Set<number>();
-  if (installerId.value !== null) selectedIds.add(installerId.value);
-  if (measurerId.value !== null) selectedIds.add(measurerId.value);
-  return installersList.value.filter((inst) => inst.is_active || selectedIds.has(inst.id));
-});
-const localServerErrors = ref<Record<string, string>>({});
 
 const createDefaultDrawerSections = () => ({
   website: false,
@@ -245,7 +217,6 @@ type DrawerSectionsState = ReturnType<typeof createDefaultDrawerSections>;
 const expandedDrawerSections = ref(createDefaultDrawerSections());
 const initializedOrderId = ref<number | null>(null);
 
-const localFormError = ref('');
 const showManagerLabelInput = ref(false);
 
 const {
@@ -292,10 +263,7 @@ const customerDisplayName = computed(() => (
   || ''
 ));
 const isWebsiteOrder = computed(() => props.order?.lead_source === 'site');
-const isB2cCustomer = computed(() => {
-  if (!customer.value) return true; // defaults to B2C if unknown
-  return customer.value.type !== 'company';
-});
+const isB2cCustomer = buildIsB2cCustomer(computed(() => props.order));
 const displayOrderTitle = computed(() => (
   orderTitle.value.trim()
   || customer.value?.full_legal_name
@@ -396,15 +364,6 @@ const draftKey = computed(() => (
 const drawerSectionsKey = computed(() => (
   props.order ? `manager_order_drawer_sections_${props.order.id}` : ''
 ));
-const hasManualEurRate = computed(() => Boolean(currentFxRate.value?.eur_byn));
-
-const getActiveFxRate = (currency: PaymentCurrency | null): number | null => {
-  if (!currentFxRate.value || !currency) return null;
-  if (currency === 'USD') return currentFxRate.value.usd_byn ?? null;
-  if (currency === 'EUR') return currentFxRate.value.eur_byn ?? null;
-  return null;
-};
-
 const loadOrderEmails = async (orderId: number) => {
   const requestId = ++orderEmailsRequestId;
   try {
@@ -418,21 +377,6 @@ const loadOrderEmails = async (orderId: number) => {
     orderEmails.value = [];
     orderEmailsLoaded.value = false;
   }
-};
-
-const normalizeManagerLabel = (value: string) => value.trim().replace(/\s+/g, ' ');
-
-const addManagerLabel = () => {
-  const label = normalizeManagerLabel(managerLabelDraft.value);
-  if (!label) return;
-  const exists = managerLabels.value.some((item) => item.toLocaleLowerCase('ru-RU') === label.toLocaleLowerCase('ru-RU'));
-  if (!exists) managerLabels.value.push(label);
-  managerLabelDraft.value = '';
-  showManagerLabelInput.value = false;
-};
-
-const removeManagerLabel = (label: string) => {
-  managerLabels.value = managerLabels.value.filter((item) => item !== label);
 };
 
 const copyText = async (value: string | null | undefined, label: string) => {
@@ -478,12 +422,6 @@ const toggleHold = async () => {
 };
 
 const orderDocuments = computed(() => props.order?.documents || []);
-const isRepairWorkflow = computed(() => workflowType.value === 'repair');
-const showProductLinesSection = computed(() => workflowType.value === 'sales_installation');
-const buildRepairMetaPayload = () => normalizeRepairMeta(
-  repairMeta.value,
-  { defaultRepairStatus: isRepairWorkflow.value },
-);
 const beforeDocumentGenerate = async (type: string) => {
   if (!props.order?.id) return false;
   let mutated = false;
@@ -515,75 +453,8 @@ const refreshOrderFromDocumentsPanel = () => {
   }
 };
 
-const totalPaymentsPreview = computed(() => {
-  const bynPaid = payments.value.filter((p) => p.currency === 'BYN').reduce((sum, p) => sum + p.amount, 0);
-  if (!enableCurrency.value || !currentFxRate.value || !targetCurrency.value) {
-    return bynPaid;
-  }
-  const foreignPaid = payments.value.filter((p) => p.currency === targetCurrency.value).reduce((sum, p) => sum + p.amount, 0);
-  const rate = getActiveFxRate(targetCurrency.value);
-  if (!rate) return bynPaid;
-  return bynPaid + (foreignPaid * rate);
-});
-
-const calculatedTargetCurrencyPayments = computed(() => {
-  return payments.value.reduce((sum, p) => {
-    if (p.currency === targetCurrency.value) {
-      return sum + p.amount;
-    }
-    if (p.currency === 'BYN' && currentFxRate.value && targetCurrency.value) {
-      const rate = getActiveFxRate(targetCurrency.value);
-      if (rate) {
-        return sum + (p.amount / rate);
-      }
-    }
-    return sum;
-  }, 0);
-});
-
-const balanceDuePreview = computed(() => {
-  if (enableCurrency.value && currentFxRate.value && targetCurrency.value) {
-    const rate = getActiveFxRate(targetCurrency.value);
-    if (!rate) return Math.max(0, totalPreview.value - totalPaymentsPreview.value);
-    return targetCurrencyBalanceDue.value * rate;
-  }
-  return Math.max(0, totalPreview.value - totalPaymentsPreview.value);
-});
-
-const targetCurrencyBalanceDue = computed(() => {
-  return Math.max(0, (targetCurrencyAmount.value || 0) - calculatedTargetCurrencyPayments.value);
-});
-
 const currentLinesSnapshot = () => buildCurrentLinesSnapshot(activeProposalId.value);
-const currentFormSnapshot = () => JSON.stringify({
-  status: status.value,
-  title: orderTitle.value.trim(),
-  workflowType: workflowType.value,
-  repairMeta: buildRepairMetaPayload(),
-  managerLabels: [...managerLabels.value],
-  nextFollowupDate: nextFollowupDate.value,
-  assessmentDate: assessmentDate.value,
-  installationDate: installationDate.value,
-  comment: comment.value,
-  installerId: installerId.value,
-  customerDeliveryAddress: customerDeliveryAddress.value.trim(),
-  customerBranchId: customerBranchId.value,
-  measurementRequired: measurementRequired.value,
-  measurerId: measurerId.value,
-  measurementResult: measurementResult.value,
-  additionalConditions: additionalConditions.value,
-  proposalStatus: proposalStatus.value,
-  negotiationStatus: negotiationStatus.value,
-  executionStatus: executionStatus.value,
-  executionWithoutPayment: executionWithoutPayment.value,
-  executionWithoutPaymentReason: executionWithoutPaymentReason.value,
-  autoExecutionOnPayment: autoExecutionOnPayment.value,
-  autoCloseOnPayment: autoCloseOnPayment.value,
-  enableCurrency: enableCurrency.value,
-  targetCurrency: targetCurrency.value,
-  targetCurrencyAmount: targetCurrencyAmount.value,
-});
-
+const currentFormSnapshot = () => buildCurrentFormSnapshot(proposalStatus.value);
 const hasUnsavedChanges = computed(() => (
   Boolean(props.order?.id)
   && (
@@ -696,52 +567,7 @@ const initForm = async (order: ManagerOrderDetailResponse | null) => {
     orderEmails.value = [];
     orderEmailsLoaded.value = false;
   }
-  status.value = order.status;
-  orderTitle.value = order.title ?? '';
-  workflowType.value = normalizeOrderWorkflowType((order as any).workflow_type);
-  repairMeta.value = normalizeRepairMeta(((order as any).repair_meta || {}) as Partial<RepairMeta>, {
-    defaultRepairStatus: workflowType.value === 'repair',
-  });
-  managerLabels.value = [...(order.manager_labels ?? [])];
-  managerLabelDraft.value = '';
-  nextFollowupDate.value = toLocalDateTimeInput(order.next_followup_date);
-  assessmentDate.value = toLocalDateTimeInput(order.measurement_date);
-  installationDate.value = toLocalDateTimeInput(order.installation_date);
-  comment.value = order.comment ?? '';
-  isPaid.value = order.is_paid;
-  installerId.value = order.installer_id ?? null;
-  customerDeliveryAddress.value = order.delivery_address || '';
-  customerBranchId.value = order.customer_branch?.id ?? null;
-  measurementRequired.value = order.measurement_required ?? false;
-  measurerId.value = order.measurer_id ?? null;
-  measurementResult.value = order.measurement_result ?? '';
-  additionalConditions.value = order.additional_conditions ?? '';
-  negotiationStatus.value = order.negotiation_status || 'awaiting_offer';
-  executionStatus.value = order.execution_status || 'needs_schedule';
-  executionWithoutPayment.value = Boolean(order.execution_without_payment);
-  executionWithoutPaymentReason.value = order.execution_without_payment_reason || '';
-  autoExecutionOnPayment.value = Boolean(order.auto_execution_on_payment);
-  autoCloseOnPayment.value = Boolean(order.auto_close_on_payment);
-  targetCurrency.value = order.target_currency || null;
-  targetCurrencyAmount.value = order.target_currency_amount || null;
-
-  // Set default currency toggle state
-  enableCurrency.value = !!order.target_currency;
-
-  if (enableCurrency.value && !currentFxRate.value) {
-      ManagerSettingsService.getFxRate().then(res => {
-          currentFxRate.value = res;
-          if (targetCurrency.value === 'EUR' && !res.eur_byn) {
-            targetCurrency.value = 'USD';
-          }
-      }).catch(e => console.warn('Failed to load fx rate on init', e));
-  }
-
-  if (installersList.value.length === 0) {
-    api.getManagerInstallers(1, 100).then(res => {
-      installersList.value = res.items;
-    }).catch(e => console.error("Failed to load installers", e));
-  }
+  hydrateOrder(order);
 
   const selectedProposal = (order.proposals || []).find((proposal) => proposal.is_selected && !proposal.is_archived)
     || (order.proposals || []).find((proposal) => !proposal.is_archived)
@@ -754,9 +580,6 @@ const initForm = async (order: ManagerOrderDetailResponse | null) => {
   savedLinesSnapshot.value = currentLinesSnapshot();
   showEstimateImport.value = false;
   await loadEstimateOptions();
-
-  // Payments
-  payments.value = [...(order.payments || [])];
 
   resetLookupState();
   savedFormSnapshot.value = currentFormSnapshot();
@@ -802,8 +625,6 @@ watch(
   },
 );
 
-const buildProposalLinesPayload = () => buildLinesPayload(activeProposalId.value);
-
 const openProposalSend = async () => {
   const proposal = activeProposal.value;
   if (!proposal) return;
@@ -846,173 +667,13 @@ const handleWorkspaceNextAction = async () => {
   openWorkspaceTarget(action.target);
 };
 
-const hasDiagnosticServiceLine = () => serviceLines.value.some((line) => /диагност/i.test(line.title || ''));
-
-let workflowChangeRequestId = 0;
-
-const addDefaultRepairDiagnostic = async (requestId: number) => {
-  if (hasDiagnosticServiceLine()) return;
-  try {
-    const response = await api.listManagerQuickTariffs('диагностика', 'repair' as any, 5);
-    if (requestId !== workflowChangeRequestId || workflowType.value !== 'repair') return;
-    const option = (response.items || [])[0];
-    const diagnosticLine: ServiceLine = {
-      service_id: null,
-      title: 'Диагностика кондиционера на объекте',
-      quantity: 1,
-      price: 0,
-      cost: 0,
-    };
-    if (option) applyTariffTemplateToLine(diagnosticLine, option);
-    serviceLines.value = [
-      diagnosticLine,
-      ...serviceLines.value,
-    ];
-    setToast('Добавили базовую диагностику для ремонта');
-  } catch (error) {
-    if (requestId !== workflowChangeRequestId || workflowType.value !== 'repair') return;
-    serviceLines.value = [
-      {
-        service_id: null,
-        title: 'Диагностика кондиционера на объекте',
-        quantity: 1,
-        price: 0,
-        cost: 0,
-      },
-      ...serviceLines.value,
-    ];
-    setToast(`Не нашли тариф диагностики: ${getApiErrorMessage(error)}`, 'error');
-  }
-};
-
-const setWorkflowType = async (next: OrderWorkflowType) => {
-  if (workflowType.value === next) return;
-  const hasScenarioData = productLines.value.length > 0
-    || serviceLines.value.length > 0
-    || Boolean(comment.value.trim())
-    || Boolean(installationDate.value)
-    || Boolean(measurementResult.value.trim());
-  if (hasScenarioData) {
-    const confirmed = await confirmDialog({
-      title: 'Сменить сценарий заказа?',
-      description: 'В заказе уже есть данные. Скрытые разделы сохранятся и останутся доступны после возврата к сценарию.',
-      confirmText: 'Сменить сценарий',
-      variant: 'warning',
-    });
-    if (!confirmed) return;
-  }
-  const requestId = ++workflowChangeRequestId;
-  workflowType.value = next;
-  serviceTariffOptions.value = [];
-  activeServiceSuggestionIndex.value = null;
-  if (next === 'repair') {
-    repairMeta.value = normalizeRepairMeta(repairMeta.value, { defaultRepairStatus: true });
-    await addDefaultRepairDiagnostic(requestId);
-  }
-};
-
 const handleSave = () => {
   if (!props.order) return;
-  localServerErrors.value = {};
-  localFormError.value = '';
-
-  const errors: Record<string, string> = {};
-  if (!status.value) {
-    errors.status = 'Укажите статус';
-  }
-
-  if (assessmentDate.value && installationDate.value && installationDate.value < assessmentDate.value) {
-    errors.installation_date = 'Дата монтажа не может быть раньше даты замера';
-  }
-
-  if (productLines.value.some((line) => line.quantity <= 0)) {
-    errors.products = 'Количество товара должно быть больше 0';
-  } else if (productLines.value.some((line) => line.price < 0)) {
-    errors.products = 'Цена товара не может быть отрицательной';
-  } else if (productLines.value.some((line) => !line.product_id)) {
-    errors.products = 'Выберите товар из выпадающего списка';
-  }
-
-  if (serviceLines.value.some((line) => line.quantity <= 0)) {
-    errors.services = 'Количество услуги должно быть больше 0';
-  } else if (serviceLines.value.some((line) => line.price < 0)) {
-    errors.services = 'Цена услуги не может быть отрицательной';
-  } else if (serviceLines.value.some((line) => !line.title?.trim())) {
-    errors.services = 'Для услуги укажите название';
-  }
-
-  if (Object.keys(errors).length) {
-    localServerErrors.value = errors;
-    localFormError.value = 'Исправьте ошибки в форме';
-    return;
-  }
-
-  // Cross-field validation for Negotiation
-  if (status.value === 'execution') {
-    if (totalPreview.value <= 0) {
-      localFormError.value = 'Нельзя перевести в монтаж с пустой сметой';
-      return;
-    }
-    if (measurementRequired.value && !measurementResult.value?.trim()) {
-      localFormError.value = 'Требуется замер: заполните результат замера';
-      return;
-    }
-  }
-
-  if (enableCurrency.value) {
-    if (!targetCurrency.value) {
-      localFormError.value = 'Выберите валюту сделки';
-      return;
-    }
-    const activeRate = getActiveFxRate(targetCurrency.value);
-    if (!activeRate) {
-      localFormError.value = 'Для выбранной валюты сейчас нет доступного курса';
-      return;
-    }
-    if (!targetCurrencyAmount.value || targetCurrencyAmount.value <= 0) {
-      localFormError.value = 'Укажите зафиксированную сумму в валюте';
-      return;
-    }
-  } else if (payments.value.some((payment) => payment.currency !== 'BYN')) {
-    localFormError.value = 'Нельзя отключить валютный режим, пока в заказе есть валютные платежи';
-    return;
-  }
-
+  const payload = buildSavePayload(activeProposalLocked.value);
+  if (!payload) return;
   pendingDraftClearOrderId.value = props.order.id;
-  const linePayload = buildProposalLinesPayload();
-  repairMeta.value = buildRepairMetaPayload();
-  const payload: ManagerOrderUpdatePayload = {
-    status: status.value,
-    title: orderTitle.value,
-    workflow_type: workflowType.value as any,
-    repair_meta: buildRepairMetaPayload() as any,
-    manager_labels: managerLabels.value,
-    next_followup_date: fromLocalDateTimeInput(nextFollowupDate.value),
-    measurement_date: fromLocalDateTimeInput(assessmentDate.value),
-    installation_date: fromLocalDateTimeInput(installationDate.value),
-    comment: comment.value,
-    is_paid: isPaid.value,
-    installer_id: installerId.value,
-    customer_branch_id: customerBranchId.value,
-    customer_delivery_address: customerDeliveryAddress.value,
-    products: activeProposalLocked.value ? undefined : linePayload.products,
-    services: activeProposalLocked.value ? undefined : linePayload.services,
-    measurement_required: measurementRequired.value,
-    measurer_id: measurerId.value,
-    measurement_result: measurementResult.value,
-    additional_conditions: additionalConditions.value,
-    negotiation_status: status.value === 'negotiation' ? negotiationStatus.value : undefined,
-    execution_status: status.value === 'execution' ? executionStatus.value : undefined,
-    execution_without_payment: status.value === 'execution' ? executionWithoutPayment.value : false,
-    execution_without_payment_reason: status.value === 'execution' && executionWithoutPayment.value ? executionWithoutPaymentReason.value : null,
-    auto_execution_on_payment: autoExecutionOnPayment.value,
-    auto_close_on_payment: status.value === 'execution' ? autoCloseOnPayment.value : false,
-    target_currency: enableCurrency.value ? (targetCurrency.value || null) : null,
-    target_currency_amount: enableCurrency.value && targetCurrencyAmount.value ? Number(String(targetCurrencyAmount.value).replace(',', '.')) : null,
-  };
   emit('save', { orderId: props.order.id, data: payload });
 };
-
 const closeDrawer = async (options?: { force?: boolean } | Event) => {
   const isDomEvent = typeof Event !== 'undefined' && options instanceof Event;
   const force = Boolean(options && !isDomEvent && (options as { force?: boolean }).force);

--- a/manager_frontend/src/components/orders/OrderEditDrawer.vue
+++ b/manager_frontend/src/components/orders/OrderEditDrawer.vue
@@ -3,7 +3,6 @@ import { computed, nextTick, ref, watch } from 'vue';
 import { useDebounceFn } from '@vueuse/core';
 import { api } from '../../api';
 import DealExecutionTab from './DealExecutionTab.vue';
-import OrderDocumentsPanel from './OrderDocumentsPanel.vue';
 import OrderDrawerSection from './OrderDrawerSection.vue';
 import OrderAttachmentsPanel from '../service-attachments/OrderAttachmentsPanel.vue';
 import OrderEquipmentPanel from '../equipment/OrderEquipmentPanel.vue';
@@ -18,6 +17,7 @@ import OrderProductLinesEditor from './OrderProductLinesEditor.vue';
 import OrderServiceLinesEditor from './OrderServiceLinesEditor.vue';
 import OrderCustomerContext from './OrderCustomerContext.vue';
 import OrderExecutionPanel from './OrderExecutionPanel.vue';
+import OrderDocumentsWorkspace from './OrderDocumentsWorkspace.vue';
 import { confirmDialog, promptDialog } from '../../services/ui-feedback';
 import type { ServiceAttachmentEquipmentOption } from '../service-attachments/types';
 import type {
@@ -208,7 +208,7 @@ const showEstimateImport = ref(false);
 const payments = ref<PaymentResponse[]>([]);
 const linkedEquipmentOptions = ref<ServiceAttachmentEquipmentOption[]>([]);
 const equipmentPanelRef = ref<InstanceType<typeof OrderEquipmentPanel> | null>(null);
-const documentsPanelRef = ref<InstanceType<typeof OrderDocumentsPanel> | null>(null);
+const documentsWorkspaceRef = ref<InstanceType<typeof OrderDocumentsWorkspace> | null>(null);
 const proposalToolbarRef = ref<InstanceType<typeof OrderProposalToolbar> | null>(null);
 const executionWorkspaceOpen = ref(false);
 const activeWorkspaceTarget = ref<OrderWorkspaceTarget | null>(null);
@@ -525,27 +525,13 @@ const toggleHold = async () => {
     }
 };
 
-const isCompanyOrder = computed(() => props.order?.customer?.type === 'company' || !!props.order?.customer?.inn);
 const orderDocuments = computed(() => props.order?.documents || []);
-const hasOrderContract = computed(() => orderDocuments.value.some((doc) => doc.doc_type === 'contract'));
-const hasContract = computed(() => (isCompanyOrder.value ? !!props.order?.customer_contract_id : false) || hasOrderContract.value);
-const hasOrderInvoice = computed(() => orderDocuments.value.some((doc) => doc.doc_type === 'invoice'));
-const hasClosingBaseDocument = computed(() => hasContract.value || hasOrderInvoice.value);
 const isRepairWorkflow = computed(() => workflowType.value === 'repair');
 const showProductLinesSection = computed(() => workflowType.value === 'sales_installation');
 const buildRepairMetaPayload = () => normalizeRepairMeta(
   repairMeta.value,
   { defaultRepairStatus: isRepairWorkflow.value },
 );
-const documentSectionSummary = computed(() => {
-  const count = orderDocuments.value.length;
-  if (!count) return 'Документов нет';
-  const mod100 = count % 100;
-  const mod10 = count % 10;
-  const noun = mod100 >= 11 && mod100 <= 14 ? 'документов' : mod10 === 1 ? 'документ' : mod10 >= 2 && mod10 <= 4 ? 'документа' : 'документов';
-  return `${count} ${noun}${hasContract.value ? '' : ' · договор не создан'}`;
-});
-const documentSectionHasError = computed(() => isCompanyOrder.value && !props.order?.customer_contract_id && !hasClosingBaseDocument.value);
 const beforeDocumentGenerate = async (type: string) => {
   if (!props.order?.id) return false;
   let mutated = false;
@@ -1352,9 +1338,9 @@ const openProposalSend = async () => {
     document.doc_type === 'offer'
     && (!document.proposal_id || document.proposal_id === proposal.id)
   ));
-  if (offerExists) documentsPanelRef.value?.openSend();
+  if (offerExists) documentsWorkspaceRef.value?.openSend();
   else {
-    documentsPanelRef.value?.openCreate();
+    documentsWorkspaceRef.value?.openCreate();
     setToast('Сначала создайте коммерческое предложение для активного варианта', 'error');
   }
   document.getElementById('order-workspace-documents')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
@@ -1364,7 +1350,7 @@ const openDocumentsSend = async () => {
   expandedDrawerSections.value.documents = true;
   activeWorkspaceTarget.value = 'documents';
   await nextTick();
-  documentsPanelRef.value?.openSend();
+  documentsWorkspaceRef.value?.openSend();
   document.getElementById('order-workspace-documents')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
 };
 
@@ -2135,49 +2121,18 @@ watch(
       </div>
       </OrderDrawerSection>
 
-      <!-- Экшн-зона (Proposal & Docs) -->
-      <OrderDrawerSection
+      <OrderDocumentsWorkspace
         v-if="order"
-        id="order-workspace-documents"
+        ref="documentsWorkspaceRef"
         v-model:expanded="expandedDrawerSections.documents"
-        title="Документы"
-        :summary="documentSectionSummary"
-        tone="amber"
-        :has-error="documentSectionHasError"
-      >
-        <div v-if="status === 'negotiation'" class="mb-6">
-          <div class="flex flex-wrap gap-2">
-            <!-- B2C Action -->
-            <a
-              v-if="customer?.type === 'individual'"
-              :href="`https://wa.me/${(customer?.phone || '').replace(/\D/g, '')}?text=${encodeURIComponent(`Здравствуйте, ${customer?.name}! Расчет по вашему заказу: Итого к оплате ${formatMoney(totalPreview)}. Подтверждаем?`)}`"
-              target="_blank"
-              class="flex items-center gap-1 rounded-xl bg-[#25D366] px-4 py-2 text-sm font-medium text-white shadow hover:bg-[#20BE5A]"
-            >
-              <span class="material-icons-round text-[18px]">chat</span> Отправить в WhatsApp
-            </a>
-            <a
-              v-if="customer?.type === 'individual'"
-              :href="`viber://chat?number=%2B${(customer?.phone || '').replace(/\D/g, '')}`"
-              target="_blank"
-              class="flex items-center gap-1 rounded-xl bg-[#7360f2] px-4 py-2 text-sm font-medium text-white shadow hover:bg-[#5e4cd1]"
-            >
-              <span class="material-icons-round text-[18px]">chat</span> Viber
-            </a>
-          </div>
-        </div>
-
-        <OrderDocumentsPanel
-          v-if="order"
-          ref="documentsPanelRef"
-          :order="order"
-          :active-proposal-id="activeProposalId"
-          :product-lines="productLines"
-          :before-generate="beforeDocumentGenerate"
-          @refresh="refreshOrderFromDocumentsPanel"
-          @toast="handleDocumentPanelToast"
-        />
-      </OrderDrawerSection>
+        :order="order"
+        :active-proposal-id="activeProposalId"
+        :product-lines="productLines"
+        :total="totalPreview"
+        :before-generate="beforeDocumentGenerate"
+        @refresh="refreshOrderFromDocumentsPanel"
+        @toast="handleDocumentPanelToast"
+      />
 
 
       <OrderExecutionPanel

--- a/manager_frontend/src/components/orders/OrderEditDrawer.vue
+++ b/manager_frontend/src/components/orders/OrderEditDrawer.vue
@@ -26,7 +26,6 @@ import type {
 import { ManagerOrdersService } from '../../client';
 import {
   buildOrderWorkspaceViewModel,
-  type OrderWorkspaceTarget,
 } from './order-workspace';
 import { getApiErrorMessage } from '../../utils/api-errors';
 import { useSmartStickyHeader } from '../../composables/useSmartStickyHeader';
@@ -35,6 +34,7 @@ import { useOrderProposalLifecycle } from '../../composables/useOrderProposalLif
 import { useOrderDrawerForm } from '../../composables/useOrderDrawerForm';
 import { useOrderDrawerPersistence } from '../../composables/useOrderDrawerPersistence';
 import { useOrderDocumentStatus } from '../../composables/useOrderDocumentStatus';
+import { useOrderWorkspaceNavigation } from '../../composables/useOrderWorkspaceNavigation';
 
 const props = defineProps<{
   modelValue: boolean;
@@ -192,8 +192,6 @@ const linkedEquipmentOptions = ref<ServiceAttachmentEquipmentOption[]>([]);
 const equipmentPanelRef = ref<InstanceType<typeof OrderEquipmentPanel> | null>(null);
 const documentsWorkspaceRef = ref<InstanceType<typeof OrderDocumentsWorkspace> | null>(null);
 const proposalToolbarRef = ref<InstanceType<typeof OrderProposalToolbar> | null>(null);
-const executionWorkspaceOpen = ref(false);
-const activeWorkspaceTarget = ref<OrderWorkspaceTarget | null>(null);
 
 const showManagerLabelInput = ref(false);
 
@@ -265,6 +263,23 @@ const {
   order: computed(() => props.order),
   payments,
 });
+
+const {
+  activeWorkspaceTarget,
+  executionWorkspaceOpen,
+  openDocumentsSend,
+  openProposalSend: openProposalDocuments,
+  openWorkspaceTarget,
+  resetWorkspaceNavigation,
+} = useOrderWorkspaceNavigation({
+  status,
+  workflowType,
+  expandedSections: expandedDrawerSections,
+  equipmentPanelRef,
+  documentsWorkspaceRef,
+  setToast,
+});
+const openProposalSend = () => openProposalDocuments(activeProposal.value, orderDocuments.value);
 
 const customer = computed(() => props.order?.customer ?? null);
 const customerDisplayName = computed(() => (
@@ -390,8 +405,7 @@ const initForm = async (order: ManagerOrderDetailResponse | null) => {
     initializedOrderId.value = order.id;
     expandedDrawerSections.value = restoreDrawerSections();
     linkedEquipmentOptions.value = [];
-    executionWorkspaceOpen.value = false;
-    activeWorkspaceTarget.value = null;
+    resetWorkspaceNavigation();
     resetOrderEmails();
   }
   hydrateOrder(order);
@@ -451,32 +465,6 @@ watch(
     if (props.modelValue) await initForm(value);
   },
 );
-
-const openProposalSend = async () => {
-  const proposal = activeProposal.value;
-  if (!proposal) return;
-  expandedDrawerSections.value.documents = true;
-  activeWorkspaceTarget.value = 'documents';
-  await nextTick();
-  const offerExists = orderDocuments.value.some((document) => (
-    document.doc_type === 'offer'
-    && (!document.proposal_id || document.proposal_id === proposal.id)
-  ));
-  if (offerExists) documentsWorkspaceRef.value?.openSend();
-  else {
-    documentsWorkspaceRef.value?.openCreate();
-    setToast('Сначала создайте коммерческое предложение для активного варианта', 'error');
-  }
-  document.getElementById('order-workspace-documents')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-};
-
-const openDocumentsSend = async () => {
-  expandedDrawerSections.value.documents = true;
-  activeWorkspaceTarget.value = 'documents';
-  await nextTick();
-  documentsWorkspaceRef.value?.openSend();
-  document.getElementById('order-workspace-documents')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-};
 
 const handleWorkspaceNextAction = async () => {
   const action = orderWorkspace.value.nextAction;
@@ -548,47 +536,6 @@ const deleteOrder = async () => {
 };
 const getFieldError = (field: string): string => localServerErrors.value[field] || props.serverErrors?.[field] || '';
 const displayFormError = computed(() => localFormError.value || props.formError || '');
-const openWorkspaceTarget = async (target: OrderWorkspaceTarget, allowToggle = false) => {
-  const shouldClose = allowToggle && activeWorkspaceTarget.value === target;
-  if (activeWorkspaceTarget.value === 'equipment') equipmentPanelRef.value?.collapse();
-  if (workflowType.value === 'sales_installation' && target !== 'object') {
-    expandedDrawerSections.value.proposals = false;
-    expandedDrawerSections.value.documents = false;
-    expandedDrawerSections.value.payments = false;
-    expandedDrawerSections.value.execution = false;
-    executionWorkspaceOpen.value = false;
-  }
-  if (shouldClose) {
-    activeWorkspaceTarget.value = null;
-    return;
-  }
-  if (target !== 'object') activeWorkspaceTarget.value = target;
-  if (target === 'object') expandedDrawerSections.value.clientDetails = true;
-  if (target === 'planning') {
-    if (workflowType.value === 'sales_installation') expandedDrawerSections.value.proposals = true;
-    if (status.value === 'execution') expandedDrawerSections.value.execution = true;
-    else expandedDrawerSections.value.planningDetails = true;
-  }
-  if (target === 'proposal') expandedDrawerSections.value.proposals = true;
-  if (target === 'documents') {
-    expandedDrawerSections.value.documents = true;
-  }
-  if (target === 'payments') {
-    if (status.value === 'execution') executionWorkspaceOpen.value = true;
-    else expandedDrawerSections.value.payments = true;
-  }
-  await nextTick();
-  if (target === 'equipment') {
-    expandedDrawerSections.value.proposals = true;
-    await equipmentPanelRef.value?.expand();
-    await nextTick();
-  }
-  const elementId = status.value === 'execution' && target === 'payments'
-    ? 'order-workspace-execution-details'
-    : 'order-workspace-' + target;
-  document.getElementById(elementId)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-};
-
 const discardUnsavedChanges = async () => {
   if (!props.order) return;
   clearDraft();

--- a/manager_frontend/src/components/orders/OrderEditDrawer.vue
+++ b/manager_frontend/src/components/orders/OrderEditDrawer.vue
@@ -17,6 +17,7 @@ import OrderRepairPanel from './OrderRepairPanel.vue';
 import OrderProductLinesEditor from './OrderProductLinesEditor.vue';
 import OrderServiceLinesEditor from './OrderServiceLinesEditor.vue';
 import OrderCustomerContext from './OrderCustomerContext.vue';
+import OrderExecutionPanel from './OrderExecutionPanel.vue';
 import { confirmDialog, promptDialog } from '../../services/ui-feedback';
 import type { ServiceAttachmentEquipmentOption } from '../service-attachments/types';
 import type {
@@ -34,7 +35,7 @@ import type {
   OutgoingEmailResponse,
 } from '../../client';
 import { ManagerOrdersService, ManagerSettingsService, ManagerMailService } from '../../client';
-import { EXECUTION_STATUS_OPTIONS, formatMoney } from './order-utils';
+import { formatMoney } from './order-utils';
 import {
   buildOrderWorkspaceViewModel,
   normalizeOrderWorkflowType,
@@ -176,13 +177,6 @@ const autoExecutionOnPayment = ref(false);
 const autoCloseOnPayment = ref(false);
 const activeProposalId = ref<number | null>(null);
 const proposalActionLoading = ref(false);
-const executionStatusLabel = computed(() => (
-  EXECUTION_STATUS_OPTIONS.find((option) => option.value === executionStatus.value)?.label || 'Назначить работы'
-));
-
-const setExecutionStatus = (value: string) => {
-  executionStatus.value = value;
-};
 
 const installersList = ref<ManagerInstallerResponse[]>([]);
 
@@ -2186,50 +2180,15 @@ watch(
       </OrderDrawerSection>
 
 
-      <OrderDrawerSection
+      <OrderExecutionPanel
         v-if="status === 'execution'"
-        id="order-workspace-planning"
         v-model:expanded="expandedDrawerSections.execution"
-        :title="workflowType === 'sales_installation' ? 'Монтаж' : 'Работы'"
-        :summary="executionStatusLabel"
-        tone="default"
-      >
-        <label v-if="workflowType === 'sales_installation'" class="field-label">
-          Общий этап заказа
-          <select v-model="executionStatus" class="field-input mt-1">
-            <option v-for="option in EXECUTION_STATUS_OPTIONS" :key="option.value" :value="option.value">{{ option.label }}</option>
-          </select>
-        </label>
-        <div v-else class="grid grid-cols-2 gap-2 sm:grid-cols-3">
-          <button
-            v-for="option in EXECUTION_STATUS_OPTIONS"
-            :key="option.value"
-            type="button"
-            class="inline-flex min-h-10 items-center justify-center gap-1.5 rounded-xl border px-2 py-2 text-xs font-semibold transition"
-            :class="executionStatus === option.value
-              ? 'border-teal-500 bg-white text-teal-800 shadow-sm'
-              : 'border-teal-100 bg-white/70 text-slate-600 hover:border-teal-300 hover:text-teal-800'"
-            @click="setExecutionStatus(option.value)"
-          >
-            <span class="material-icons-round text-[15px]">{{ option.icon }}</span>
-            <span class="truncate">{{ option.label }}</span>
-          </button>
-        </div>
-        <div class="mt-3 grid gap-2 sm:grid-cols-2">
-          <label class="flex items-start gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-xs text-slate-700 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200">
-            <input v-model="executionWithoutPayment" type="checkbox" class="mt-0.5 h-4 w-4 rounded border-gray-300 text-teal-600 focus:ring-teal-600" />
-            <span><strong class="block">Разрешить переходы при наличии долга</strong><span class="mt-0.5 block text-slate-500 dark:text-slate-400">Менеджер сможет продолжать работу без полной оплаты.</span></span>
-          </label>
-          <label class="flex items-start gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-xs text-slate-700 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200">
-            <input v-model="autoCloseOnPayment" type="checkbox" class="mt-0.5 h-4 w-4 rounded border-gray-300 text-teal-600 focus:ring-teal-600" />
-            <span><strong class="block">Автоматически завершить после полной оплаты</strong><span class="mt-0.5 block text-slate-500 dark:text-slate-400">Сработает, когда долг станет нулевым.</span></span>
-          </label>
-        </div>
-        <label v-if="executionWithoutPayment" class="field-label mt-3">
-          Причина работы при наличии долга
-          <textarea v-model="executionWithoutPaymentReason" class="field-input min-h-[60px]" placeholder="Например: постоянный клиент, оплата по факту..." />
-        </label>
-      </OrderDrawerSection>
+        v-model:execution-status="executionStatus"
+        v-model:execution-without-payment="executionWithoutPayment"
+        v-model:execution-without-payment-reason="executionWithoutPaymentReason"
+        v-model:auto-close-on-payment="autoCloseOnPayment"
+        :workflow-type="workflowType"
+      />
 
       <DealExecutionTab
         v-if="status === 'execution' && order && executionWorkspaceOpen"

--- a/manager_frontend/src/components/orders/OrderEditDrawer.vue
+++ b/manager_frontend/src/components/orders/OrderEditDrawer.vue
@@ -17,12 +17,11 @@ import OrderServiceLinesEditor from './OrderServiceLinesEditor.vue';
 import OrderCustomerContext from './OrderCustomerContext.vue';
 import OrderExecutionPanel from './OrderExecutionPanel.vue';
 import OrderDocumentsWorkspace from './OrderDocumentsWorkspace.vue';
-import { confirmDialog, promptDialog } from '../../services/ui-feedback';
+import { confirmDialog } from '../../services/ui-feedback';
 import type { ServiceAttachmentEquipmentOption } from '../service-attachments/types';
 import type {
   ManagerOrderDetailResponse,
   ManagerOrderUpdatePayload,
-  OrderProposalResponse,
   ManagerInstallerResponse,
   PaymentResponse,
   PaymentCurrency,
@@ -30,24 +29,18 @@ import type {
   OutgoingEmailResponse,
 } from '../../client';
 import { ManagerOrdersService, ManagerSettingsService, ManagerMailService } from '../../client';
-import { formatMoney } from './order-utils';
 import {
   buildOrderWorkspaceViewModel,
   normalizeOrderWorkflowType,
   type OrderWorkflowType,
   type OrderWorkspaceTarget,
 } from './order-workspace';
-import {
-  isProposalRevisionLocked,
-  normalizeProposalStatus,
-  proposalStatusLabel,
-  type ProposalLifecycleStatus,
-} from './proposal-lifecycle';
 import { emptyRepairMeta, normalizeRepairMeta, type RepairMeta } from './repair-meta';
 import { fromLocalDateTimeInput, toLocalDateTimeInput } from '../../utils/datetime';
 import { getApiErrorMessage } from '../../utils/api-errors';
 import { useSmartStickyHeader } from '../../composables/useSmartStickyHeader';
 import { useOrderCommercialEditor } from '../../composables/useOrderCommercialEditor';
+import { useOrderProposalLifecycle } from '../../composables/useOrderProposalLifecycle';
 import type {
   OrderDrawerDraft,
   OrderLogisticsComponent,
@@ -151,15 +144,12 @@ const measurementRequired = ref(false);
 const measurerId = ref<number | null>(null);
 const measurementResult = ref('');
 const additionalConditions = ref('');
-const proposalStatus = ref<ProposalLifecycleStatus>('draft');
 const negotiationStatus = ref('awaiting_offer');
 const executionStatus = ref('needs_schedule');
 const executionWithoutPayment = ref(false);
 const executionWithoutPaymentReason = ref('');
 const autoExecutionOnPayment = ref(false);
 const autoCloseOnPayment = ref(false);
-const activeProposalId = ref<number | null>(null);
-const proposalActionLoading = ref(false);
 
 const installersList = ref<ManagerInstallerResponse[]>([]);
 
@@ -258,6 +248,43 @@ const initializedOrderId = ref<number | null>(null);
 const localFormError = ref('');
 const showManagerLabelInput = ref(false);
 
+const {
+  activeProposal,
+  activeProposalId,
+  activeProposalLineLabel,
+  activeProposalLocked,
+  activeProposalStatus,
+  archiveProposal,
+  changeActiveProposalStatus,
+  createProposal,
+  duplicateProposal,
+  loadProposalLines,
+  onProposalClick,
+  proposalActionLoading,
+  proposalStatus,
+  proposals: orderProposals,
+  renameProposal,
+  saveCurrentProposalLines,
+  selectProposalForOrder,
+  selectedProposal: selectedOrderProposal,
+} = useOrderProposalLifecycle({
+  order: computed(() => props.order),
+  negotiationStatus,
+  total: totalPreview,
+  localFormError,
+  buildLinesPayload,
+  validateLines: validateProposalLines,
+  loadLines,
+  resetLookupState,
+  loadSupplyRequests: loadOrderSupplyRequests,
+  clearDraft: () => clearDraft(),
+  currentLinesSnapshot: buildCurrentLinesSnapshot,
+  savedLinesSnapshot,
+  setToast,
+  onUpdated: (updatedOrder) => emit('updated', updatedOrder),
+  onReload: (orderId) => emit('reload', orderId),
+});
+
 const customer = computed(() => props.order?.customer ?? null);
 const customerDisplayName = computed(() => (
   customer.value?.full_legal_name
@@ -280,32 +307,6 @@ const compactObjectAddress = computed(() => (
   || props.order?.customer_branch?.delivery_address
   || ''
 ));
-const orderProposals = computed(() => {
-  const proposals = props.order?.proposals || [];
-  return [...proposals]
-    .filter((proposal) => !proposal.is_archived)
-    .sort((a, b) => Number(a.sort_order || 0) - Number(b.sort_order || 0) || Number(a.id) - Number(b.id));
-});
-const selectedOrderProposal = computed(() => (
-  orderProposals.value.find((proposal) => proposal.is_selected)
-  || orderProposals.value[0]
-  || null
-));
-const activeProposal = computed(() => (
-  orderProposals.value.find((proposal) => proposal.id === activeProposalId.value)
-  || selectedOrderProposal.value
-));
-const activeProposalStatus = computed(() => normalizeProposalStatus(activeProposal.value?.status || proposalStatus.value));
-const activeProposalLocked = computed(() => isProposalRevisionLocked(activeProposalStatus.value));
-const activeProposalLineLabel = computed(() => {
-  const proposal = activeProposal.value;
-  if (!proposal) return 'Предложение не создано';
-  const count = (proposal.product_lines?.length || 0) + (proposal.service_lines?.length || 0);
-  const mod100 = count % 100;
-  const mod10 = count % 10;
-  const noun = mod100 >= 11 && mod100 <= 14 ? 'позиций' : mod10 === 1 ? 'позиция' : mod10 >= 2 && mod10 <= 4 ? 'позиции' : 'позиций';
-  return `${proposal.name} · ${proposalStatusLabel(proposal.status)} · ${count} ${noun} · ${formatMoney(proposal.total_amount || 0)}`;
-});
 const documentEmailStatus = computed<'unknown' | 'none' | 'pending' | 'sent' | 'failed'>(() => {
   if (!orderEmailsLoaded.value) return 'unknown';
   const latestDocumentEmail = [...orderEmails.value]
@@ -673,26 +674,14 @@ const restoreDrawerSections = (): DrawerSectionsState => {
   }
 };
 
-const clearDraft = () => {
+function clearDraft() {
   if (!draftKey.value) return;
   try {
     window.sessionStorage.removeItem(draftKey.value);
   } catch (error) {
     console.warn('Failed to clear order drawer draft', error);
   }
-};
-
-const loadProposalLines = (proposal: OrderProposalResponse | null | undefined, fallbackOrder?: ManagerOrderDetailResponse | null) => {
-  editingServiceLineIndex.value = null;
-  if (proposal) {
-    activeProposalId.value = proposal.id;
-    proposalStatus.value = normalizeProposalStatus(proposal.status);
-    loadLines(proposal.product_lines || [], proposal.service_lines || []);
-    return;
-  }
-  activeProposalId.value = null;
-  loadLines(fallbackOrder?.product_lines ?? [], fallbackOrder?.service_lines ?? []);
-};
+}
 
 const initForm = async (order: ManagerOrderDetailResponse | null) => {
   if (!order) return;
@@ -727,7 +716,6 @@ const initForm = async (order: ManagerOrderDetailResponse | null) => {
   measurerId.value = order.measurer_id ?? null;
   measurementResult.value = order.measurement_result ?? '';
   additionalConditions.value = order.additional_conditions ?? '';
-  proposalStatus.value = normalizeProposalStatus(order.proposal_status);
   negotiationStatus.value = order.negotiation_status || 'awaiting_offer';
   executionStatus.value = order.execution_status || 'needs_schedule';
   executionWithoutPayment.value = Boolean(order.execution_without_payment);
@@ -814,217 +802,7 @@ watch(
   },
 );
 
-const applyOrderResponse = async (
-  order: ManagerOrderDetailResponse,
-  preferredProposalId?: number | null,
-  emitReload = true,
-) => {
-  emit('updated', order);
-  const nextProposal = preferredProposalId
-    ? (order.proposals || []).find((proposal) => proposal.id === preferredProposalId && !proposal.is_archived)
-    : ((order.proposals || []).find((proposal) => proposal.is_selected && !proposal.is_archived)
-      || (order.proposals || []).find((proposal) => !proposal.is_archived));
-  loadProposalLines(nextProposal || null, order);
-  syncProductLookupFromLines();
-  await loadOrderSupplyRequests(order.id);
-  if (emitReload) emit('reload', order.id);
-};
-
 const buildProposalLinesPayload = () => buildLinesPayload(activeProposalId.value);
-
-const saveCurrentProposalLines = async () => {
-  if (!props.order?.id) return props.order || null;
-  if (activeProposalLocked.value) return props.order;
-  const validationError = validateProposalLines();
-  if (validationError) {
-    localFormError.value = validationError;
-    throw new Error(validationError);
-  }
-  const currentProposalId = activeProposalId.value;
-  const order = await ManagerOrdersService.patchManagerOrder(props.order.id, buildProposalLinesPayload());
-  clearDraft();
-  await applyOrderResponse(order, currentProposalId, false);
-  savedLinesSnapshot.value = currentLinesSnapshot();
-  return order;
-};
-
-const setActiveProposal = async (proposal: OrderProposalResponse) => {
-  if (!proposal || activeProposalId.value === proposal.id || proposalActionLoading.value) return;
-  proposalActionLoading.value = true;
-  try {
-    await saveCurrentProposalLines();
-  } catch (error) {
-    setToast(`Сначала сохраните текущий вариант: ${getApiErrorMessage(error)}`, 'error');
-    return;
-  } finally {
-    proposalActionLoading.value = false;
-  }
-  loadProposalLines(proposal, props.order);
-  productLookupById.value = {};
-  syncProductLookupFromLines();
-};
-
-const onProposalClick = (proposal: OrderProposalResponse) => {
-  void setActiveProposal(proposal);
-};
-
-const createProposal = async () => {
-  if (!props.order?.id || proposalActionLoading.value) return;
-  const name = await promptDialog({
-    title: 'Новое предложение',
-    inputLabel: 'Название',
-    initialValue: `Вариант ${orderProposals.value.length + 1}`,
-    required: true,
-    confirmText: 'Создать',
-  });
-  if (name === null) return;
-  proposalActionLoading.value = true;
-  try {
-    await saveCurrentProposalLines();
-    const order = await ManagerOrdersService.createManagerOrderProposal(props.order.id, { name });
-    const created = order.proposals?.[Math.max(0, (order.proposals?.length || 1) - 1)] || null;
-    await applyOrderResponse(order, created?.id || null);
-    setToast('Предложение создано', 'success');
-  } catch (error) {
-    setToast(`Ошибка создания предложения: ${getApiErrorMessage(error)}`, 'error');
-  } finally {
-    proposalActionLoading.value = false;
-  }
-};
-
-const duplicateProposal = async () => {
-  if (!props.order?.id || !activeProposal.value?.id || proposalActionLoading.value) return;
-  const name = await promptDialog({
-    title: 'Копия предложения',
-    inputLabel: 'Название',
-    initialValue: `${activeProposal.value.name} копия`,
-    required: true,
-    confirmText: 'Создать копию',
-  });
-  if (name === null) return;
-  proposalActionLoading.value = true;
-  try {
-    const sourceProposalId = activeProposal.value.id;
-    await saveCurrentProposalLines();
-    const order = await ManagerOrdersService.duplicateManagerOrderProposal(props.order.id, sourceProposalId, { name });
-    const created = order.proposals?.[Math.max(0, (order.proposals?.length || 1) - 1)] || null;
-    await applyOrderResponse(order, created?.id || null);
-    setToast('Предложение скопировано', 'success');
-  } catch (error) {
-    setToast(`Ошибка копирования предложения: ${getApiErrorMessage(error)}`, 'error');
-  } finally {
-    proposalActionLoading.value = false;
-  }
-};
-
-const renameProposal = async () => {
-  if (!props.order?.id || !activeProposal.value?.id || proposalActionLoading.value) return;
-  const name = await promptDialog({
-    title: 'Переименовать предложение',
-    inputLabel: 'Название',
-    initialValue: activeProposal.value.name,
-    required: true,
-    confirmText: 'Переименовать',
-  });
-  if (name === null || !name.trim()) return;
-  proposalActionLoading.value = true;
-  try {
-    const proposalId = activeProposal.value.id;
-    await saveCurrentProposalLines();
-    const order = await ManagerOrdersService.patchManagerOrderProposal(props.order.id, proposalId, { name });
-    await applyOrderResponse(order, proposalId);
-    setToast('Название обновлено', 'success');
-  } catch (error) {
-    setToast(`Ошибка переименования: ${getApiErrorMessage(error)}`, 'error');
-  } finally {
-    proposalActionLoading.value = false;
-  }
-};
-
-const archiveProposal = async () => {
-  if (!props.order?.id || !activeProposal.value?.id || proposalActionLoading.value) return;
-  if (orderProposals.value.length <= 1) {
-    setToast('Нельзя удалить единственное предложение', 'error');
-    return;
-  }
-  if (!await confirmDialog({
-    title: 'Архивировать предложение?',
-    description: activeProposal.value.name,
-    confirmText: 'Архивировать',
-    variant: 'warning',
-  })) return;
-  const archivedId = activeProposal.value.id;
-  proposalActionLoading.value = true;
-  try {
-    const order = await ManagerOrdersService.archiveManagerOrderProposal(props.order.id, archivedId);
-    const next = (order.proposals || []).find((proposal) => proposal.is_selected && !proposal.is_archived)
-      || (order.proposals || []).find((proposal) => proposal.id !== archivedId && !proposal.is_archived)
-      || null;
-    await applyOrderResponse(order, next?.id || null);
-    setToast('Предложение архивировано', 'success');
-  } catch (error) {
-    setToast(`Ошибка архивации: ${getApiErrorMessage(error)}`, 'error');
-  } finally {
-    proposalActionLoading.value = false;
-  }
-};
-
-const selectProposalForOrder = async (proposal?: OrderProposalResponse) => {
-  const targetProposal = proposal || activeProposal.value;
-  if (!props.order?.id || !targetProposal?.id || targetProposal.is_selected || proposalActionLoading.value) return;
-  proposalActionLoading.value = true;
-  try {
-    await saveCurrentProposalLines();
-    const order = await ManagerOrdersService.selectManagerOrderProposal(props.order.id, targetProposal.id);
-    await applyOrderResponse(order, targetProposal.id);
-    setToast('Предложение выбрано для заказа', 'success');
-  } catch (error) {
-    setToast(`Ошибка выбора предложения: ${getApiErrorMessage(error)}`, 'error');
-  } finally {
-    proposalActionLoading.value = false;
-  }
-};
-
-const changeActiveProposalStatus = async (nextStatus: ProposalLifecycleStatus) => {
-  const proposal = activeProposal.value;
-  if (!props.order?.id || !proposal?.id || proposalActionLoading.value) return;
-  if (nextStatus === activeProposalStatus.value) return;
-
-  if (nextStatus === 'ready_to_send') {
-    const validationError = validateProposalLines();
-    if (validationError || totalPreview.value <= 0) {
-      setToast(validationError || 'Добавьте хотя бы одну позицию с ненулевой суммой', 'error');
-      return;
-    }
-  }
-  if (nextStatus === 'sent' && !await confirmDialog({
-    title: 'Отметить предложение отправленным?',
-    description: 'Используйте это действие, если предложение отправлено не через CRM. Для email используйте основную кнопку отправки.',
-    confirmText: 'Отметить отправленным',
-    variant: 'warning',
-  })) return;
-  if (nextStatus === 'draft' && activeProposalLocked.value && !await confirmDialog({
-    title: 'Вернуть предложение в черновик?',
-    description: 'После этого предложение снова можно будет редактировать.',
-    confirmText: 'Вернуть в черновик',
-    variant: 'warning',
-  })) return;
-
-  proposalActionLoading.value = true;
-  try {
-    if (nextStatus === 'ready_to_send') await saveCurrentProposalLines();
-    const order = await ManagerOrdersService.patchManagerOrderProposal(props.order.id, proposal.id, { status: nextStatus });
-    proposalStatus.value = nextStatus;
-    negotiationStatus.value = order.negotiation_status || negotiationStatus.value;
-    await applyOrderResponse(order, proposal.id);
-    const label = proposalStatusLabel(nextStatus);
-    setToast(`Статус предложения: ${label}`, 'success');
-  } catch (error) {
-    setToast(`Не удалось изменить статус: ${getApiErrorMessage(error)}`, 'error');
-  } finally {
-    proposalActionLoading.value = false;
-  }
-};
 
 const openProposalSend = async () => {
   const proposal = activeProposal.value;

--- a/manager_frontend/src/components/orders/OrderEditDrawer.vue
+++ b/manager_frontend/src/components/orders/OrderEditDrawer.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { computed, nextTick, ref, watch } from 'vue';
-import { useDebounceFn } from '@vueuse/core';
 import { api } from '../../api';
 import DealExecutionTab from './DealExecutionTab.vue';
 import OrderDrawerSection from './OrderDrawerSection.vue';
@@ -23,12 +22,8 @@ import type { ServiceAttachmentEquipmentOption } from '../service-attachments/ty
 import type {
   ManagerOrderDetailResponse,
   ManagerOrderUpdatePayload,
-  ManagerServiceEstimateResponse,
-  OrderProductLineResponse,
   OrderProposalResponse,
-  OrderServiceLineResponse,
   ManagerInstallerResponse,
-  ManagerQuickTariffResponse,
   PaymentResponse,
   PaymentCurrency,
   FxRateResponse,
@@ -50,20 +45,13 @@ import {
 } from './proposal-lifecycle';
 import { emptyRepairMeta, normalizeRepairMeta, type RepairMeta } from './repair-meta';
 import { fromLocalDateTimeInput, toLocalDateTimeInput } from '../../utils/datetime';
-import {
-  useServiceDescriptionMode,
-  type ServiceDescriptionMode,
-} from './service-description-mode';
-
 import { getApiErrorMessage } from '../../utils/api-errors';
 import { useSmartStickyHeader } from '../../composables/useSmartStickyHeader';
+import { useOrderCommercialEditor } from '../../composables/useOrderCommercialEditor';
 import type {
-  LogisticsComponentKind,
   OrderDrawerDraft,
   OrderLogisticsComponent,
-  ProductLine,
   ProductLogisticsTemplateComponent,
-  ProductOption,
   ServiceLine,
 } from './order-editor-types';
 
@@ -95,12 +83,15 @@ const serviceKindLabels: Record<string, string> = {
 };
 
 const formatServiceKind = (kind?: string | null) => serviceKindLabels[String(kind || '')] || kind || '';
-const productOptions = ref<ProductOption[]>([]);
-const productLookupById = ref<Record<number, ProductOption>>({});
-const activeSuggestionIndex = ref<number | null>(null);
-const productLookupLoading = ref(false);
 const toast = ref('');
-let productSearchRequestId = 0;
+const toastType = ref<'success' | 'error'>('success');
+function setToast(message: string, type: 'success' | 'error' = 'success') {
+  toast.value = message;
+  toastType.value = type;
+  window.setTimeout(() => {
+    if (toast.value === message) toast.value = '';
+  }, 3000);
+}
 
 const status = ref('new_lead');
 const orderTitle = ref('');
@@ -123,14 +114,6 @@ const targetCurrency = ref<PaymentCurrency | null>(null);
 const targetCurrencyAmount = ref<number | null>(null);
 const enableCurrency = ref(false);
 const currentFxRate = ref<FxRateResponse | null>(null);
-
-const searchInStock = ref(false);
-
-watch(searchInStock, () => {
-  if (activeSuggestionIndex.value !== null) {
-    onProductQueryInput(activeSuggestionIndex.value);
-  }
-});
 
 const syncTargetCurrencyAmountFromRate = () => {
   const rate = getActiveFxRate(targetCurrency.value);
@@ -180,31 +163,65 @@ const proposalActionLoading = ref(false);
 
 const installersList = ref<ManagerInstallerResponse[]>([]);
 
-const productLines = ref<ProductLine[]>([]);
-const supplyRequests = ref<any[]>([]);
-const supplyActionLoadingLineId = ref<number | null>(null);
-const serviceLines = ref<ServiceLine[]>([]);
-const editingServiceLineIndex = ref<number | null>(null);
 const savedLinesSnapshot = ref('');
 const savedFormSnapshot = ref('');
 const pendingDraftClearOrderId = ref<number | null>(null);
-const activeServiceSuggestionIndex = ref<number | null>(null);
-const serviceTariffOptions = ref<ManagerQuickTariffResponse[]>([]);
-const serviceTariffLookupLoading = ref(false);
-let serviceTariffSearchRequestId = 0;
-const estimateOptions = ref<ManagerServiceEstimateResponse[]>([]);
-const estimateOptionsLoading = ref(false);
-const estimateImportMode = ref<'detailed' | 'collapsed'>('detailed');
 const {
-  preferredMode: serviceDescriptionMode,
-  rememberMode: setDefaultServiceDescriptionMode,
-  applyTariffTemplate: applyTariffTemplateToLine,
-  replaceLineDescription,
-} = useServiceDescriptionMode();
-const selectedEstimateId = ref<number | null>(null);
-const estimateSearchQuery = ref('');
-const importingEstimate = ref(false);
-const showEstimateImport = ref(false);
+  activeServiceSuggestionIndex,
+  activeSuggestionIndex,
+  addProductLine,
+  addServiceLine,
+  applyEstimateToServices,
+  applyTariffTemplateToLine,
+  buildLinesPayload,
+  createSupplyFromProductLine,
+  currentLinesSnapshot: buildCurrentLinesSnapshot,
+  editingServiceLineIndex,
+  estimateImportMode,
+  estimateOptions,
+  estimateOptionsLoading,
+  estimateSearchQuery,
+  importingEstimate,
+  loadEstimateOptions,
+  loadLines,
+  loadOrderSupplyRequests,
+  margin: marginPreview,
+  onProductInputBlur,
+  onProductInputFocus,
+  onProductQueryInput,
+  onServiceTitleBlur,
+  onServiceTitleFocus,
+  onServiceTitleInput,
+  openSelectedProduct,
+  productLines,
+  productLookupById,
+  productLookupLoading,
+  productOptions,
+  removeProductLine,
+  removeServiceLine,
+  resetLookupState,
+  searchInStock,
+  selectProductForLine,
+  selectServiceTariffForLine,
+  selectedEstimateId,
+  serviceDescriptionMode,
+  serviceLines,
+  serviceTariffLookupLoading,
+  serviceTariffOptions,
+  setDefaultServiceDescriptionMode,
+  setServiceLineDescriptionMode,
+  showEstimateImport,
+  supplyActionLoadingLineId,
+  supplyBadgeForLine,
+  syncProductLookupFromLines,
+  toggleEstimateImport,
+  total: totalPreview,
+  validateLines: validateProposalLines,
+} = useOrderCommercialEditor({
+  order: computed(() => props.order),
+  setToast,
+  persistDraft: () => persistDraft(),
+});
 const payments = ref<PaymentResponse[]>([]);
 const linkedEquipmentOptions = ref<ServiceAttachmentEquipmentOption[]>([]);
 const equipmentPanelRef = ref<InstanceType<typeof OrderEquipmentPanel> | null>(null);
@@ -387,36 +404,6 @@ const getActiveFxRate = (currency: PaymentCurrency | null): number | null => {
   return null;
 };
 
-const toastType = ref<'success' | 'error'>('success');
-const setToast = (message: string, type: 'success' | 'error' = 'success') => {
-  toast.value = message;
-  toastType.value = type;
-  window.setTimeout(() => {
-    if (toast.value === message) toast.value = '';
-  }, 3000);
-};
-
-const supplyStatusLabels: Record<string, string> = {
-  draft: 'черновик',
-  awaiting_reply: 'ждем ответ',
-  reserved: 'бронь',
-  ordered: 'заказано',
-  ready_for_pickup: 'готово к забору',
-  picked_up: 'забрано',
-  received: 'получено',
-  canceled: 'отменено',
-};
-
-const loadOrderSupplyRequests = async (orderId: number) => {
-  try {
-    const response = await api.listSupplyRequests({ orderId, limit: 100 });
-    supplyRequests.value = response.items || [];
-  } catch (error) {
-    console.warn('Failed to load supply requests for order', error);
-    supplyRequests.value = [];
-  }
-};
-
 const loadOrderEmails = async (orderId: number) => {
   const requestId = ++orderEmailsRequestId;
   try {
@@ -429,42 +416,6 @@ const loadOrderEmails = async (orderId: number) => {
     console.warn('Failed to load order email summary', error);
     orderEmails.value = [];
     orderEmailsLoaded.value = false;
-  }
-};
-
-const supplyBadgeForLine = (line: ProductLine) => {
-  if (!line.link_id) return null;
-  for (const request of supplyRequests.value) {
-    const requestLine = (request.lines || []).find((item: any) => Number(item.order_product_link_id) === Number(line.link_id));
-    if (requestLine) {
-      return {
-        label: supplyStatusLabels[requestLine.status] || requestLine.status,
-        requestId: request.id,
-        status: requestLine.status,
-      };
-    }
-  }
-  return null;
-};
-
-const createSupplyFromProductLine = async (line: ProductLine, intent: 'order' | 'reserve') => {
-  if (!props.order?.id) return;
-  if (!line.link_id) {
-    setToast('Сначала сохраните заказ, чтобы создать поставку по строке.', 'error');
-    return;
-  }
-  supplyActionLoadingLineId.value = line.link_id;
-  try {
-    await api.createSupplyRequestFromOrderLines({
-      order_product_link_ids: [line.link_id],
-      intent,
-    });
-    setToast(intent === 'reserve' ? 'Строка отправлена в бронирование.' : 'Строка добавлена в поставки.');
-    await loadOrderSupplyRequests(props.order.id);
-  } catch (error) {
-    setToast(`Не удалось создать поставку: ${getApiErrorMessage(error)}`, 'error');
-  } finally {
-    supplyActionLoadingLineId.value = null;
   }
 };
 
@@ -563,12 +514,6 @@ const refreshOrderFromDocumentsPanel = () => {
   }
 };
 
-const totalPreview = computed(() => {
-  const pTotal = productLines.value.reduce((sum, line) => sum + line.price * line.quantity, 0);
-  const sTotal = serviceLines.value.reduce((sum, line) => sum + line.price * line.quantity, 0);
-  return pTotal + sTotal;
-});
-
 const totalPaymentsPreview = computed(() => {
   const bynPaid = payments.value.filter((p) => p.currency === 'BYN').reduce((sum, p) => sum + p.amount, 0);
   if (!enableCurrency.value || !currentFxRate.value || !targetCurrency.value) {
@@ -608,101 +553,7 @@ const targetCurrencyBalanceDue = computed(() => {
   return Math.max(0, (targetCurrencyAmount.value || 0) - calculatedTargetCurrencyPayments.value);
 });
 
-const marginPreview = computed(() => {
-  const pCost = productLines.value.reduce((sum, line) => sum + line.cost * line.quantity, 0);
-  const sCost = serviceLines.value.reduce((sum, line) => sum + line.cost * line.quantity, 0);
-  return Math.round(totalPreview.value - (pCost + sCost));
-});
-
-const rememberProductOption = (option: ProductOption) => {
-  productLookupById.value = {
-    ...productLookupById.value,
-    [option.id]: option,
-  };
-};
-
-const rememberProductOptions = (options: ProductOption[]) => {
-  if (!options.length) return;
-  const merged = { ...productLookupById.value };
-  for (const option of options) merged[option.id] = option;
-  productLookupById.value = merged;
-};
-
-const mapSmartSearchItemToOption = (item: any): ProductOption => ({
-  id: Number(item.id),
-  title: String(item.title ?? ''),
-  price: Number(item.price ?? 0),
-  cost: Number(item.min_cost_byn ?? 0),
-  is_inverter: Boolean(item.is_inverter),
-  power_cooling: item.power_cooling == null ? null : Number(item.power_cooling),
-  availability_status: String(item.availability_status ?? 'out_of_stock'),
-  vitebsk_qty: Number(item.vitebsk_qty ?? 0),
-  minsk_qty: Number(item.minsk_qty ?? 0),
-  specs: ((item.specs || {}) as Record<string, any>),
-});
-
-const syncProductLookupFromLines = () => {
-  for (const line of productLines.value) {
-    if (!line.product_id || productLookupById.value[line.product_id]) continue;
-    rememberProductOption({
-      id: line.product_id,
-      title: line.product_query,
-      price: line.price,
-      cost: line.cost,
-      is_inverter: false,
-      power_cooling: null,
-      availability_status: 'out_of_stock',
-      vitebsk_qty: 0,
-      minsk_qty: 0,
-    });
-  }
-};
-
-const debouncedLoadProductOptions = useDebounceFn(async (index: number, q: string, requestId: number) => {
-  try {
-    productLookupLoading.value = true;
-    const response = await api.smartSearchProducts(q, 20);
-    if (requestId !== productSearchRequestId || activeSuggestionIndex.value !== index) return;
-    let options = Array.isArray(response) ? response.map(mapSmartSearchItemToOption) : [];
-    if (searchInStock.value) {
-      options = options.filter(o => o.vitebsk_qty > 0 || o.minsk_qty > 0 || o.availability_status === 'check_availability');
-    }
-    productOptions.value = options;
-    rememberProductOptions(options);
-  } catch (error) {
-    setToast(`Ошибка поиска товаров: ${getApiErrorMessage(error)}`);
-    if (requestId === productSearchRequestId) {
-      productOptions.value = [];
-    }
-  } finally {
-    if (requestId === productSearchRequestId) {
-      productLookupLoading.value = false;
-    }
-  }
-}, 400);
-
-const currentLinesSnapshot = () => JSON.stringify({
-  activeProposalId: activeProposalId.value,
-  products: productLines.value.map((line) => ({
-    link_id: line.link_id ?? null,
-    product_id: Number(line.product_id || 0),
-    product_query: String(line.product_query || '').trim(),
-    quantity: Number(line.quantity || 0),
-    price: Number(line.price || 0),
-    cost: Number(line.cost || 0),
-    product_country: line.product_country || null,
-    product_logistics_components: line.product_logistics_components || [],
-    logistics_components: line.logistics_components || null,
-  })),
-  services: serviceLines.value.map((line) => ({
-    service_id: line.service_id ?? null,
-    title: String(line.title || '').trim(),
-    quantity: Number(line.quantity || 0),
-    price: Number(line.price || 0),
-    cost: Number(line.cost || 0),
-  })),
-});
-
+const currentLinesSnapshot = () => buildCurrentLinesSnapshot(activeProposalId.value);
 const currentFormSnapshot = () => JSON.stringify({
   status: status.value,
   title: orderTitle.value.trim(),
@@ -740,7 +591,7 @@ const hasUnsavedChanges = computed(() => (
   )
 ));
 
-const persistDraft = () => {
+function persistDraft() {
   if (!draftKey.value) return;
   try {
     const payload: OrderDrawerDraft = {
@@ -751,7 +602,7 @@ const persistDraft = () => {
   } catch (error) {
     console.warn('Failed to persist order drawer draft', error);
   }
-};
+}
 
 const restoreDraft = () => {
   if (!draftKey.value) return;
@@ -831,42 +682,16 @@ const clearDraft = () => {
   }
 };
 
-const mapProductLineFromResponse = (line: OrderProductLineResponse): ProductLine => ({
-  link_id: line.id,
-  product_id: line.product_id || 0,
-  product_query: line.product_title || '',
-  quantity: line.quantity,
-  price: line.price,
-  cost: line.cost,
-  product_country: (line as any).product_country || null,
-  product_logistics_components: Array.isArray((line as any).product_logistics_components)
-    ? ((line as any).product_logistics_components as ProductLogisticsTemplateComponent[])
-    : [],
-  logistics_components: Array.isArray((line as any).logistics_components) && (line as any).logistics_components.length
-    ? ((line as any).logistics_components as OrderLogisticsComponent[])
-    : null,
-});
-
-const mapServiceLineFromResponse = (line: OrderServiceLineResponse): ServiceLine => ({
-  service_id: line.service_id,
-  title: line.service_title,
-  quantity: Math.max(1, Number(line.quantity || 1)),
-  price: Number(line.price || 0),
-  cost: Number(line.cost || 0),
-});
-
 const loadProposalLines = (proposal: OrderProposalResponse | null | undefined, fallbackOrder?: ManagerOrderDetailResponse | null) => {
   editingServiceLineIndex.value = null;
   if (proposal) {
     activeProposalId.value = proposal.id;
     proposalStatus.value = normalizeProposalStatus(proposal.status);
-    productLines.value = (proposal.product_lines || []).map(mapProductLineFromResponse);
-    serviceLines.value = (proposal.service_lines || []).map(mapServiceLineFromResponse);
+    loadLines(proposal.product_lines || [], proposal.service_lines || []);
     return;
   }
   activeProposalId.value = null;
-  productLines.value = (fallbackOrder?.product_lines ?? []).map(mapProductLineFromResponse);
-  serviceLines.value = (fallbackOrder?.service_lines ?? []).map(mapServiceLineFromResponse);
+  loadLines(fallbackOrder?.product_lines ?? [], fallbackOrder?.service_lines ?? []);
 };
 
 const initForm = async (order: ManagerOrderDetailResponse | null) => {
@@ -945,15 +770,7 @@ const initForm = async (order: ManagerOrderDetailResponse | null) => {
   // Payments
   payments.value = [...(order.payments || [])];
 
-  productLookupById.value = {};
-
-  syncProductLookupFromLines();
-  productOptions.value = [];
-  activeSuggestionIndex.value = null;
-  productLookupLoading.value = false;
-  serviceTariffOptions.value = [];
-  activeServiceSuggestionIndex.value = null;
-  serviceTariffLookupLoading.value = false;
+  resetLookupState();
   savedFormSnapshot.value = currentFormSnapshot();
   restoreDraft();
   syncProductLookupFromLines();
@@ -997,96 +814,6 @@ watch(
   },
 );
 
-const onProductChanged = (index: number, applyCatalogPrice = false) => {
-  const row = productLines.value[index];
-  if (!row) return;
-  const selected = productLookupById.value[row.product_id];
-  if (!selected) return;
-  row.product_query = selected.title;
-  if (applyCatalogPrice) {
-    row.price = selected.price;
-  }
-};
-
-const onProductQueryInput = (index: number) => {
-  const row = productLines.value[index];
-  if (!row) return;
-  activeSuggestionIndex.value = index;
-  const query = row.product_query.trim();
-  row.product_id = 0;
-  productSearchRequestId += 1;
-  if (query.length < 2) {
-    productOptions.value = [];
-    productLookupLoading.value = false;
-    return;
-  }
-  debouncedLoadProductOptions(index, query, productSearchRequestId);
-};
-
-const onProductInputBlur = (index: number) => {
-  window.setTimeout(() => {
-    if (activeSuggestionIndex.value === index) {
-      activeSuggestionIndex.value = null;
-    }
-  }, 120);
-};
-
-const onProductInputFocus = (index: number) => {
-  activeSuggestionIndex.value = index;
-};
-
-const selectProductForLine = (index: number, option: ProductOption) => {
-  const row = productLines.value[index];
-  if (!row) return;
-  row.product_id = option.id;
-  row.product_query = option.title;
-  row.price = option.price;
-  row.product_country = getProductCountryFromSpecs(option.specs);
-  row.product_logistics_components = normalizeProductLogisticsTemplate(option.specs?.logistics_components);
-  row.logistics_components = null;
-  // Quick selection means the row now follows the selected catalog product.
-  if (option.cost && option.cost > 0) {
-    row.cost = option.cost;
-  }
-  rememberProductOption(option);
-  activeSuggestionIndex.value = null;
-  productOptions.value = [];
-  onProductChanged(index, false);
-};
-
-const openSelectedProduct = (index: number) => {
-  const row = productLines.value[index];
-  if (!row?.product_id) return;
-  persistDraft();
-  const returnTo = `${window.location.pathname}${window.location.search}`;
-  const query = new URLSearchParams({
-    editProductId: String(row.product_id),
-    editProductQuery: row.product_query || '',
-    returnTo,
-  });
-  window.history.pushState({}, '', `/manager/products?${query.toString()}`);
-  window.dispatchEvent(new PopStateEvent('popstate'));
-};
-
-const addProductLine = () => {
-  productLines.value.push({
-    link_id: null,
-    product_id: 0,
-    product_query: '',
-    quantity: 1,
-    price: 0,
-    cost: 0,
-    product_country: null,
-    product_logistics_components: [],
-    logistics_components: null,
-  });
-};
-
-const addServiceLine = () => {
-  serviceLines.value.push({ title: '', quantity: 1, price: 0, cost: 0, service_id: null });
-  editingServiceLineIndex.value = serviceLines.value.length - 1;
-};
-
 const applyOrderResponse = async (
   order: ManagerOrderDetailResponse,
   preferredProposalId?: number | null,
@@ -1103,36 +830,7 @@ const applyOrderResponse = async (
   if (emitReload) emit('reload', order.id);
 };
 
-const buildProposalLinesPayload = () => ({
-  products: productLines.value.map((line) => ({
-    product_id: line.product_id || 0,
-    quantity: Math.trunc(Number(line.quantity) || 0),
-    price: Math.round(Number(line.price) || 0),
-    cost: (!line.cost && line.cost !== 0) ? null : toIntegerMoney(line.cost),
-    logistics_components: normalizeOrderLogisticsComponents(line.logistics_components),
-    link_id: line.link_id ?? null,
-    proposal_id: activeProposalId.value,
-  })),
-  services: serviceLines.value.map((line) => ({
-    service_id: line.service_id ?? null,
-    title: line.title,
-    quantity: Math.trunc(Number(line.quantity) || 0),
-    price: Math.round(Number(line.price) || 0),
-    cost: (!line.cost && line.cost !== 0) ? null : toIntegerMoney(line.cost),
-    link_id: null,
-    proposal_id: activeProposalId.value,
-  })),
-});
-
-const validateProposalLines = () => {
-  if (productLines.value.some((line) => line.quantity <= 0)) return 'Количество товара должно быть больше 0';
-  if (productLines.value.some((line) => line.price < 0)) return 'Цена товара не может быть отрицательной';
-  if (productLines.value.some((line) => !line.product_id)) return 'Выберите товар из выпадающего списка';
-  if (serviceLines.value.some((line) => line.quantity <= 0)) return 'Количество услуги должно быть больше 0';
-  if (serviceLines.value.some((line) => line.price < 0)) return 'Цена услуги не может быть отрицательной';
-  if (serviceLines.value.some((line) => !line.title?.trim())) return 'Для услуги укажите название';
-  return '';
-};
+const buildProposalLinesPayload = () => buildLinesPayload(activeProposalId.value);
 
 const saveCurrentProposalLines = async () => {
   if (!props.order?.id) return props.order || null;
@@ -1370,85 +1068,6 @@ const handleWorkspaceNextAction = async () => {
   openWorkspaceTarget(action.target);
 };
 
-const toggleEstimateImport = async () => {
-  showEstimateImport.value = !showEstimateImport.value;
-  if (showEstimateImport.value && !estimateOptions.value.length && !estimateOptionsLoading.value) {
-    await loadEstimateOptions();
-  }
-};
-
-const debouncedLoadServiceTariffOptions = useDebounceFn(async (index: number, q: string, requestId: number) => {
-  try {
-    serviceTariffLookupLoading.value = true;
-    const response = await api.listManagerQuickTariffs(q, null, 10);
-    if (requestId !== serviceTariffSearchRequestId || activeServiceSuggestionIndex.value !== index) return;
-    serviceTariffOptions.value = response.items || [];
-  } catch (error) {
-    setToast(`Ошибка поиска тарифов: ${getApiErrorMessage(error)}`, 'error');
-    if (requestId === serviceTariffSearchRequestId) {
-      serviceTariffOptions.value = [];
-    }
-  } finally {
-    if (requestId === serviceTariffSearchRequestId) {
-      serviceTariffLookupLoading.value = false;
-    }
-  }
-}, 300);
-
-const onServiceTitleInput = (index: number) => {
-  const row = serviceLines.value[index];
-  if (!row) return;
-  activeServiceSuggestionIndex.value = index;
-  row.service_id = null;
-  const query = row.title.trim();
-  serviceTariffSearchRequestId += 1;
-  if (query.length < 2) {
-    serviceTariffOptions.value = [];
-    serviceTariffLookupLoading.value = false;
-    return;
-  }
-  debouncedLoadServiceTariffOptions(index, query, serviceTariffSearchRequestId);
-};
-
-const onServiceTitleFocus = (index: number) => {
-  activeServiceSuggestionIndex.value = index;
-  const row = serviceLines.value[index];
-  if (row?.title.trim() && row.title.trim().length >= 2) {
-    onServiceTitleInput(index);
-  }
-};
-
-const onServiceTitleBlur = (index: number) => {
-  window.setTimeout(() => {
-    if (activeServiceSuggestionIndex.value === index) {
-      activeServiceSuggestionIndex.value = null;
-    }
-  }, 120);
-};
-
-const selectServiceTariffForLine = (index: number, option: ManagerQuickTariffResponse) => {
-  const row = serviceLines.value[index];
-  if (!row) return;
-  applyTariffTemplateToLine(row, option);
-  activeServiceSuggestionIndex.value = null;
-  serviceTariffOptions.value = [];
-};
-
-const setServiceLineDescriptionMode = async (index: number, mode: ServiceDescriptionMode) => {
-  const row = serviceLines.value[index];
-  if (!row) return;
-  await replaceLineDescription(
-    row,
-    mode,
-    () => confirmDialog({
-      title: 'Заменить изменённое название?',
-      description: 'Текст был отредактирован вручную. При замене эти изменения будут потеряны.',
-      confirmText: mode === 'full' ? 'Заменить на подробное' : 'Заменить на краткое',
-      variant: 'warning',
-    }),
-  );
-};
-
 const hasDiagnosticServiceLine = () => serviceLines.value.some((line) => /диагност/i.test(line.title || ''));
 
 let workflowChangeRequestId = 0;
@@ -1512,141 +1131,6 @@ const setWorkflowType = async (next: OrderWorkflowType) => {
     repairMeta.value = normalizeRepairMeta(repairMeta.value, { defaultRepairStatus: true });
     await addDefaultRepairDiagnostic(requestId);
   }
-};
-
-const loadEstimateOptions = async () => {
-  estimateOptionsLoading.value = true;
-  try {
-    const response = await api.listManagerServiceEstimates(1, 10);
-    estimateOptions.value = response.items;
-    if (!response.items.length) {
-      selectedEstimateId.value = null;
-      return;
-    }
-    if (!selectedEstimateId.value || !response.items.some((item) => item.id === selectedEstimateId.value)) {
-      selectedEstimateId.value = response.items[0]!.id;
-    }
-  } catch (error) {
-    console.warn('Failed to load service estimates', error);
-    estimateOptions.value = [];
-    selectedEstimateId.value = null;
-  } finally {
-    estimateOptionsLoading.value = false;
-  }
-};
-
-const applyEstimateToServices = async () => {
-  const estimateId = Number(selectedEstimateId.value);
-  if (!Number.isFinite(estimateId) || estimateId <= 0) {
-    setToast('Выберите смету для добавления', 'error');
-    return;
-  }
-  importingEstimate.value = true;
-  try {
-    const response = await api.getManagerServiceEstimateOrderLines(
-      estimateId,
-      estimateImportMode.value,
-      serviceDescriptionMode.value,
-    );
-    if (!response.services.length) {
-      setToast('В выбранной смете нет строк', 'error');
-      return;
-    }
-
-    const mappedLines: ServiceLine[] = response.services.map((line) => ({
-      service_id: line.service_id ?? null,
-      title: line.title || 'Услуга',
-      quantity: Math.max(1, Number(line.quantity || 1)),
-      price: Number(line.price || 0),
-      cost: Number(line.cost || 0),
-    }));
-    serviceLines.value = [...serviceLines.value, ...mappedLines];
-    showEstimateImport.value = false;
-    setToast(
-      response.mode === 'collapsed'
-        ? `Смета #${response.estimate_id} добавлена одной строкой`
-        : `Смета #${response.estimate_id} добавлена: ${mappedLines.length} строк`
-    );
-  } catch (error) {
-    setToast(`Ошибка импорта сметы: ${getApiErrorMessage(error)}`, 'error');
-  } finally {
-    importingEstimate.value = false;
-  }
-};
-
-const removeProductLine = async (index: number) => {
-  if (!await confirmDialog({ title: 'Удалить товар из заказа?', confirmText: 'Удалить', variant: 'danger' })) return;
-  productLines.value.splice(index, 1);
-  if (activeSuggestionIndex.value === index) {
-    activeSuggestionIndex.value = null;
-    productOptions.value = [];
-  }
-};
-
-const removeServiceLine = async (index: number) => {
-  if (!await confirmDialog({ title: 'Удалить услугу из заказа?', confirmText: 'Удалить', variant: 'danger' })) return;
-  serviceLines.value.splice(index, 1);
-  editingServiceLineIndex.value = null;
-  if (activeServiceSuggestionIndex.value === index) {
-    activeServiceSuggestionIndex.value = null;
-    serviceTariffOptions.value = [];
-  }
-};
-
-const toIntegerMoney = (value: number | null | undefined): number | null => {
-  if (value == null || Number.isNaN(Number(value))) return null;
-  return Math.round(Number(value));
-};
-const LOGISTICS_COMPONENT_KINDS = new Set(['indoor', 'outdoor', 'accessory', 'other']);
-const normalizeLogisticsKind = (value: unknown): LogisticsComponentKind => {
-  const raw = String(value || '').trim();
-  return LOGISTICS_COMPONENT_KINDS.has(raw) ? (raw as LogisticsComponentKind) : 'other';
-};
-const getProductCountryFromSpecs = (specs?: Record<string, any> | null) => {
-  if (!specs) return null;
-  return String(specs.country || specs.country_of_origin || specs['Страна производства'] || specs['Страна-производитель'] || '').trim() || null;
-};
-const normalizePositiveInteger = (value: unknown, fallback = 1) => {
-  const parsed = Math.trunc(Number(value));
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
-};
-const normalizePositiveNumber = (value: unknown, fallback = 0) => {
-  const parsed = Number(value);
-  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
-};
-const normalizeProductLogisticsTemplate = (raw: unknown): ProductLogisticsTemplateComponent[] => {
-  if (!Array.isArray(raw)) return [];
-  return raw
-    .map((item): ProductLogisticsTemplateComponent | null => {
-      const source = (item || {}) as Record<string, any>;
-      const title = String(source.title || '').trim();
-      if (!title) return null;
-      return {
-        title,
-        country: String(source.country || '').trim() || null,
-        unit: String(source.unit || '').trim() || 'шт.',
-        quantity_per_parent: normalizePositiveInteger(source.quantity_per_parent, 1),
-        price_weight: normalizePositiveNumber(source.price_weight, 1),
-        kind: normalizeLogisticsKind(source.kind),
-      };
-    })
-    .filter((item): item is ProductLogisticsTemplateComponent => Boolean(item));
-};
-const normalizeOrderLogisticsComponents = (
-  components?: OrderLogisticsComponent[] | null,
-): OrderLogisticsComponent[] | null => {
-  if (!components?.length) return null;
-  const normalized = components
-    .map((component) => ({
-      title: String(component.title || '').trim(),
-      country: String(component.country || '').trim() || 'Китай',
-      unit: String(component.unit || '').trim() || 'шт.',
-      quantity_per_parent: normalizePositiveInteger(component.quantity_per_parent, 1),
-      unit_price: normalizePositiveNumber(component.unit_price, 0),
-      kind: normalizeLogisticsKind(component.kind),
-    }))
-    .filter((component) => Boolean(component.title));
-  return normalized.length ? normalized : null;
 };
 
 const handleSave = () => {

--- a/manager_frontend/src/components/orders/OrderEditDrawer.vue
+++ b/manager_frontend/src/components/orders/OrderEditDrawer.vue
@@ -22,9 +22,8 @@ import type { ServiceAttachmentEquipmentOption } from '../service-attachments/ty
 import type {
   ManagerOrderDetailResponse,
   ManagerOrderUpdatePayload,
-  OutgoingEmailResponse,
 } from '../../client';
-import { ManagerOrdersService, ManagerMailService } from '../../client';
+import { ManagerOrdersService } from '../../client';
 import {
   buildOrderWorkspaceViewModel,
   type OrderWorkspaceTarget,
@@ -35,6 +34,7 @@ import { useOrderCommercialEditor } from '../../composables/useOrderCommercialEd
 import { useOrderProposalLifecycle } from '../../composables/useOrderProposalLifecycle';
 import { useOrderDrawerForm } from '../../composables/useOrderDrawerForm';
 import { useOrderDrawerPersistence } from '../../composables/useOrderDrawerPersistence';
+import { useOrderDocumentStatus } from '../../composables/useOrderDocumentStatus';
 
 const props = defineProps<{
   modelValue: boolean;
@@ -194,9 +194,6 @@ const documentsWorkspaceRef = ref<InstanceType<typeof OrderDocumentsWorkspace> |
 const proposalToolbarRef = ref<InstanceType<typeof OrderProposalToolbar> | null>(null);
 const executionWorkspaceOpen = ref(false);
 const activeWorkspaceTarget = ref<OrderWorkspaceTarget | null>(null);
-const orderEmails = ref<OutgoingEmailResponse[]>([]);
-const orderEmailsLoaded = ref(false);
-let orderEmailsRequestId = 0;
 
 const showManagerLabelInput = ref(false);
 
@@ -257,6 +254,18 @@ const {
   currentFormSnapshot: () => buildCurrentFormSnapshot(proposalStatus.value),
 });
 
+const {
+  documentEmailStatus,
+  loadOrderEmails,
+  missingReferencedInvoice,
+  orderDocuments,
+  resetOrderEmails,
+  sentDocumentTypes,
+} = useOrderDocumentStatus({
+  order: computed(() => props.order),
+  payments,
+});
+
 const customer = computed(() => props.order?.customer ?? null);
 const customerDisplayName = computed(() => (
   customer.value?.full_legal_name
@@ -276,65 +285,6 @@ const compactObjectAddress = computed(() => (
   || props.order?.customer_branch?.delivery_address
   || ''
 ));
-const documentEmailStatus = computed<'unknown' | 'none' | 'pending' | 'sent' | 'failed'>(() => {
-  if (!orderEmailsLoaded.value) return 'unknown';
-  const latestDocumentEmail = [...orderEmails.value]
-    .filter((email) => Boolean(email.attachments?.length))
-    .sort((left, right) => Date.parse(right.created_at) - Date.parse(left.created_at))[0];
-  if (!latestDocumentEmail) return 'none';
-  if (latestDocumentEmail.status === 'sent') return 'sent';
-  if (latestDocumentEmail.status === 'pending') return 'pending';
-  if (latestDocumentEmail.status === 'failed') return 'failed';
-  return 'none';
-});
-const normalizeDocumentIdentity = (value: unknown) => (
-  String(value || '').toUpperCase().replace(/[^A-ZА-ЯЁ0-9]/g, '')
-);
-const sentDocumentTypes = computed(() => {
-  const types = new Set<string>();
-  const documentsByNumber = new Map(
-    orderDocuments.value
-      .filter((document) => document.number)
-      .map((document) => [normalizeDocumentIdentity(document.number), document.doc_type]),
-  );
-  for (const email of orderEmails.value) {
-    if (email.status !== 'sent') continue;
-    for (const attachment of email.attachments || []) {
-      const metadata = attachment as typeof attachment & {
-        document_type?: string | null;
-        document_number?: string | null;
-      };
-      if (metadata.document_type) {
-        types.add(metadata.document_type);
-        continue;
-      }
-      const filename = normalizeDocumentIdentity(metadata.document_number || metadata.filename);
-      for (const [number, docType] of documentsByNumber) {
-        if (number && filename.includes(number)) {
-          types.add(docType);
-          break;
-        }
-      }
-    }
-  }
-  return [...types];
-});
-const normalizeDocumentNumber = (value: string) => value.toUpperCase().replace(/[^A-ZА-ЯЁ0-9]/g, '');
-const missingReferencedInvoice = computed(() => {
-  const invoiceNumbers = new Set(
-    orderDocuments.value
-      .filter((document) => document.doc_type === 'invoice')
-      .map((document) => normalizeDocumentNumber(document.number || ''))
-      .filter(Boolean),
-  );
-  for (const payment of payments.value) {
-    const purpose = payment.bank_receipt?.payment_purpose || payment.comment || '';
-    const match = purpose.match(/сч[её]т(?:у|а|ом|е)?\s*(?:№\s*)?([A-ZА-ЯЁ0-9][A-ZА-ЯЁ0-9/-]{2,})/iu);
-    const referencedNumber = match?.[1]?.trim();
-    if (referencedNumber && !invoiceNumbers.has(normalizeDocumentNumber(referencedNumber))) return referencedNumber;
-  }
-  return null;
-});
 const orderWorkspace = computed(() => buildOrderWorkspaceViewModel({
   status: status.value,
   negotiationStatus: negotiationStatus.value,
@@ -359,21 +309,6 @@ const orderWorkspace = computed(() => buildOrderWorkspaceViewModel({
   paid: totalPaymentsPreview.value,
   balance: balanceDuePreview.value,
 }));
-const loadOrderEmails = async (orderId: number) => {
-  const requestId = ++orderEmailsRequestId;
-  try {
-    const response = await ManagerMailService.listManagerOrderOutgoingEmails(orderId, 20);
-    if (requestId !== orderEmailsRequestId || props.order?.id !== orderId) return;
-    orderEmails.value = response.items || [];
-    orderEmailsLoaded.value = true;
-  } catch (error) {
-    if (requestId !== orderEmailsRequestId) return;
-    console.warn('Failed to load order email summary', error);
-    orderEmails.value = [];
-    orderEmailsLoaded.value = false;
-  }
-};
-
 const copyText = async (value: string | null | undefined, label: string) => {
   const normalized = String(value || '').trim();
   if (!normalized) {
@@ -416,7 +351,6 @@ const toggleHold = async () => {
     }
 };
 
-const orderDocuments = computed(() => props.order?.documents || []);
 const beforeDocumentGenerate = async (type: string) => {
   if (!props.order?.id) return false;
   let mutated = false;
@@ -458,8 +392,7 @@ const initForm = async (order: ManagerOrderDetailResponse | null) => {
     linkedEquipmentOptions.value = [];
     executionWorkspaceOpen.value = false;
     activeWorkspaceTarget.value = null;
-    orderEmails.value = [];
-    orderEmailsLoaded.value = false;
+    resetOrderEmails();
   }
   hydrateOrder(order);
 

--- a/manager_frontend/src/components/orders/OrderExecutionPanel.vue
+++ b/manager_frontend/src/components/orders/OrderExecutionPanel.vue
@@ -1,0 +1,67 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { EXECUTION_STATUS_OPTIONS } from './order-utils';
+import type { OrderWorkflowType } from './order-workspace';
+import OrderDrawerSection from './OrderDrawerSection.vue';
+
+defineProps<{
+  workflowType: OrderWorkflowType;
+}>();
+
+const expanded = defineModel<boolean>('expanded', { required: true });
+const executionStatus = defineModel<string>('executionStatus', { required: true });
+const executionWithoutPayment = defineModel<boolean>('executionWithoutPayment', { required: true });
+const executionWithoutPaymentReason = defineModel<string>('executionWithoutPaymentReason', { required: true });
+const autoCloseOnPayment = defineModel<boolean>('autoCloseOnPayment', { required: true });
+
+const summary = computed(() => (
+  EXECUTION_STATUS_OPTIONS.find((option) => option.value === executionStatus.value)?.label || 'Назначить работы'
+));
+</script>
+
+<template>
+  <OrderDrawerSection
+    id="order-workspace-planning"
+    v-model:expanded="expanded"
+    :title="workflowType === 'sales_installation' ? 'Монтаж' : 'Работы'"
+    :summary="summary"
+    tone="default"
+  >
+    <label v-if="workflowType === 'sales_installation'" class="field-label">
+      Общий этап заказа
+      <select v-model="executionStatus" data-testid="execution-status" class="field-input mt-1">
+        <option v-for="option in EXECUTION_STATUS_OPTIONS" :key="option.value" :value="option.value">{{ option.label }}</option>
+      </select>
+    </label>
+    <div v-else class="grid grid-cols-2 gap-2 sm:grid-cols-3">
+      <button
+        v-for="option in EXECUTION_STATUS_OPTIONS"
+        :key="option.value"
+        type="button"
+        :data-testid="`execution-status-${option.value}`"
+        class="inline-flex min-h-10 items-center justify-center gap-1.5 rounded-xl border px-2 py-2 text-xs font-semibold transition"
+        :class="executionStatus === option.value
+          ? 'border-teal-500 bg-white text-teal-800 shadow-sm'
+          : 'border-teal-100 bg-white/70 text-slate-600 hover:border-teal-300 hover:text-teal-800'"
+        @click="executionStatus = option.value"
+      >
+        <span class="material-icons-round text-[15px]">{{ option.icon }}</span>
+        <span class="truncate">{{ option.label }}</span>
+      </button>
+    </div>
+    <div class="mt-3 grid gap-2 sm:grid-cols-2">
+      <label class="flex items-start gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-xs text-slate-700 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200">
+        <input v-model="executionWithoutPayment" data-testid="execution-without-payment" type="checkbox" class="mt-0.5 h-4 w-4 rounded border-gray-300 text-teal-600 focus:ring-teal-600" />
+        <span><strong class="block">Разрешить переходы при наличии долга</strong><span class="mt-0.5 block text-slate-500 dark:text-slate-400">Менеджер сможет продолжать работу без полной оплаты.</span></span>
+      </label>
+      <label class="flex items-start gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-xs text-slate-700 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200">
+        <input v-model="autoCloseOnPayment" data-testid="auto-close-on-payment" type="checkbox" class="mt-0.5 h-4 w-4 rounded border-gray-300 text-teal-600 focus:ring-teal-600" />
+        <span><strong class="block">Автоматически завершить после полной оплаты</strong><span class="mt-0.5 block text-slate-500 dark:text-slate-400">Сработает, когда долг станет нулевым.</span></span>
+      </label>
+    </div>
+    <label v-if="executionWithoutPayment" class="field-label mt-3">
+      Причина работы при наличии долга
+      <textarea v-model="executionWithoutPaymentReason" data-testid="execution-without-payment-reason" class="field-input min-h-[60px]" placeholder="Например: постоянный клиент, оплата по факту..." />
+    </label>
+  </OrderDrawerSection>
+</template>

--- a/manager_frontend/src/components/orders/OrderManagerLabels.vue
+++ b/manager_frontend/src/components/orders/OrderManagerLabels.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+
+const labels = defineModel<string[]>({ required: true });
+const draft = ref('');
+const editing = ref(false);
+
+const addLabel = () => {
+  const label = draft.value.trim().replace(/\s+/g, ' ');
+  if (!label) return;
+  const exists = labels.value.some((item) => (
+    item.toLocaleLowerCase('ru-RU') === label.toLocaleLowerCase('ru-RU')
+  ));
+  if (!exists) labels.value = [...labels.value, label];
+  draft.value = '';
+  editing.value = false;
+};
+
+const removeLabel = (label: string) => {
+  labels.value = labels.value.filter((item) => item !== label);
+};
+</script>
+
+<template>
+  <div v-if="labels.length || editing" class="mt-3 flex flex-wrap items-center gap-1.5">
+    <span v-for="label in labels" :key="label" class="inline-flex items-center gap-1 rounded-full border border-teal-200 bg-teal-50 px-2 py-1 text-xs font-medium text-teal-800 dark:border-teal-500/30 dark:bg-teal-500/10 dark:text-teal-200">
+      {{ label }}
+      <button type="button" class="rounded-full p-0.5 hover:bg-teal-100 dark:hover:bg-teal-800" :aria-label="`Удалить метку ${label}`" @click="removeLabel(label)">
+        <span class="material-icons-round block text-[13px]">close</span>
+      </button>
+    </span>
+    <button v-if="!editing" type="button" data-testid="add-manager-label" class="inline-flex items-center gap-1 rounded-full border border-dashed border-slate-300 px-2 py-1 text-xs font-medium text-slate-500 hover:border-teal-300 hover:text-teal-700 dark:border-slate-700 dark:text-slate-400" @click="editing = true">
+      <span class="material-icons-round text-[13px]">add</span> Добавить метку
+    </button>
+    <div v-else class="flex min-w-[190px] gap-1.5">
+      <input v-model="draft" data-testid="manager-label-draft" class="field-input h-8 text-xs" placeholder="Новая метка" @keydown.enter.prevent="addLabel" @keydown.esc.prevent="editing = false" />
+      <button type="button" class="btn-mini h-8 px-2 text-xs" @click="addLabel">Добавить</button>
+    </div>
+  </div>
+  <button v-else type="button" data-testid="add-manager-label" class="mt-2 inline-flex items-center gap-1 text-xs font-medium text-slate-500 hover:text-teal-700 dark:text-slate-400 dark:hover:text-teal-300" @click="editing = true">
+    <span class="material-icons-round text-[14px]">add</span> Добавить метку
+  </button>
+</template>

--- a/manager_frontend/src/components/orders/OrderPaymentsPanel.vue
+++ b/manager_frontend/src/components/orders/OrderPaymentsPanel.vue
@@ -1,0 +1,376 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue';
+import type {
+  BankReceiptResponse,
+  FxRateResponse,
+  ManagerOrderDetailResponse,
+  PaymentCurrency,
+  PaymentResponse,
+} from '../../client';
+import { ManagerMailService, ManagerOrdersService } from '../../client';
+import { getApiErrorMessage } from '../../utils/api-errors';
+import OrderDrawerSection from './OrderDrawerSection.vue';
+import { formatMoney } from './order-utils';
+
+const props = defineProps<{
+  order: ManagerOrderDetailResponse;
+  expanded: boolean;
+  payments: PaymentResponse[];
+  enableCurrency: boolean;
+  targetCurrency: PaymentCurrency | null;
+  targetCurrencyAmount: number | null;
+  currentFxRate: FxRateResponse | null;
+  isB2cCustomer: boolean;
+  total: number;
+  totalPayments: number;
+  balanceDue: number;
+  margin: number;
+  calculatedTargetCurrencyPayments: number;
+  targetCurrencyBalanceDue: number;
+}>();
+
+const emit = defineEmits<{
+  'update:expanded': [value: boolean];
+  'update:payments': [value: PaymentResponse[]];
+  'update:enableCurrency': [value: boolean];
+  'update:targetCurrency': [value: PaymentCurrency | null];
+  'update:targetCurrencyAmount': [value: number | null];
+  toast: [payload: { message: string; type: 'success' | 'error' }];
+  reload: [orderId: number];
+}>();
+
+const expandedModel = computed({
+  get: () => props.expanded,
+  set: (value: boolean) => emit('update:expanded', value),
+});
+const enableCurrencyModel = computed({
+  get: () => props.enableCurrency,
+  set: (value: boolean) => emit('update:enableCurrency', value),
+});
+const targetCurrencyModel = computed({
+  get: () => props.targetCurrency,
+  set: (value: PaymentCurrency | null) => emit('update:targetCurrency', value),
+});
+const targetCurrencyAmountModel = computed({
+  get: () => props.targetCurrencyAmount,
+  set: (value: number | null) => emit('update:targetCurrencyAmount', value),
+});
+
+const bankReceipts = ref<BankReceiptResponse[]>([]);
+const bankReceiptsLoading = ref(false);
+const attachingReceiptId = ref<number | null>(null);
+const newPaymentAmount = ref<number | null>(null);
+const newPaymentType = ref('prepayment');
+const isAddingPayment = ref(false);
+const deletingPaymentId = ref<number | null>(null);
+
+const summary = computed(() => (
+  `оплачено ${formatMoney(props.totalPayments)} · остаток ${formatMoney(props.balanceDue)} · итого ${formatMoney(props.total)} · маржа ${formatMoney(props.margin)}`
+));
+const candidateBankReceipts = computed(() => (
+  bankReceipts.value.filter((receipt) => receipt.status === 'requires_review')
+));
+const hasDebtForBankReceipts = computed(() => (
+  props.balanceDue > 0 && Boolean(props.order.customer?.inn)
+));
+const hasManualEurRate = computed(() => Boolean(props.currentFxRate?.eur_byn));
+
+const activeFxRate = (currency: PaymentCurrency | null): number | null => {
+  if (!props.currentFxRate || !currency) return null;
+  if (currency === 'USD') return props.currentFxRate.usd_byn ?? null;
+  if (currency === 'EUR') return props.currentFxRate.eur_byn ?? null;
+  return null;
+};
+
+const notify = (message: string, type: 'success' | 'error') => {
+  emit('toast', { message, type });
+};
+
+const loadCandidateBankReceipts = async () => {
+  const inn = props.order.customer?.inn;
+  if (!inn) {
+    bankReceipts.value = [];
+    return;
+  }
+  bankReceiptsLoading.value = true;
+  try {
+    const response = await ManagerMailService.listManagerBankReceipts(
+      1,
+      20,
+      'requires_review',
+      inn,
+    );
+    bankReceipts.value = response.items || [];
+  } catch (error) {
+    console.error('Failed to load bank receipts', error);
+    bankReceipts.value = [];
+  } finally {
+    bankReceiptsLoading.value = false;
+  }
+};
+
+watch(
+  () => props.order,
+  () => void loadCandidateBankReceipts(),
+  { immediate: true },
+);
+
+const addPayment = async () => {
+  if (!newPaymentAmount.value) return;
+  if (props.enableCurrency) {
+    if (!props.targetCurrency) {
+      notify('Сначала выберите валюту сделки', 'error');
+      return;
+    }
+    if (!activeFxRate(props.targetCurrency)) {
+      notify('Для выбранной валюты нет доступного курса', 'error');
+      return;
+    }
+  }
+  isAddingPayment.value = true;
+  try {
+    const payments = await ManagerOrdersService.addManagerOrderPayment(
+      props.order.id,
+      {
+        amount: newPaymentAmount.value,
+        type: newPaymentType.value,
+        currency: props.enableCurrency
+          ? (props.targetCurrency || 'USD')
+          : 'BYN',
+      },
+    );
+    emit('update:payments', payments);
+    newPaymentAmount.value = null;
+    notify('Платеж добавлен', 'success');
+  } catch (error) {
+    notify(`Ошибка: ${getApiErrorMessage(error)}`, 'error');
+  } finally {
+    isAddingPayment.value = false;
+  }
+};
+
+const attachBankReceipt = async (receipt: BankReceiptResponse) => {
+  if (!receipt.id) return;
+  attachingReceiptId.value = receipt.id;
+  try {
+    await ManagerMailService.attachManagerBankReceipt(receipt.id, {
+      order_id: props.order.id,
+      payment_type: 'postpayment',
+    });
+    notify('Поступление прикреплено к заказу', 'success');
+    await loadCandidateBankReceipts();
+    emit('reload', props.order.id);
+  } catch (error) {
+    notify(`Ошибка привязки: ${getApiErrorMessage(error)}`, 'error');
+  } finally {
+    attachingReceiptId.value = null;
+  }
+};
+
+const receiptCandidateHint = (receipt: BankReceiptResponse) => {
+  const meta = receipt.match_meta as any;
+  const documents = Array.isArray(meta?.document_candidates)
+    ? meta.document_candidates
+    : [];
+  if (documents.length) {
+    const document = documents[0];
+    return `${document.doc_type || 'документ'} ${document.number || ''} · заказ #${document.order_id}`;
+  }
+  const orderIds = Array.isArray(meta?.candidate_order_ids)
+    ? meta.candidate_order_ids
+    : [];
+  return orderIds.length ? `кандидат: заказ #${orderIds[0]}` : '';
+};
+
+const formatReceiptDate = (value?: string | null) => {
+  if (!value) return 'дата не указана';
+  return new Date(value).toLocaleString('ru-RU', {
+    day: '2-digit',
+    month: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+};
+
+const formatPaymentType = (value?: string | null) => (
+  value === 'prepayment' ? 'Аванс' : 'Доплата'
+);
+
+const formatBankPaymentDate = (value?: string | null) => {
+  if (!value) return 'дата не указана';
+  return new Date(value).toLocaleString('ru-RU', {
+    day: '2-digit',
+    month: '2-digit',
+    year: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+};
+
+const openBankReceiptJournal = (payment: PaymentResponse) => {
+  if (!payment.bank_receipt_id) return;
+  window.history.pushState({}, '', `/manager/payments?orderId=${props.order.id}`);
+  window.dispatchEvent(new PopStateEvent('popstate'));
+};
+
+const deletePayment = async (paymentId: number) => {
+  try {
+    const payments = await ManagerOrdersService.deleteManagerOrderPayment(
+      props.order.id,
+      paymentId,
+    );
+    emit('update:payments', payments);
+    deletingPaymentId.value = null;
+    notify('Платеж удален', 'success');
+  } catch (error) {
+    notify(`Ошибка: ${getApiErrorMessage(error)}`, 'error');
+  }
+};
+</script>
+
+<template>
+  <OrderDrawerSection
+    id="order-workspace-payments"
+    v-model:expanded="expandedModel"
+    title="Оплаты"
+    :summary="summary"
+    icon="account_balance_wallet"
+    tone="default"
+  >
+    <section
+      class="rounded-2xl border border-slate-200 bg-slate-50 p-3 shadow-sm sm:p-5"
+      data-testid="order-payments-panel"
+    >
+      <div v-if="isB2cCustomer" class="mb-4 flex justify-end">
+        <label class="flex cursor-pointer items-center gap-2 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-600 shadow-sm transition-colors hover:bg-slate-50">
+          <input v-model="enableCurrencyModel" type="checkbox" class="h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500" />
+          Считать в валюте
+        </label>
+      </div>
+
+      <div v-if="enableCurrency" class="mb-5 rounded-xl border border-blue-100 bg-blue-50/30 p-3 sm:p-4">
+        <div class="mb-4 flex flex-col gap-3 sm:flex-row sm:items-end sm:gap-4">
+          <label class="field-label !mb-0 text-xs sm:w-1/3">
+            Валюта
+            <select v-model="targetCurrencyModel" class="field-input mt-1">
+              <option value="USD">USD ($)</option>
+              <option value="EUR" :disabled="!hasManualEurRate">EUR (€)</option>
+            </select>
+          </label>
+          <label class="field-label !mb-0 flex-1 text-xs">
+            Зафиксировать сумму
+            <div class="relative">
+              <input v-model.number="targetCurrencyAmountModel" type="number" step="0.01" min="0" class="field-input mt-1 w-full" placeholder="Итоговая сумма в валюте" />
+              <span v-if="currentFxRate?.usd_byn && targetCurrency === 'USD'" class="absolute right-3 top-1/2 -translate-y-1/2 rounded bg-blue-50/80 px-1 text-[10px] font-medium text-blue-400" title="Текущий курс NBRB">Курс: {{ currentFxRate.usd_byn }}</span>
+              <span v-else-if="currentFxRate?.eur_byn && targetCurrency === 'EUR'" class="absolute right-3 top-1/2 -translate-y-1/2 rounded bg-blue-50/80 px-1 text-[10px] font-medium text-blue-400" title="Текущий курс NBRB">Курс: {{ currentFxRate.eur_byn }}</span>
+            </div>
+          </label>
+        </div>
+        <p v-if="targetCurrency === 'EUR' && !hasManualEurRate" class="text-xs text-amber-700">
+          EUR недоступен при ручном источнике курса. Переключите источник курса на NBRB.
+        </p>
+        <div class="flex flex-col gap-3 border-t border-blue-100 pt-3 sm:flex-row sm:items-center sm:justify-between">
+          <div class="sm:w-1/2">
+            <p class="mb-1 text-xs uppercase tracking-wide text-slate-500">Внесено оплат ({{ targetCurrency || 'USD' }})</p>
+            <p class="text-xl font-bold text-gray-800">{{ calculatedTargetCurrencyPayments.toFixed(2) }}</p>
+          </div>
+          <div class="sm:text-right">
+            <p class="mb-1 text-xs uppercase tracking-wide text-slate-500">Остаток долга ({{ targetCurrency || 'USD' }})</p>
+            <p class="text-2xl font-bold" :class="targetCurrencyBalanceDue > 0 ? 'text-red-500' : 'text-blue-600'">
+              {{ targetCurrencyBalanceDue.toFixed(2) }}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div class="mt-3 flex flex-col gap-2 rounded-xl border border-slate-200 bg-white p-3 shadow-sm sm:flex-row sm:items-end">
+        <label class="field-label !mb-0 flex-1 text-xs">
+          Внести платеж ({{ enableCurrency ? (targetCurrency || 'USD') : 'BYN' }})
+          <input v-model.number="newPaymentAmount" data-testid="payment-amount" type="number" step="0.01" min="0" class="field-input mt-1 shadow-sm" placeholder="0.00" />
+        </label>
+        <label class="field-label !mb-0 text-xs sm:w-1/3">
+          Тип
+          <select v-model="newPaymentType" class="field-input mt-1 shadow-sm">
+            <option value="prepayment">Аванс</option>
+            <option value="postpayment">Доплата</option>
+          </select>
+        </label>
+        <button type="button" data-testid="add-payment" class="btn-mini h-[38px] w-full sm:w-[100px]" :disabled="!newPaymentAmount || isAddingPayment" @click="addPayment">Внести</button>
+      </div>
+
+      <div v-if="hasDebtForBankReceipts" class="mt-4 rounded-xl border border-amber-200 bg-amber-50/60 p-3">
+        <div class="mb-3 flex items-center justify-between gap-3">
+          <div>
+            <p class="text-sm font-semibold text-amber-900">Банковские поступления по УНП</p>
+            <p class="text-xs text-amber-700">Можно прикрепить поступление, которое требует ручной проверки.</p>
+          </div>
+          <span v-if="bankReceiptsLoading" class="material-icons-round animate-spin text-amber-600">refresh</span>
+        </div>
+        <div v-if="candidateBankReceipts.length" class="space-y-2">
+          <div v-for="receipt in candidateBankReceipts" :key="receipt.id" class="rounded-lg border border-amber-100 bg-white p-3 text-xs shadow-sm">
+            <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+              <div class="min-w-0">
+                <div class="flex flex-wrap items-center gap-2">
+                  <span class="font-bold text-slate-900">{{ formatMoney(receipt.amount) }}</span>
+                  <span class="text-slate-500">{{ formatReceiptDate(receipt.received_at) }}</span>
+                  <span v-if="receipt.payment_document_number" class="rounded bg-slate-100 px-1.5 py-0.5 font-medium text-slate-500">№ {{ receipt.payment_document_number }}</span>
+                </div>
+                <p v-if="receiptCandidateHint(receipt)" class="mt-1 text-amber-700">{{ receiptCandidateHint(receipt) }}</p>
+                <p class="mt-1 line-clamp-2 text-slate-500">{{ receipt.payment_purpose || 'Назначение не указано' }}</p>
+              </div>
+              <button type="button" :data-testid="`attach-receipt-${receipt.id}`" class="btn-mini h-8 shrink-0" :disabled="attachingReceiptId === receipt.id" @click="attachBankReceipt(receipt)">
+                {{ attachingReceiptId === receipt.id ? '...' : 'Прикрепить' }}
+              </button>
+            </div>
+          </div>
+        </div>
+        <div v-else-if="!bankReceiptsLoading" class="rounded-lg border border-dashed border-amber-200 bg-white/70 p-3 text-center text-xs text-amber-700">
+          Нет неподтвержденных поступлений по УНП {{ order.customer?.inn }}
+        </div>
+      </div>
+
+      <div class="mt-4 max-h-56 space-y-2 overflow-y-auto pr-1">
+        <div v-for="payment in payments" :key="payment.id" class="rounded-lg border border-slate-100 bg-white px-3 py-2 text-xs shadow-sm">
+          <div class="flex flex-wrap items-center justify-between gap-2">
+            <div class="flex flex-wrap items-center gap-2">
+              <span class="text-slate-500">{{ new Date(payment.date).toLocaleDateString() }}</span>
+              <span v-if="payment.bank_receipt" class="inline-flex items-center gap-1 rounded-full border border-emerald-200 bg-emerald-50 px-2 py-0.5 font-semibold text-emerald-700">
+                <span class="material-icons-round text-[13px]">account_balance</span>
+                Банк
+              </span>
+            </div>
+            <span class="font-bold text-slate-800" :class="payment.currency !== 'BYN' ? 'text-blue-600' : ''">
+              <template v-if="payment.currency !== 'BYN'">{{ payment.amount.toFixed(2) }} {{ payment.currency }}</template>
+              <template v-else>{{ formatMoney(payment.amount) }}</template>
+            </span>
+            <span class="w-16 text-right text-slate-400">{{ formatPaymentType(payment.type) }}</span>
+            <div v-if="deletingPaymentId === payment.id" class="ml-2 flex items-center gap-2">
+              <button type="button" class="font-medium text-slate-500 hover:text-slate-800" @click="deletingPaymentId = null">Отмена</button>
+              <button type="button" :data-testid="`delete-payment-${payment.id}`" class="font-bold text-red-500 hover:text-red-700" @click="deletePayment(payment.id)">Да, удалить</button>
+            </div>
+            <button v-else type="button" class="ml-2 flex h-6 w-6 items-center justify-center rounded text-red-400 transition-colors hover:bg-red-50 hover:text-red-600" title="Удалить платеж" @click="deletingPaymentId = payment.id">
+              <span class="material-icons-round text-[14px]">delete</span>
+            </button>
+          </div>
+          <div v-if="payment.bank_receipt" class="mt-2 rounded-lg border border-emerald-100 bg-emerald-50/40 p-2 text-[11px] text-slate-600">
+            <div class="flex flex-wrap items-center gap-2">
+              <span class="font-semibold text-emerald-800">ПП № {{ payment.bank_receipt.payment_document_number || payment.bank_receipt.payment_document_raw || payment.bank_receipt.id }}</span>
+              <span>{{ formatBankPaymentDate(payment.bank_receipt.received_at || payment.date) }}</span>
+              <span v-if="payment.bank_receipt.payer_unp">УНП {{ payment.bank_receipt.payer_unp }}</span>
+            </div>
+            <p v-if="payment.bank_receipt.payer_name" class="mt-1 truncate font-medium text-slate-700">{{ payment.bank_receipt.payer_name }}</p>
+            <p v-if="payment.bank_receipt.payment_purpose" class="mt-1 line-clamp-2 text-slate-500">{{ payment.bank_receipt.payment_purpose }}</p>
+            <button type="button" class="mt-1 inline-flex items-center gap-1 font-semibold text-emerald-700 hover:text-emerald-900" @click="openBankReceiptJournal(payment)">
+              <span class="material-icons-round text-[13px]">receipt_long</span>
+              Открыть в журнале
+            </button>
+          </div>
+          <p v-else-if="payment.comment" class="mt-1 text-[11px] text-slate-500">{{ payment.comment }}</p>
+        </div>
+        <div v-if="!payments.length" class="rounded-xl border border-dashed border-gray-200 py-3 text-center text-sm italic text-gray-500">
+          Нет оплат
+        </div>
+      </div>
+    </section>
+  </OrderDrawerSection>
+</template>

--- a/manager_frontend/src/components/orders/OrderPlanningPanel.vue
+++ b/manager_frontend/src/components/orders/OrderPlanningPanel.vue
@@ -1,0 +1,162 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import type { ManagerInstallerResponse } from '../../client';
+import DateTimeField from '../ui/DateTimeField.vue';
+import OrderDrawerSection from './OrderDrawerSection.vue';
+import { NEGOTIATION_STATUS_OPTIONS } from './order-utils';
+import { buildMeasurementSummary, type OrderWorkflowType } from './order-workspace';
+
+const props = defineProps<{
+  workflowType: OrderWorkflowType;
+  executorOptions: ManagerInstallerResponse[];
+  customerBranchId: number | null;
+  newBranchAddress: string;
+  measurementError?: string;
+  installationError?: string;
+}>();
+
+const measurementRequired = defineModel<boolean>('measurementRequired', { required: true });
+const assessmentDate = defineModel<string>('assessmentDate', { required: true });
+const negotiationStatus = defineModel<string>('negotiationStatus', { required: true });
+const autoExecutionOnPayment = defineModel<boolean>('autoExecutionOnPayment', { required: true });
+const detailsExpanded = defineModel<boolean>('detailsExpanded', { required: true });
+const measurerId = defineModel<number | null>('measurerId', { required: true });
+const measurementResult = defineModel<string>('measurementResult', { required: true });
+const installationDate = defineModel<string>('installationDate', { required: true });
+const installerId = defineModel<number | null>('installerId', { required: true });
+
+const isRepairWorkflow = computed(() => props.workflowType === 'repair');
+const title = computed(() => {
+  if (props.workflowType === 'repair') return 'Диагностика и выезд';
+  if (props.workflowType === 'maintenance') return 'Планирование обслуживания';
+  if (props.workflowType === 'service_work') return 'Планирование работ';
+  return 'Планирование';
+});
+const workDateLabel = computed(() => {
+  if (props.workflowType === 'repair') return 'Дата диагностики / ремонта';
+  if (props.workflowType === 'maintenance') return 'Дата обслуживания';
+  if (props.workflowType === 'service_work') return 'Дата работ';
+  return 'Дата монтажа';
+});
+
+const formatDateTime = (value?: string | null) => {
+  if (!value) return null;
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed.toLocaleString('ru-RU', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+};
+
+const summary = computed(() => {
+  const parts = [buildMeasurementSummary({
+    required: measurementRequired.value,
+    date: assessmentDate.value,
+    result: measurementResult.value,
+    kind: isRepairWorkflow.value ? 'diagnostic' : 'measurement',
+    formatDate: formatDateTime,
+  })];
+  if (installationDate.value) {
+    parts.push(`${workDateLabel.value.toLowerCase()} ${formatDateTime(installationDate.value)}`);
+  }
+  return parts.join(' · ');
+});
+
+const detailsSummary = computed(() => {
+  const parts: string[] = [];
+  if (measurerId.value) parts.push('замерщик назначен');
+  if (measurementResult.value.trim()) parts.push('есть результат замера');
+  if (props.customerBranchId) parts.push('выбран филиал');
+  if (props.newBranchAddress.trim()) parts.push('готовится новый филиал');
+  return parts.join(' · ') || 'дополнительные поля не заполнены';
+});
+</script>
+
+<template>
+  <section id="order-workspace-planning" class="mt-4 rounded-2xl border border-blue-100 bg-blue-50/30 p-3 dark:border-blue-500/30 dark:bg-blue-500/10">
+    <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      <div class="min-w-0">
+        <h3 class="text-sm font-semibold text-blue-900 dark:text-blue-100">{{ title }}</h3>
+        <p class="mt-0.5 truncate text-xs text-blue-700/70 dark:text-blue-200/70">{{ summary }}</p>
+      </div>
+      <button
+        v-if="!measurementRequired"
+        type="button"
+        data-testid="enable-measurement"
+        class="btn-mini-outline justify-center whitespace-nowrap text-xs"
+        @click="measurementRequired = true"
+      >
+        <span class="material-icons-round text-[15px]">add_location_alt</span>
+        {{ isRepairWorkflow ? 'Назначить диагностику' : 'Назначить замер' }}
+      </button>
+      <label v-else class="inline-flex items-center gap-2 rounded-xl bg-white px-3 py-2 text-xs font-medium text-blue-900 ring-1 ring-blue-100 dark:bg-slate-900 dark:text-blue-100 dark:ring-blue-500/30">
+        <input v-model="measurementRequired" type="checkbox" class="h-4 w-4 rounded border-gray-300 text-teal-600 focus:ring-teal-600" />
+        {{ isRepairWorkflow ? 'Диагностика нужна' : 'Замер нужен' }}
+      </label>
+    </div>
+
+    <div class="mt-3 rounded-xl border border-blue-100 bg-white p-3 shadow-sm dark:border-blue-500/30 dark:bg-slate-900">
+      <label class="block">
+        <span class="text-xs font-semibold uppercase tracking-[0.12em] text-blue-900/70 dark:text-blue-200/80">Состояние переговоров</span>
+        <select v-model="negotiationStatus" data-testid="negotiation-status" class="field-input mt-2 bg-white dark:bg-slate-950">
+          <option v-for="option in NEGOTIATION_STATUS_OPTIONS" :key="option.value" :value="option.value">{{ option.label }}</option>
+        </select>
+      </label>
+      <label class="mt-3 flex items-start gap-2 rounded-xl border border-emerald-100 bg-emerald-50/70 px-3 py-2 text-xs text-emerald-900 dark:border-emerald-500/30 dark:bg-emerald-500/10 dark:text-emerald-100">
+        <input v-model="autoExecutionOnPayment" type="checkbox" class="mt-0.5 h-4 w-4 rounded border-gray-300 text-teal-600 focus:ring-teal-600" />
+        <span>
+          <span class="block font-semibold">После полной оплаты автоматически перевести заказ в этап «Работы»</span>
+          <span class="mt-0.5 block text-emerald-700/80 dark:text-emerald-200/70">Сработает автоматически, когда долг по заказу станет нулевым.</span>
+        </span>
+      </label>
+    </div>
+
+    <div v-if="measurementRequired" class="mt-3 rounded-xl border border-blue-100 bg-white p-3 shadow-sm dark:border-blue-500/30 dark:bg-slate-900">
+      <DateTimeField v-model="assessmentDate" :label="isRepairWorkflow ? 'Дата и время диагностики' : 'Дата и время замера'" :error="measurementError" />
+    </div>
+
+    <OrderDrawerSection
+      v-model:expanded="detailsExpanded"
+      :title="isRepairWorkflow ? 'Детали диагностики и ремонта' : 'Детали выезда и монтажа'"
+      :summary="detailsSummary"
+      tone="blue"
+      :has-error="Boolean(measurementError || installationError)"
+    >
+      <div class="grid gap-3 md:grid-cols-2">
+        <template v-if="measurementRequired">
+          <label class="field-label">
+            {{ isRepairWorkflow ? 'Специалист' : 'Замерщик' }}
+            <select v-model="measurerId" data-testid="measurer" class="field-input">
+              <option :value="null">Не назначен</option>
+              <option v-for="installer in executorOptions" :key="installer.id" :value="installer.id">
+                {{ installer.name }} {{ !installer.is_active ? '(в архиве)' : '' }}
+              </option>
+            </select>
+          </label>
+          <label class="field-label md:col-span-2">
+            Результат замера
+            <textarea
+              v-model="measurementResult"
+              class="field-input min-h-[60px]"
+              :placeholder="isRepairWorkflow ? 'Краткий результат диагностики...' : 'Резюме после выезда (длины трасс, доп. работы)...'"
+            />
+          </label>
+        </template>
+        <DateTimeField v-model="installationDate" :label="workDateLabel" :error="installationError" />
+        <label class="field-label">
+          {{ isRepairWorkflow ? 'Исполнитель ремонта' : 'Монтажник' }}
+          <select v-model="installerId" data-testid="installer" class="field-input">
+            <option :value="null">Не назначен</option>
+            <option v-for="installer in executorOptions" :key="installer.id" :value="installer.id">
+              {{ installer.name }} {{ !installer.is_active ? '(в архиве)' : '' }}
+            </option>
+          </select>
+        </label>
+      </div>
+    </OrderDrawerSection>
+  </section>
+</template>

--- a/manager_frontend/src/components/orders/OrderProductLinesEditor.vue
+++ b/manager_frontend/src/components/orders/OrderProductLinesEditor.vue
@@ -1,0 +1,134 @@
+<script setup lang="ts">
+import type { ProductLine, ProductOption } from './order-editor-types';
+import { formatMoney } from './order-utils';
+
+type SupplyBadge = { label: string; requestId: number; status: string } | null;
+
+const props = defineProps<{
+  productOptions: ProductOption[];
+  productLookupById: Record<number, ProductOption>;
+  productLookupLoading: boolean;
+  activeSuggestionIndex: number | null;
+  supplyActionLoadingLineId: number | null;
+  productsError?: string;
+  supplyBadgeForLine: (line: ProductLine) => SupplyBadge;
+}>();
+
+const emit = defineEmits<{
+  focus: [index: number];
+  input: [index: number];
+  blur: [index: number];
+  select: [payload: { index: number; option: ProductOption }];
+  open: [index: number];
+  remove: [index: number];
+  add: [];
+  supply: [payload: { line: ProductLine; intent: 'order' | 'reserve' }];
+}>();
+
+const lines = defineModel<ProductLine[]>('lines', { required: true });
+const searchInStock = defineModel<boolean>('searchInStock', { required: true });
+
+const suggestionsFor = (index: number) => (
+  props.activeSuggestionIndex === index ? props.productOptions.slice(0, 10) : []
+);
+const catalogPrice = (productId: number) => props.productLookupById[productId]?.price ?? null;
+const isPriceDifferent = (line: ProductLine) => {
+  const price = catalogPrice(line.product_id);
+  return price !== null && Number(line.price) !== Number(price);
+};
+const lineTotal = (line: ProductLine) => Number(line.quantity || 0) * Number(line.price || 0);
+</script>
+
+<template>
+  <section class="mt-2">
+    <div class="mb-2 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+      <div class="flex flex-wrap items-center gap-3">
+        <h4 class="text-md font-semibold text-gray-800">Товары</h4>
+        <label class="flex cursor-pointer items-center gap-1 rounded border border-gray-200 bg-white px-2 py-1 text-xs text-gray-600 shadow-sm transition-colors hover:bg-gray-50">
+          <input v-model="searchInStock" type="checkbox" class="h-3 w-3 rounded border-gray-300 text-teal-600 focus:ring-teal-500" />
+          В наличии
+        </label>
+      </div>
+    </div>
+    <p v-if="productsError" class="mb-2 text-xs text-red-300">{{ productsError }}</p>
+    <div class="space-y-2">
+      <div v-for="(line, index) in lines" :key="`product-${index}`" class="relative rounded-xl border border-gray-200 bg-white p-3 shadow-sm">
+        <button type="button" class="absolute -right-2 -top-2 z-10 inline-flex h-8 w-8 items-center justify-center rounded-full border border-red-200 bg-red-50 text-lg font-bold text-red-600 shadow-sm transition-colors hover:bg-red-100" :aria-label="`Удалить товар #${index + 1}`" title="Удалить товар" @click="emit('remove', index)">
+          ×
+        </button>
+        <div class="grid grid-cols-6 gap-2 md:grid-cols-12 md:items-start">
+          <label class="relative col-span-6 space-y-1 md:col-span-5">
+            <span class="flex items-center justify-between gap-2 px-1 text-xs font-medium text-gray-500 md:h-6">
+              <span>Название</span>
+              <button v-if="line.product_id" class="text-xs font-semibold text-teal-700 hover:text-teal-900" type="button" @click="emit('open', index)">
+                Открыть ↗
+              </button>
+            </span>
+            <textarea
+              v-model="line.product_query"
+              class="field-input min-h-[44px] resize-none overflow-hidden text-sm leading-snug focus:min-h-[120px] focus:resize-y focus:overflow-auto sm:text-base"
+              rows="1"
+              placeholder="Поиск и выбор товара"
+              @focus="emit('focus', index)"
+              @input="emit('input', index)"
+              @blur="emit('blur', index)"
+            />
+            <div v-if="!line.product_id && line.product_query.trim().length >= 2 && (productLookupLoading || suggestionsFor(index).length)" class="absolute left-0 right-0 top-full z-20 mt-1 max-h-56 overflow-auto rounded-[12px] border border-gray-200 bg-white p-1 shadow-xl">
+              <div v-if="productLookupLoading" class="px-3 py-2 text-xs text-gray-500">Поиск товаров...</div>
+              <button
+                v-for="item in suggestionsFor(index)"
+                :key="`product-suggest-${index}-${item.id}`"
+                type="button"
+                :data-testid="`select-product-${item.id}`"
+                class="mb-1 block w-full rounded-[12px] px-3 py-2 text-left text-xs text-gray-700 hover:bg-slate-100 dark:hover:bg-slate-800 last:mb-0"
+                @mousedown.prevent
+                @click="emit('select', { index, option: item })"
+              >
+                <p class="truncate font-medium text-gray-900 dark:text-slate-100">{{ item.title }}</p>
+                <p class="mt-1 flex flex-wrap items-center gap-1 text-[11px] text-gray-500 dark:text-slate-300">
+                  <span>{{ formatMoney(item.price) }}</span><span>·</span><span>{{ item.is_inverter ? 'Инвертор' : 'On/Off' }}</span><span>·</span>
+                  <template v-if="item.vitebsk_qty > 0 || item.minsk_qty > 0">
+                    <span v-if="item.vitebsk_qty > 0" class="rounded bg-emerald-50 px-1 font-medium text-emerald-600">Вит: {{ item.vitebsk_qty }}</span>
+                    <span v-if="item.minsk_qty > 0" class="rounded bg-blue-50 px-1 font-medium text-blue-500">Минск: {{ item.minsk_qty }}</span>
+                  </template>
+                  <template v-else>
+                    <span v-if="item.availability_status === 'check_availability'" class="font-medium text-amber-500">Уточнять</span>
+                    <span v-else class="text-gray-400">Нет в наличии</span>
+                  </template>
+                </p>
+              </button>
+            </div>
+          </label>
+          <label class="col-span-4 space-y-1 md:col-span-2">
+            <span class="flex h-auto items-center px-1 text-xs font-medium text-gray-500 md:h-6">Цена</span>
+            <input v-model.number="line.price" type="number" min="0" class="field-input" placeholder="0" />
+          </label>
+          <label class="col-span-2 space-y-1 md:col-span-1">
+            <span class="flex h-auto items-center whitespace-nowrap px-1 text-xs font-medium text-gray-500 md:h-6 md:text-[11px]">Кол-во</span>
+            <input v-model.number="line.quantity" type="number" min="1" class="field-input" placeholder="1" />
+          </label>
+          <label class="col-span-3 space-y-1 md:col-span-2">
+            <span class="flex h-auto items-center px-1 text-xs font-medium text-gray-500 md:h-6">Себест.</span>
+            <input v-model.number="line.cost" type="number" min="0" class="field-input" placeholder="0" />
+          </label>
+          <div class="col-span-3 space-y-1 md:col-span-2">
+            <span class="flex h-auto items-center px-1 text-xs font-medium text-gray-500 md:h-6">Итого</span>
+            <div class="rounded-lg bg-gray-50 px-3 py-2"><p class="whitespace-nowrap text-base font-semibold leading-tight text-gray-900">{{ formatMoney(lineTotal(line)) }}</p></div>
+          </div>
+          <p v-if="isPriceDifferent(line)" class="col-span-6 rounded-md border border-amber-300 bg-amber-50 px-2 py-1 text-xs text-amber-700 md:col-span-12">
+            Цена строки отличается от каталожной ({{ formatMoney(catalogPrice(line.product_id) || 0) }}).
+          </p>
+          <div class="col-span-6 flex flex-wrap items-center gap-2 border-t border-gray-100 pt-2 md:col-span-12">
+            <span v-if="supplyBadgeForLine(line)" class="inline-flex items-center gap-1 rounded-full bg-teal-50 px-2 py-1 text-xs font-semibold text-teal-700">
+              Поставка: {{ supplyBadgeForLine(line)?.label }}
+            </span>
+            <span v-else-if="line.link_id" class="text-xs text-gray-500">Поставка не создана</span>
+            <button type="button" class="rounded-lg border border-teal-200 px-3 py-1.5 text-xs font-semibold text-teal-700 hover:bg-teal-50 disabled:opacity-50" :disabled="!line.product_id || supplyActionLoadingLineId === line.link_id" @click="emit('supply', { line, intent: 'order' })">В поставку</button>
+            <button type="button" class="rounded-lg border border-indigo-200 px-3 py-1.5 text-xs font-semibold text-indigo-700 hover:bg-indigo-50 disabled:opacity-50" :disabled="!line.product_id || supplyActionLoadingLineId === line.link_id" @click="emit('supply', { line, intent: 'reserve' })">Забронировать</button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <button type="button" data-testid="add-product-line" class="btn-mini mt-3 w-full justify-center" @click="emit('add')">+ товар</button>
+  </section>
+</template>

--- a/manager_frontend/src/components/orders/OrderProposalWorkspace.vue
+++ b/manager_frontend/src/components/orders/OrderProposalWorkspace.vue
@@ -1,0 +1,116 @@
+<script setup lang="ts">
+import { reactive, ref } from 'vue';
+import type { useOrderCommercialEditor } from '../../composables/useOrderCommercialEditor';
+import type { useOrderProposalLifecycle } from '../../composables/useOrderProposalLifecycle';
+import OrderDrawerSection from './OrderDrawerSection.vue';
+import OrderProductLinesEditor from './OrderProductLinesEditor.vue';
+import OrderProposalToolbar from './OrderProposalToolbar.vue';
+import OrderServiceLinesEditor from './OrderServiceLinesEditor.vue';
+
+const props = defineProps<{
+  commercial: ReturnType<typeof useOrderCommercialEditor>;
+  proposal: ReturnType<typeof useOrderProposalLifecycle>;
+  title: string;
+  showProductLines: boolean;
+  productsError?: string;
+  servicesError?: string;
+  formatServiceKind: (kind?: string | null) => string;
+}>();
+
+const emit = defineEmits<{ send: [] }>();
+const expanded = defineModel<boolean>('expanded', { required: true });
+const toolbarRef = ref<InstanceType<typeof OrderProposalToolbar> | null>(null);
+const commercial = reactive(props.commercial);
+const proposal = reactive(props.proposal);
+
+defineExpose({ openResponse: () => toolbarRef.value?.openResponse() });
+</script>
+
+<template>
+  <OrderDrawerSection
+    id="order-workspace-proposal"
+    v-model:expanded="expanded"
+    :title="title"
+    :summary="proposal.activeProposalLineLabel"
+    tone="default"
+    :has-error="Boolean(productsError || servicesError)"
+  >
+    <div class="min-w-0">
+      <OrderProposalToolbar
+        ref="toolbarRef"
+        class="mb-4"
+        :proposals="proposal.proposals"
+        :active-proposal-id="proposal.activeProposal?.id"
+        :loading="proposal.proposalActionLoading"
+        @open="proposal.onProposalClick"
+        @select="proposal.selectProposalForOrder"
+        @create="proposal.createProposal"
+        @duplicate="proposal.duplicateProposal"
+        @rename="proposal.renameProposal"
+        @archive="proposal.archiveProposal"
+        @change-status="proposal.changeActiveProposalStatus"
+        @send="emit('send')"
+      />
+
+      <div v-if="proposal.activeProposalLocked" class="mb-3 flex flex-col gap-2 rounded-xl border border-amber-200 bg-amber-50 p-3 text-xs text-amber-900 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-100 sm:flex-row sm:items-center sm:justify-between">
+        <span>Эта редакция уже {{ proposal.activeProposalStatus === 'approved' ? 'принята клиентом' : 'отправлена' }}. Чтобы изменить состав или стоимость, создайте копию либо верните её в черновик.</span>
+        <div class="flex shrink-0 gap-2">
+          <button type="button" class="btn-mini-outline h-8 px-2 text-xs" @click="proposal.duplicateProposal">Создать копию</button>
+          <button type="button" class="btn-mini-outline h-8 px-2 text-xs" @click="proposal.changeActiveProposalStatus('draft')">В черновик</button>
+        </div>
+      </div>
+
+      <fieldset :disabled="proposal.activeProposalLocked" :class="proposal.activeProposalLocked ? 'opacity-60' : ''">
+        <OrderProductLinesEditor
+          v-if="showProductLines"
+          v-model:lines="commercial.productLines"
+          v-model:search-in-stock="commercial.searchInStock"
+          :product-options="commercial.productOptions"
+          :product-lookup-by-id="commercial.productLookupById"
+          :product-lookup-loading="commercial.productLookupLoading"
+          :active-suggestion-index="commercial.activeSuggestionIndex"
+          :supply-action-loading-line-id="commercial.supplyActionLoadingLineId"
+          :products-error="productsError"
+          :supply-badge-for-line="commercial.supplyBadgeForLine"
+          @focus="commercial.onProductInputFocus"
+          @input="commercial.onProductQueryInput"
+          @blur="commercial.onProductInputBlur"
+          @select="commercial.selectProductForLine($event.index, $event.option)"
+          @open="commercial.openSelectedProduct"
+          @remove="commercial.removeProductLine"
+          @add="commercial.addProductLine"
+          @supply="commercial.createSupplyFromProductLine($event.line, $event.intent)"
+        />
+
+        <OrderServiceLinesEditor
+          v-model:lines="commercial.serviceLines"
+          v-model:editing-index="commercial.editingServiceLineIndex"
+          v-model:show-estimate-import="commercial.showEstimateImport"
+          v-model:selected-estimate-id="commercial.selectedEstimateId"
+          v-model:estimate-search-query="commercial.estimateSearchQuery"
+          v-model:estimate-import-mode="commercial.estimateImportMode"
+          v-model:description-mode="commercial.serviceDescriptionMode"
+          :service-options="commercial.serviceTariffOptions"
+          :service-lookup-loading="commercial.serviceTariffLookupLoading"
+          :active-suggestion-index="commercial.activeServiceSuggestionIndex"
+          :services-error="servicesError"
+          :estimate-options="commercial.estimateOptions"
+          :estimate-options-loading="commercial.estimateOptionsLoading"
+          :importing-estimate="commercial.importingEstimate"
+          :format-service-kind="formatServiceKind"
+          @focus="commercial.onServiceTitleFocus"
+          @input="commercial.onServiceTitleInput"
+          @blur="commercial.onServiceTitleBlur"
+          @select="commercial.selectServiceTariffForLine($event.index, $event.option)"
+          @description-mode="commercial.setServiceLineDescriptionMode($event.index, $event.mode)"
+          @remove="commercial.removeServiceLine"
+          @add="commercial.addServiceLine"
+          @toggle-estimate="commercial.toggleEstimateImport"
+          @import-estimate="commercial.applyEstimateToServices"
+          @load-estimates="commercial.loadEstimateOptions"
+          @remember-description-mode="commercial.setDefaultServiceDescriptionMode"
+        />
+      </fieldset>
+    </div>
+  </OrderDrawerSection>
+</template>

--- a/manager_frontend/src/components/orders/OrderRepairEquipmentPanel.vue
+++ b/manager_frontend/src/components/orders/OrderRepairEquipmentPanel.vue
@@ -1,0 +1,373 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue';
+import type {
+  EquipmentServiceEventType,
+  ManagerEquipmentDetailResponse,
+  ManagerEquipmentHistoryFromRepairOrderPayload,
+  ManagerEquipmentItemResponse,
+} from '../../client';
+import { ManagerEquipmentService } from '../../client';
+import { getApiErrorMessage } from '../../utils/api-errors';
+import { EQUIPMENT_EVENT_OPTIONS, type RepairMeta } from './repair-meta';
+
+const props = defineProps<{
+  orderId: number;
+  orderTitle: string;
+  customerId: number | null;
+  customerBranchId: number | null;
+  objectAddress: string;
+}>();
+
+const emit = defineEmits<{
+  toast: [payload: { message: string; type: 'success' | 'error' }];
+}>();
+
+const repairMeta = defineModel<RepairMeta>('repairMeta', { required: true });
+const equipment = ref<ManagerEquipmentItemResponse[]>([]);
+const loading = ref(false);
+const errorMessage = ref('');
+const selectedId = ref<number | null>(null);
+const selectedDetail = ref<ManagerEquipmentDetailResponse | null>(null);
+const historyLoading = ref(false);
+const creating = ref(false);
+const recordingHistory = ref(false);
+const historyEventType = ref<EquipmentServiceEventType | ''>('');
+const historyNotes = ref('');
+
+const selectedEquipment = computed(() => (
+  equipment.value.find((item) => item.id === selectedId.value) || null
+));
+
+const notify = (message: string, type: 'success' | 'error') => {
+  emit('toast', { message, type });
+};
+
+const trimOrNull = (value: string) => value.trim() || null;
+
+const reset = () => {
+  equipment.value = [];
+  selectedId.value = null;
+  selectedDetail.value = null;
+  errorMessage.value = '';
+  historyEventType.value = '';
+  historyNotes.value = '';
+};
+
+const loadDetail = async (equipmentId: number) => {
+  historyLoading.value = true;
+  errorMessage.value = '';
+  try {
+    selectedDetail.value = await ManagerEquipmentService.getManagerEquipment(equipmentId, 10);
+  } catch (error) {
+    selectedDetail.value = null;
+    errorMessage.value = `Не удалось загрузить историю оборудования: ${getApiErrorMessage(error)}`;
+  } finally {
+    historyLoading.value = false;
+  }
+};
+
+const selectEquipment = async (equipmentId: number) => {
+  selectedId.value = equipmentId;
+  await loadDetail(equipmentId);
+};
+
+const loadEquipment = async () => {
+  if (!props.customerId) {
+    reset();
+    return;
+  }
+  loading.value = true;
+  errorMessage.value = '';
+  try {
+    const response = await ManagerEquipmentService.listManagerEquipment(
+      props.customerId,
+      props.customerBranchId || null,
+      1,
+      50,
+      false,
+    );
+    equipment.value = response.items || [];
+    if (selectedId.value && !equipment.value.some((item) => item.id === selectedId.value)) {
+      selectedId.value = null;
+      selectedDetail.value = null;
+    }
+    if (!selectedId.value && equipment.value.length) {
+      await selectEquipment(equipment.value[0]!.id);
+    } else if (selectedId.value) {
+      await loadDetail(selectedId.value);
+    }
+  } catch (error) {
+    equipment.value = [];
+    selectedDetail.value = null;
+    errorMessage.value = `Не удалось загрузить оборудование клиента: ${getApiErrorMessage(error)}`;
+  } finally {
+    loading.value = false;
+  }
+};
+
+const createFromMeta = async () => {
+  if (!props.customerId || creating.value) return;
+  const meta = repairMeta.value;
+  const displayName = trimOrNull(meta.equipment_name) || trimOrNull(props.orderTitle);
+  const hasPassportData = Boolean(
+    displayName
+    || trimOrNull(meta.equipment_brand)
+    || trimOrNull(meta.equipment_model)
+    || trimOrNull(meta.equipment_serial_number)
+    || trimOrNull(meta.equipment_inventory_number),
+  );
+  if (!hasPassportData) {
+    errorMessage.value = 'Заполните название, бренд, модель, серийный или инвентарный номер';
+    return;
+  }
+  creating.value = true;
+  errorMessage.value = '';
+  try {
+    const notes = [
+      meta.equipment_power ? `Мощность: ${meta.equipment_power}` : '',
+      meta.equipment_commissioning_date
+        ? `Ввод в эксплуатацию: ${meta.equipment_commissioning_date}`
+        : '',
+    ].filter(Boolean).join('\n') || null;
+    const created = await ManagerEquipmentService.createManagerEquipment({
+      customer_id: props.customerId,
+      customer_branch_id: props.customerBranchId || null,
+      equipment_type: 'hvac',
+      display_name: displayName,
+      brand: trimOrNull(meta.equipment_brand),
+      model: trimOrNull(meta.equipment_model),
+      serial: trimOrNull(meta.equipment_serial_number),
+      inventory_number: trimOrNull(meta.equipment_inventory_number),
+      location_hint: trimOrNull(props.objectAddress),
+      refrigerant_type: trimOrNull(meta.refrigerant_type),
+      notes,
+    });
+    selectedId.value = created.id;
+    await loadEquipment();
+    await loadDetail(created.id);
+    notify('Оборудование создано из полей ремонта', 'success');
+  } catch (error) {
+    errorMessage.value = `Не удалось создать оборудование: ${getApiErrorMessage(error)}`;
+  } finally {
+    creating.value = false;
+  }
+};
+
+const recordHistory = async () => {
+  if (!selectedId.value || recordingHistory.value) return;
+  recordingHistory.value = true;
+  errorMessage.value = '';
+  try {
+    const payload: ManagerEquipmentHistoryFromRepairOrderPayload = {
+      order_id: props.orderId,
+      event_type: historyEventType.value || null,
+      notes: trimOrNull(historyNotes.value),
+    };
+    await ManagerEquipmentService.createManagerEquipmentHistoryFromRepairOrder(
+      selectedId.value,
+      payload,
+    );
+    historyEventType.value = '';
+    historyNotes.value = '';
+    await loadDetail(selectedId.value);
+    notify('Событие записано в историю оборудования', 'success');
+  } catch (error) {
+    errorMessage.value = `Не удалось записать историю: ${getApiErrorMessage(error)}`;
+  } finally {
+    recordingHistory.value = false;
+  }
+};
+
+const equipmentTitle = (item?: Pick<ManagerEquipmentItemResponse, 'display_name' | 'brand' | 'model' | 'serial' | 'inventory_number'> | null) => {
+  if (!item) return 'Оборудование';
+  const name = item.display_name?.trim();
+  if (name) return name;
+  const parts = [item.brand, item.model, item.serial || item.inventory_number]
+    .map((value) => value?.trim())
+    .filter(Boolean);
+  return parts.join(' ') || 'Оборудование';
+};
+
+const equipmentSubtitle = (item: ManagerEquipmentItemResponse | ManagerEquipmentDetailResponse) => {
+  const parts = [
+    item.brand,
+    item.model,
+    item.serial ? `SN ${item.serial}` : '',
+    item.inventory_number ? `Инв. ${item.inventory_number}` : '',
+    item.location_hint,
+    item.refrigerant_type,
+  ].map((value) => value?.trim()).filter(Boolean);
+  return parts.join(' · ') || 'Паспортные данные не заполнены';
+};
+
+const eventLabel = (value?: EquipmentServiceEventType | null) => (
+  EQUIPMENT_EVENT_OPTIONS.find((option) => option.value === value)?.label || 'Другое'
+);
+
+const historyLine = (item: NonNullable<ManagerEquipmentDetailResponse['recent_history']>[number]) => {
+  const parts = [
+    item.complaint_snapshot,
+    item.diagnostic_result,
+    item.repair_recommendation,
+    item.refrigerant_type ? `Хладагент ${item.refrigerant_type}` : '',
+    item.refrigerant_amount,
+    item.not_repairable ? 'Не ремонтируется' : '',
+    item.not_repairable_reason,
+    item.notes,
+  ].map((value) => value?.trim()).filter(Boolean);
+  return parts.join(' · ') || 'Без подробностей';
+};
+
+const formatDateTime = (value?: string | null) => {
+  if (!value) return null;
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed.toLocaleString('ru-RU', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+};
+
+watch(
+  () => [props.customerId, props.customerBranchId, props.orderId],
+  () => void loadEquipment(),
+  { immediate: true },
+);
+</script>
+
+<template>
+  <details class="md:col-span-2 rounded-xl border border-slate-200 bg-slate-50 p-3">
+    <summary class="cursor-pointer select-none text-sm font-semibold text-slate-900">
+      Оборудование и паспортные данные
+      <span class="ml-2 text-xs font-normal text-slate-500">{{ repairMeta.equipment_model || repairMeta.equipment_name || 'не заполнено' }}</span>
+    </summary>
+    <div class="mt-3 grid gap-3 md:grid-cols-2">
+      <label class="field-label">
+        Оборудование
+        <input v-model="repairMeta.equipment_name" class="field-input" placeholder="Кондиционер настенный" />
+      </label>
+      <label class="field-label">
+        Бренд
+        <input v-model="repairMeta.equipment_brand" class="field-input" placeholder="LG, Gree, Mitsubishi..." />
+      </label>
+      <label class="field-label">
+        Модель
+        <input v-model="repairMeta.equipment_model" class="field-input" placeholder="Модель внутреннего/наружного блока" />
+      </label>
+      <label class="field-label">
+        Мощность
+        <input v-model="repairMeta.equipment_power" class="field-input" placeholder="2,5 кВт" />
+      </label>
+      <label class="field-label">
+        Серийный номер
+        <input v-model="repairMeta.equipment_serial_number" class="field-input" placeholder="SN..." />
+      </label>
+      <label class="field-label">
+        Инвентарный номер
+        <input v-model="repairMeta.equipment_inventory_number" class="field-input" placeholder="Инв. номер заказчика" />
+      </label>
+      <label class="field-label md:col-span-2">
+        Дата ввода в эксплуатацию
+        <input v-model="repairMeta.equipment_commissioning_date" class="field-input" placeholder="Например: 2021 г. или 12.05.2021" />
+      </label>
+
+      <div class="md:col-span-2 rounded-xl border border-slate-200 bg-slate-50 p-3">
+        <div class="mb-3 flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+          <div class="min-w-0">
+            <p class="text-sm font-semibold text-slate-900">Карточка оборудования и история</p>
+            <p class="mt-1 text-xs text-slate-600">
+              История оборудования записывается отдельным действием и не меняет CRM/Kanban статус заказа.
+            </p>
+          </div>
+          <div class="flex flex-wrap gap-2">
+            <button type="button" data-testid="reload-repair-equipment" class="btn-mini-outline justify-center whitespace-nowrap text-xs" :disabled="loading" @click="loadEquipment">
+              Обновить
+            </button>
+            <button type="button" data-testid="create-repair-equipment" class="btn-mini justify-center whitespace-nowrap text-xs" :disabled="creating || !customerId" @click="createFromMeta">
+              {{ creating ? 'Создаем...' : 'Создать из полей' }}
+            </button>
+          </div>
+        </div>
+
+        <p v-if="errorMessage" role="alert" class="mb-3 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700">
+          {{ errorMessage }}
+        </p>
+
+        <div v-if="!customerId" class="rounded-lg border border-dashed border-slate-200 bg-white px-3 py-4 text-center text-xs text-slate-500">
+          Выберите клиента, чтобы вести оборудование.
+        </div>
+        <div v-else-if="loading" class="rounded-lg border border-dashed border-slate-200 bg-white px-3 py-4 text-xs text-slate-500">
+          Загружаем оборудование клиента...
+        </div>
+        <div v-else class="grid gap-3 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
+          <div class="space-y-2">
+            <button
+              v-for="item in equipment"
+              :key="item.id"
+              type="button"
+              :data-testid="`repair-equipment-${item.id}`"
+              class="w-full rounded-lg border px-3 py-2 text-left text-xs transition"
+              :class="selectedId === item.id
+                ? 'border-teal-400 bg-white text-teal-900 shadow-sm'
+                : 'border-slate-200 bg-white text-slate-700 hover:border-teal-200'"
+              @click="selectEquipment(item.id)"
+            >
+              <span class="block break-words font-semibold">{{ equipmentTitle(item) }}</span>
+              <span class="mt-1 block break-words text-slate-500">{{ equipmentSubtitle(item) }}</span>
+            </button>
+            <div v-if="!equipment.length" class="rounded-lg border border-dashed border-slate-200 bg-white px-3 py-4 text-center text-xs text-slate-500">
+              {{ customerBranchId ? 'Для выбранного филиала оборудование не найдено.' : 'Оборудование клиента пока не заведено.' }}
+            </div>
+          </div>
+
+          <div class="rounded-lg border border-slate-200 bg-white p-3">
+            <div v-if="historyLoading" class="text-xs text-slate-500">Загружаем историю...</div>
+            <template v-else-if="selectedEquipment">
+              <div class="mb-3">
+                <p class="break-words text-sm font-semibold text-slate-900">{{ equipmentTitle(selectedEquipment) }}</p>
+                <p class="mt-1 break-words text-xs text-slate-500">{{ equipmentSubtitle(selectedEquipment) }}</p>
+              </div>
+              <div class="grid gap-2 sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+                <label class="field-label !mb-0">
+                  Тип записи из заказа
+                  <select v-model="historyEventType" class="field-input bg-white">
+                    <option value="">Определить автоматически</option>
+                    <option v-for="option in EQUIPMENT_EVENT_OPTIONS" :key="option.value" :value="option.value">{{ option.label }}</option>
+                  </select>
+                </label>
+                <label class="field-label !mb-0">
+                  Заметка
+                  <input v-model="historyNotes" class="field-input bg-white" placeholder="Например: закрыто после согласования" />
+                </label>
+              </div>
+              <button type="button" data-testid="record-repair-history" class="btn-mini mt-2 w-full justify-center text-xs" :disabled="recordingHistory || !selectedId" @click="recordHistory">
+                {{ recordingHistory ? 'Записываем...' : 'Записать историю из этого ремонта' }}
+              </button>
+              <p class="mt-2 text-[11px] text-slate-500">
+                Действие создаст запись истории оборудования из repair meta текущего заказа. Статус заказа и этап ремонта останутся отдельными.
+              </p>
+
+              <div class="mt-3 max-h-56 space-y-2 overflow-y-auto pr-1">
+                <div v-for="entry in selectedDetail?.recent_history || []" :key="entry.id" class="rounded-lg border border-slate-100 bg-slate-50 px-3 py-2 text-xs">
+                  <div class="flex flex-wrap items-center gap-2">
+                    <span class="rounded-full bg-teal-50 px-2 py-0.5 font-semibold text-teal-700">{{ eventLabel(entry.event_type) }}</span>
+                    <span class="text-slate-500">{{ formatDateTime(entry.event_date) || 'Без даты' }}</span>
+                    <span v-if="entry.order_id" class="text-slate-500">Заказ #{{ entry.order_id }}</span>
+                  </div>
+                  <p class="mt-1 break-words text-slate-600">{{ historyLine(entry) }}</p>
+                </div>
+                <div v-if="!(selectedDetail?.recent_history || []).length" class="rounded-lg border border-dashed border-slate-200 px-3 py-3 text-center text-xs text-slate-500">
+                  История пока пустая
+                </div>
+              </div>
+            </template>
+            <div v-else class="text-xs text-slate-500">Выберите оборудование слева или создайте карточку из полей ремонта.</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </details>
+</template>

--- a/manager_frontend/src/components/orders/OrderRepairExpertFields.vue
+++ b/manager_frontend/src/components/orders/OrderRepairExpertFields.vue
@@ -1,0 +1,79 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import type { RepairMeta } from './repair-meta';
+
+const repairMeta = defineModel<RepairMeta>('repairMeta', { required: true });
+
+const structuredJson = computed(() => JSON.stringify({
+  structured_diagnosis: repairMeta.value.structured_diagnosis || {},
+  defect_act_blocks: repairMeta.value.defect_act_blocks || {},
+  risks: repairMeta.value.risks || [],
+  recommended_actions: repairMeta.value.recommended_actions || [],
+}, null, 2));
+</script>
+
+<template>
+  <details class="md:col-span-2 rounded-xl border border-amber-200 bg-amber-50/60 p-3">
+    <summary class="cursor-pointer select-none text-sm font-semibold text-amber-900">
+      Экспертный режим: JSON и ручные override-поля
+    </summary>
+    <div class="mt-3 grid gap-3 md:grid-cols-2">
+      <label class="field-label md:col-span-2">
+        Структурированные выводы AI
+        <textarea :value="structuredJson" readonly class="field-input min-h-[180px] font-mono text-xs" />
+      </label>
+      <label class="field-label">
+        Формулировка для акта
+        <textarea
+          v-model="repairMeta.complaint_official"
+          class="field-input min-h-[72px]"
+          placeholder="Override официальной формулировки жалобы"
+        />
+      </label>
+      <label class="field-label">
+        Вероятный диагноз
+        <textarea
+          v-model="repairMeta.likely_diagnosis"
+          class="field-input min-h-[72px]"
+          placeholder="Override предварительной причины"
+        />
+      </label>
+      <label class="field-label">
+        Техническое состояние
+        <textarea v-model="repairMeta.technical_condition" class="field-input min-h-[80px]" placeholder="Общее состояние, износ, загрязнение, следы вмешательства..." />
+      </label>
+      <label class="field-label">
+        Проверка запуска
+        <textarea v-model="repairMeta.startup_check_result" class="field-input min-h-[80px]" placeholder="Запускается / не запускается, ошибки, симптомы..." />
+      </label>
+      <label class="field-label">
+        Проверка компрессора
+        <textarea v-model="repairMeta.compressor_check_result" class="field-input min-h-[80px]" placeholder="Токи, сопротивления, срабатывание защиты..." />
+      </label>
+      <label class="field-label">
+        Замеры / диагностика
+        <textarea v-model="repairMeta.measurement_result" class="field-input min-h-[80px]" placeholder="Давление, температура, утечки, электрические замеры..." />
+      </label>
+      <label class="field-label">
+        Возможность дальнейшей эксплуатации
+        <textarea v-model="repairMeta.further_use_assessment" class="field-input min-h-[80px]" placeholder="Допускается / не допускается / с ограничениями..." />
+      </label>
+      <label class="field-label">
+        Ограничения эксплуатации
+        <textarea v-model="repairMeta.operation_restrictions" class="field-input min-h-[80px]" placeholder="Что нельзя делать до ремонта или замены" />
+      </label>
+      <label class="field-label">
+        Целесообразность ремонта
+        <textarea v-model="repairMeta.repair_feasibility" class="field-input min-h-[80px]" placeholder="Ремонт целесообразен / нецелесообразен..." />
+      </label>
+      <label class="field-label">
+        Рекомендованное решение
+        <textarea v-model="repairMeta.recommended_decision" class="field-input min-h-[80px]" placeholder="Ремонт, замена узла, списание, замена оборудования..." />
+      </label>
+      <label class="field-label md:col-span-2">
+        Техническое заключение
+        <textarea v-model="repairMeta.technical_conclusion" class="field-input min-h-[96px]" placeholder="Итоговый вывод для дефектного акта" />
+      </label>
+    </div>
+  </details>
+</template>

--- a/manager_frontend/src/components/orders/OrderRepairPanel.vue
+++ b/manager_frontend/src/components/orders/OrderRepairPanel.vue
@@ -1,0 +1,373 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue';
+import type { ManagerOrderDetailResponse, ManagerRepairComplaintPresetResponse } from '../../client';
+import { ManagerOrdersService, ManagerRepairComplaintsService } from '../../client';
+import { getApiErrorMessage } from '../../utils/api-errors';
+import OrderDrawerSection from './OrderDrawerSection.vue';
+import OrderRepairEquipmentPanel from './OrderRepairEquipmentPanel.vue';
+import OrderRepairExpertFields from './OrderRepairExpertFields.vue';
+import {
+  CUSTOMER_APPROVAL_STATUS_OPTIONS,
+  PARTS_STATUS_OPTIONS,
+  REFRIGERANT_PRICING_MODE_OPTIONS,
+  REPAIR_AI_DEFECT_TYPES,
+  REPAIR_CHOICE_OPTIONS,
+  REPAIR_WORKFLOW_STATUS_OPTIONS,
+  labeledOptionsWithCurrent,
+  normalizeRepairMeta,
+  selectOptionsWithCurrent,
+  type RepairMeta,
+} from './repair-meta';
+
+const props = defineProps<{
+  order: ManagerOrderDetailResponse;
+  orderTitle: string;
+  measurementResult: string;
+  customerBranchId: number | null;
+  objectAddress: string;
+}>();
+
+const emit = defineEmits<{
+  toast: [payload: { message: string; type: 'success' | 'error' }];
+  reload: [orderId: number];
+}>();
+
+const expanded = defineModel<boolean>('expanded', { required: true });
+const repairMeta = defineModel<RepairMeta>('repairMeta', { required: true });
+const complaintPresets = ref<ManagerRepairComplaintPresetResponse[]>([]);
+const complaintSearch = ref('');
+const complaintsLoading = ref(false);
+const aiDefectType = ref(REPAIR_AI_DEFECT_TYPES[0]?.value || '');
+const aiAllowAssumptions = ref(false);
+const aiPolishExisting = ref(true);
+const aiGenerating = ref(false);
+
+const notify = (message: string, type: 'success' | 'error') => {
+  emit('toast', { message, type });
+};
+
+const workflowStatusLabel = computed(() => (
+  REPAIR_WORKFLOW_STATUS_OPTIONS.find((item) => item.value === repairMeta.value.repair_status)?.label || ''
+));
+
+const summary = computed(() => {
+  const parts: string[] = [];
+  if (workflowStatusLabel.value) parts.push(workflowStatusLabel.value);
+  if (repairMeta.value.equipment_name.trim()) parts.push(repairMeta.value.equipment_name.trim());
+  const serial = repairMeta.value.equipment_serial_number.trim()
+    || repairMeta.value.equipment_inventory_number.trim();
+  if (serial) parts.push(serial);
+  if (repairMeta.value.customer_complaint.trim()) parts.push('есть жалоба');
+  if (repairMeta.value.diagnostic_result.trim()) parts.push('есть диагностика');
+  if (repairMeta.value.repair_recommendation.trim() || repairMeta.value.technical_conclusion.trim()) {
+    parts.push('есть вывод');
+  }
+  return parts.join(' · ') || 'данные для диагностики и дефектного акта';
+});
+
+const filteredPresets = computed(() => {
+  const query = complaintSearch.value.trim().toLowerCase();
+  return complaintPresets.value.filter((item) => {
+    if (!query) return true;
+    return [
+      item.customer_phrase,
+      item.document_wording,
+      item.likely_diagnosis,
+      item.complaint_group,
+    ].some((value) => String(value || '').toLowerCase().includes(query));
+  }).slice(0, 12);
+});
+
+const selectedAiDefect = computed(() => (
+  REPAIR_AI_DEFECT_TYPES.find((item) => item.value === aiDefectType.value)
+  || REPAIR_AI_DEFECT_TYPES[0]
+));
+const repairPossibleOptions = computed(() => (
+  selectOptionsWithCurrent(REPAIR_CHOICE_OPTIONS, repairMeta.value.repair_possible)
+));
+const repairNotViableOptions = computed(() => (
+  selectOptionsWithCurrent(REPAIR_CHOICE_OPTIONS, repairMeta.value.repair_not_viable)
+));
+const customerApprovalStatusOptions = computed(() => (
+  labeledOptionsWithCurrent(
+    CUSTOMER_APPROVAL_STATUS_OPTIONS,
+    repairMeta.value.customer_approval_status,
+  )
+));
+const partsStatusOptions = computed(() => (
+  labeledOptionsWithCurrent(PARTS_STATUS_OPTIONS, repairMeta.value.parts_status)
+));
+
+const buildPayload = () => normalizeRepairMeta({
+  ...repairMeta.value,
+  fault_type: repairMeta.value.fault_type || aiDefectType.value,
+}, { defaultRepairStatus: true });
+
+const loadComplaintPresets = async () => {
+  if (complaintsLoading.value) return;
+  complaintsLoading.value = true;
+  try {
+    const response = await ManagerRepairComplaintsService.listManagerRepairComplaintPresets(
+      '',
+      null,
+      false,
+      false,
+      100,
+    );
+    complaintPresets.value = response.items || [];
+  } catch (error) {
+    console.warn('Failed to load repair complaint presets', error);
+  } finally {
+    complaintsLoading.value = false;
+  }
+};
+
+const applyComplaintPreset = (preset: ManagerRepairComplaintPresetResponse) => {
+  repairMeta.value.customer_complaint = preset.customer_phrase
+    || repairMeta.value.customer_complaint;
+  repairMeta.value.complaint_official = preset.document_wording
+    || repairMeta.value.complaint_official;
+  repairMeta.value.likely_diagnosis = preset.likely_diagnosis
+    || repairMeta.value.likely_diagnosis;
+};
+
+const generateAiDraft = async () => {
+  const defect = selectedAiDefect.value;
+  if (!defect || aiGenerating.value) return;
+  aiGenerating.value = true;
+  try {
+    const response = await ManagerRepairComplaintsService.generateManagerRepairActAiDraft({
+      defect_type: defect.value,
+      defect_label: defect.label,
+      allow_assumptions: aiAllowAssumptions.value,
+      polish_existing: aiPolishExisting.value,
+      equipment_name: repairMeta.value.equipment_name || props.orderTitle || props.order.title || '',
+      equipment_brand: repairMeta.value.equipment_brand,
+      equipment_model: repairMeta.value.equipment_model,
+      equipment_power: repairMeta.value.equipment_power,
+      customer_complaint: repairMeta.value.customer_complaint,
+      complaint_official: repairMeta.value.complaint_official,
+      likely_diagnosis: repairMeta.value.likely_diagnosis,
+      diagnostic_notes: repairMeta.value.diagnostic_notes,
+      refrigerant_type: repairMeta.value.refrigerant_type,
+      refrigerant_amount: repairMeta.value.refrigerant_amount,
+      extra_context: repairMeta.value.diagnostic_notes || defect.hint,
+      current_meta: repairMeta.value as any,
+    });
+    repairMeta.value = normalizeRepairMeta({
+      ...repairMeta.value,
+      ...((response.repair_meta || {}) as Partial<RepairMeta>),
+    });
+    await ManagerOrdersService.patchManagerOrder(props.order.id, {
+      repair_meta: buildPayload() as any,
+      measurement_result: props.measurementResult,
+    });
+    emit('reload', props.order.id);
+    notify('Черновик дефектного акта заполнен и сохранен', 'success');
+  } catch (error) {
+    notify(`AI не смог подготовить черновик: ${getApiErrorMessage(error)}`, 'error');
+  } finally {
+    aiGenerating.value = false;
+  }
+};
+
+watch(
+  () => props.order.id,
+  () => {
+    const savedFaultType = repairMeta.value.fault_type
+      || (repairMeta.value.structured_diagnosis || {}).fault_type;
+    if (savedFaultType && REPAIR_AI_DEFECT_TYPES.some((item) => item.value === savedFaultType)) {
+      aiDefectType.value = savedFaultType;
+    } else {
+      repairMeta.value.fault_type = aiDefectType.value;
+    }
+    complaintSearch.value = '';
+    void loadComplaintPresets();
+  },
+  { immediate: true },
+);
+
+watch(aiDefectType, (value) => {
+  repairMeta.value.fault_type = value;
+});
+</script>
+
+<template>
+  <OrderDrawerSection
+    v-model:expanded="expanded"
+    title="Ремонт / диагностика"
+    :summary="summary"
+    tone="default"
+  >
+    <div class="grid gap-3 md:grid-cols-2">
+      <div class="md:col-span-2 rounded-xl border border-teal-100 bg-teal-50/50 p-3">
+        <div class="mb-2 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p class="text-sm font-semibold text-teal-900">Библиотека жалоб</p>
+            <p class="text-xs text-teal-700/80">Выберите типовую жалобу, чтобы заполнить формулировку и вероятный диагноз.</p>
+          </div>
+          <button type="button" data-testid="reload-repair-presets" class="btn-mini-outline justify-center whitespace-nowrap text-xs" :disabled="complaintsLoading" @click="loadComplaintPresets">
+            <span class="material-icons-round text-[15px]" :class="{ 'animate-spin': complaintsLoading }">refresh</span>
+            Обновить
+          </button>
+        </div>
+        <input v-model="complaintSearch" type="search" class="field-input mb-2" placeholder="Найти: не холодит, капает, шумит..." />
+        <div v-if="filteredPresets.length" class="flex max-h-44 flex-wrap gap-2 overflow-auto pr-1">
+          <button
+            v-for="preset in filteredPresets"
+            :key="preset.id"
+            type="button"
+            :data-testid="`repair-preset-${preset.id}`"
+            class="rounded-lg border bg-white px-3 py-2 text-left text-xs shadow-sm transition hover:border-teal-300 hover:text-teal-800"
+            :class="preset.is_favorite ? 'border-teal-200 text-teal-900' : 'border-slate-200 text-slate-700'"
+            @click="applyComplaintPreset(preset)"
+          >
+            <span class="flex items-center gap-1 font-semibold">
+              <span v-if="preset.is_favorite" class="material-icons-round text-[14px] text-amber-500">star</span>
+              {{ preset.customer_phrase }}
+            </span>
+            <span v-if="preset.document_wording" class="mt-1 line-clamp-2 block max-w-[260px] opacity-75">{{ preset.document_wording }}</span>
+          </button>
+        </div>
+        <p v-else class="rounded-lg border border-dashed border-teal-200 bg-white/70 px-3 py-3 text-xs text-teal-700">
+          {{ complaintsLoading ? 'Загружаем пресеты...' : 'Подходящих пресетов пока нет.' }}
+        </p>
+      </div>
+
+      <div class="md:col-span-2 rounded-xl border border-violet-100 bg-violet-50/60 p-3">
+        <div class="mb-2 flex flex-col gap-2 lg:flex-row lg:items-end">
+          <div class="min-w-0 flex-1">
+            <p class="text-sm font-semibold text-violet-950">AI-черновик по выбранной неисправности</p>
+            <p class="mt-1 truncate text-xs text-violet-700/80">{{ selectedAiDefect?.label || 'Базовая неисправность не выбрана' }}</p>
+          </div>
+          <button type="button" data-testid="generate-repair-ai" class="btn-mini h-[42px] justify-center whitespace-nowrap bg-violet-600 hover:bg-violet-700" :disabled="aiGenerating" @click="generateAiDraft">
+            <span v-if="aiGenerating" class="material-icons-round animate-spin text-[16px]">loop</span>
+            <span v-else class="material-icons-round text-[16px]">auto_awesome</span>
+            AI-черновик
+          </button>
+        </div>
+        <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <p class="text-xs text-violet-700/80">{{ selectedAiDefect?.hint }}</p>
+          <div class="flex flex-col gap-2 sm:flex-row sm:items-center">
+            <label class="inline-flex items-center gap-2 rounded-lg bg-white/70 px-2.5 py-1.5 text-xs font-semibold text-violet-800">
+              <input v-model="aiPolishExisting" type="checkbox" class="h-4 w-4 rounded border-violet-300 text-violet-600 focus:ring-violet-500" />
+              Причесать заполненное
+            </label>
+            <label class="inline-flex items-center gap-2 rounded-lg bg-white/70 px-2.5 py-1.5 text-xs font-semibold text-violet-800">
+              <input v-model="aiAllowAssumptions" type="checkbox" class="h-4 w-4 rounded border-violet-300 text-violet-600 focus:ring-violet-500" />
+              Заполнить на усмотрение
+            </label>
+          </div>
+        </div>
+      </div>
+
+      <details class="md:col-span-2 rounded-xl border border-slate-200 bg-slate-50 p-3">
+        <summary class="cursor-pointer select-none text-sm font-semibold text-slate-900">
+          Статусы, согласование и запчасти
+          <span class="ml-2 text-xs font-normal text-slate-500">{{ workflowStatusLabel || 'не указано' }}</span>
+        </summary>
+        <div class="mt-3 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+          <label class="field-label">
+            Этап ремонта
+            <select v-model="repairMeta.repair_status" class="field-input bg-white">
+              <option v-for="option in REPAIR_WORKFLOW_STATUS_OPTIONS" :key="option.value" :value="option.value">{{ option.label }}</option>
+            </select>
+          </label>
+          <label class="field-label">
+            Согласование клиента
+            <select v-model="repairMeta.customer_approval_status" class="field-input bg-white">
+              <option v-for="option in customerApprovalStatusOptions" :key="`approval-${option.value || 'empty'}`" :value="option.value">{{ option.label }}</option>
+            </select>
+          </label>
+          <label class="field-label">
+            Запчасти
+            <select v-model="repairMeta.parts_status" class="field-input bg-white">
+              <option v-for="option in partsStatusOptions" :key="`parts-${option.value || 'empty'}`" :value="option.value">{{ option.label }}</option>
+            </select>
+          </label>
+          <label class="field-label">
+            Комментарий согласования
+            <textarea v-model="repairMeta.customer_approval_note" class="field-input min-h-[64px] bg-white" placeholder="Кто согласовал, когда, условия" />
+          </label>
+          <label class="field-label">
+            Комментарий по запчастям
+            <textarea v-model="repairMeta.parts_note" class="field-input min-h-[64px] bg-white" placeholder="Что нужно, сроки, поставщик" />
+          </label>
+          <label class="field-label">
+            Итог ремонта
+            <textarea v-model="repairMeta.repair_completion_note" class="field-input min-h-[64px] bg-white" placeholder="Что выполнено или почему закрыто" />
+          </label>
+        </div>
+      </details>
+
+      <label class="field-label md:col-span-2">
+        Жалоба клиента
+        <textarea v-model="repairMeta.customer_complaint" class="field-input min-h-[72px]" placeholder="Например: не охлаждает, шумит, течет вода..." />
+      </label>
+      <label class="field-label">
+        Базовая неисправность
+        <select v-model="aiDefectType" data-testid="repair-defect-type" class="field-input">
+          <option v-for="item in REPAIR_AI_DEFECT_TYPES" :key="`main-${item.value}`" :value="item.value">{{ item.label }}</option>
+        </select>
+      </label>
+      <label class="field-label md:col-span-2">
+        Детали диагностики / заметки инженера
+        <textarea v-model="repairMeta.diagnostic_notes" class="field-input min-h-[72px]" placeholder="Что увидел инженер: симптомы, проверки, ограничения, важные нюансы" />
+      </label>
+      <label class="field-label">
+        Результат диагностики
+        <textarea v-model="repairMeta.diagnostic_result" class="field-input min-h-[88px]" placeholder="Что выявлено при диагностике, без лишних чисел и предположений" />
+      </label>
+      <label class="field-label">
+        Рекомендация по ремонту
+        <textarea v-model="repairMeta.repair_recommendation" class="field-input min-h-[88px]" placeholder="Что сделать: устранить утечку, заменить узел, дозаправить..." />
+      </label>
+      <label class="field-label md:col-span-2">
+        Формулировка для сметы ремонта
+        <textarea v-model="repairMeta.repair_estimate_text" class="field-input min-h-[72px]" placeholder="Короткая строка работ для сметы" />
+      </label>
+      <label class="field-label">
+        Возможен ремонт
+        <select v-model="repairMeta.repair_possible" class="field-input">
+          <option v-for="option in repairPossibleOptions" :key="`repair-possible-${option || 'empty'}`" :value="option">{{ option || 'Не указано' }}</option>
+        </select>
+      </label>
+      <label class="field-label">
+        Ремонт невозможен / нецелесообразен
+        <select v-model="repairMeta.repair_not_viable" class="field-input">
+          <option v-for="option in repairNotViableOptions" :key="`repair-not-viable-${option || 'empty'}`" :value="option">{{ option || 'Не указано' }}</option>
+        </select>
+      </label>
+      <label class="field-label">
+        Хладагент
+        <input v-model="repairMeta.refrigerant_type" class="field-input" placeholder="R32, R410A..." />
+      </label>
+      <label class="field-label">
+        Количество хладагента
+        <input v-model="repairMeta.refrigerant_amount" class="field-input" placeholder="0,45 кг или по факту" />
+      </label>
+      <label class="field-label md:col-span-2">
+        Расчет хладагента
+        <input v-model="repairMeta.refrigerant_pricing_mode" list="refrigerant-pricing-mode-options" class="field-input" placeholder="по фактической массе, включен в стоимость..." />
+        <datalist id="refrigerant-pricing-mode-options">
+          <option v-for="option in REFRIGERANT_PRICING_MODE_OPTIONS" :key="option" :value="option" />
+        </datalist>
+      </label>
+      <label class="field-label md:col-span-2">
+        Причина неремонтопригодности
+        <textarea v-model="repairMeta.repair_not_viable_reason" class="field-input min-h-[72px]" placeholder="Заполняйте, если ремонт невозможен или экономически нецелесообразен" />
+      </label>
+
+      <OrderRepairEquipmentPanel
+        v-model:repair-meta="repairMeta"
+        :order-id="order.id"
+        :order-title="orderTitle"
+        :customer-id="order.customer?.id || null"
+        :customer-branch-id="customerBranchId"
+        :object-address="objectAddress"
+        @toast="emit('toast', $event)"
+      />
+      <OrderRepairExpertFields v-model:repair-meta="repairMeta" />
+    </div>
+  </OrderDrawerSection>
+</template>

--- a/manager_frontend/src/components/orders/OrderServiceLinesEditor.vue
+++ b/manager_frontend/src/components/orders/OrderServiceLinesEditor.vue
@@ -1,0 +1,151 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import type { ManagerQuickTariffResponse, ManagerServiceEstimateResponse } from '../../client';
+import ServiceDescriptionModeSwitch from './ServiceDescriptionModeSwitch.vue';
+import type { ServiceLine } from './order-editor-types';
+import { formatMoney } from './order-utils';
+import type { ServiceDescriptionMode } from './service-description-mode';
+
+const props = defineProps<{
+  serviceOptions: ManagerQuickTariffResponse[];
+  serviceLookupLoading: boolean;
+  activeSuggestionIndex: number | null;
+  servicesError?: string;
+  estimateOptions: ManagerServiceEstimateResponse[];
+  estimateOptionsLoading: boolean;
+  importingEstimate: boolean;
+  formatServiceKind: (kind?: string | null) => string;
+}>();
+
+const emit = defineEmits<{
+  focus: [index: number];
+  input: [index: number];
+  blur: [index: number];
+  select: [payload: { index: number; option: ManagerQuickTariffResponse }];
+  descriptionMode: [payload: { index: number; mode: ServiceDescriptionMode }];
+  remove: [index: number];
+  add: [];
+  toggleEstimate: [];
+  importEstimate: [];
+  loadEstimates: [];
+  rememberDescriptionMode: [mode: ServiceDescriptionMode];
+}>();
+
+const lines = defineModel<ServiceLine[]>('lines', { required: true });
+const editingIndex = defineModel<number | null>('editingIndex', { required: true });
+const showEstimateImport = defineModel<boolean>('showEstimateImport', { required: true });
+const selectedEstimateId = defineModel<number | null>('selectedEstimateId', { required: true });
+const estimateSearchQuery = defineModel<string>('estimateSearchQuery', { required: true });
+const estimateImportMode = defineModel<'detailed' | 'collapsed'>('estimateImportMode', { required: true });
+const descriptionMode = defineModel<ServiceDescriptionMode>('descriptionMode', { required: true });
+
+const suggestionsFor = (index: number) => (
+  props.activeSuggestionIndex === index ? props.serviceOptions.slice(0, 10) : []
+);
+const filteredEstimates = computed(() => {
+  const query = estimateSearchQuery.value.trim().toLowerCase();
+  if (!query) return props.estimateOptions;
+  return props.estimateOptions.filter((estimate) => (
+    (estimate.title || '').toLowerCase().includes(query)
+    || String(estimate.id).includes(query)
+  ));
+});
+const lineTotal = (line: ServiceLine) => Number(line.quantity || 0) * Number(line.price || 0);
+const updatePreferredMode = (mode: ServiceDescriptionMode) => {
+  descriptionMode.value = mode;
+  emit('rememberDescriptionMode', mode);
+};
+</script>
+
+<template>
+  <section class="mt-6">
+    <div class="mb-2"><h4 class="text-md font-semibold text-gray-800">Услуги</h4></div>
+    <p v-if="servicesError" class="mb-2 text-xs text-red-300">{{ servicesError }}</p>
+    <div class="space-y-2">
+      <div v-for="(line, index) in lines" :key="`service-${index}`" class="relative rounded-xl border border-gray-200 bg-white p-3 shadow-sm">
+        <button v-if="editingIndex === index" type="button" class="absolute -right-2 -top-2 z-10 inline-flex h-8 w-8 items-center justify-center rounded-full border border-red-200 bg-red-50 text-lg font-bold text-red-600 shadow-sm transition-colors hover:bg-red-100" :aria-label="`Удалить услугу #${index + 1}`" title="Удалить услугу" @click="emit('remove', index)">
+          ×
+        </button>
+        <div v-if="editingIndex !== index" class="flex min-w-0 items-start gap-3">
+          <div class="min-w-0 flex-1">
+            <p class="break-words text-sm font-semibold leading-snug text-slate-900 dark:text-slate-100">{{ line.title || 'Новая услуга' }}</p>
+            <div class="mt-1 flex flex-wrap items-center justify-between gap-x-3 gap-y-1 text-xs text-slate-500 dark:text-slate-400">
+              <span>{{ line.quantity }} × {{ formatMoney(line.price) }}</span>
+              <span class="font-semibold text-slate-800 dark:text-slate-200">{{ formatMoney(lineTotal(line)) }}</span>
+            </div>
+          </div>
+          <button type="button" class="btn-mini-outline h-9 w-9 shrink-0 justify-center p-0" :aria-label="`Редактировать услугу #${index + 1}`" title="Редактировать" @click="editingIndex = index">
+            <span class="material-icons-round text-[17px]">edit</span>
+          </button>
+        </div>
+        <div v-else class="grid grid-cols-6 gap-2 md:grid-cols-12 md:items-start">
+          <div class="relative col-span-6 space-y-1 md:col-span-5">
+            <span class="flex min-h-6 items-center justify-between gap-2 px-1 text-xs font-medium text-gray-500">
+              <span>Название</span>
+              <ServiceDescriptionModeSwitch v-if="line.template_full_description" :model-value="line.description_mode || 'short'" @update:model-value="emit('descriptionMode', { index, mode: $event })" />
+            </span>
+            <textarea
+              v-model="line.title"
+              class="field-input min-h-[64px] resize-none overflow-hidden text-sm leading-snug focus:min-h-[120px] focus:resize-y focus:overflow-auto sm:text-base"
+              rows="2"
+              placeholder="Название услуги"
+              @focus="emit('focus', index)"
+              @input="emit('input', index)"
+              @blur="emit('blur', index)"
+            />
+            <div v-if="line.title.trim().length >= 2 && activeSuggestionIndex === index && (serviceLookupLoading || suggestionsFor(index).length)" class="absolute left-0 right-0 top-full z-20 mt-1 max-h-64 overflow-auto rounded-[12px] border border-gray-200 bg-white p-1 shadow-xl">
+              <div v-if="serviceLookupLoading" class="px-3 py-2 text-xs text-gray-500">Ищем тарифы...</div>
+              <button
+                v-for="item in suggestionsFor(index)"
+                :key="`service-tariff-suggest-${index}-${item.tariff_id}`"
+                type="button"
+                :data-testid="`select-service-${item.tariff_id}`"
+                class="mb-1 block w-full rounded-[12px] px-3 py-2 text-left text-xs text-gray-700 hover:bg-slate-100 last:mb-0"
+                @mousedown.prevent
+                @click="emit('select', { index, option: item })"
+              >
+                <p class="line-clamp-2 font-medium text-gray-900">{{ item.short_name || item.title }}</p>
+                <p v-if="item.full_description && item.full_description !== item.short_name" class="mt-0.5 line-clamp-2 text-[11px] leading-snug text-gray-500">{{ item.full_description }}</p>
+                <p class="mt-1 flex flex-wrap items-center gap-1 text-[11px] text-gray-500">
+                  <span>{{ formatMoney(item.price) }}</span>
+                  <span v-if="item.service_kind">· {{ formatServiceKind(item.service_kind) }}</span>
+                  <span v-if="item.category">· {{ item.category }}</span>
+                  <span v-if="item.included_route_meters">· трасса до {{ item.included_route_meters }} м</span>
+                </p>
+              </button>
+            </div>
+          </div>
+          <label class="col-span-4 space-y-1 md:col-span-2"><span class="flex h-auto items-center px-1 text-xs font-medium text-gray-500 md:h-6">Цена</span><input v-model.number="line.price" type="number" min="0" class="field-input" placeholder="0" /></label>
+          <label class="col-span-2 space-y-1 md:col-span-1"><span class="flex h-auto items-center whitespace-nowrap px-1 text-xs font-medium text-gray-500 md:h-6 md:text-[11px]">Кол-во</span><input v-model.number="line.quantity" type="number" min="1" class="field-input" placeholder="1" /></label>
+          <label class="col-span-3 space-y-1 md:col-span-2"><span class="flex h-auto items-center px-1 text-xs font-medium text-gray-500 md:h-6">Себест.</span><input v-model.number="line.cost" type="number" min="0" class="field-input" placeholder="0" /></label>
+          <div class="col-span-3 space-y-1 md:col-span-2"><span class="flex h-auto items-center px-1 text-xs font-medium text-gray-500 md:h-6">Итого</span><div class="rounded-lg bg-gray-50 px-3 py-2"><p class="whitespace-nowrap text-base font-semibold leading-tight text-gray-900">{{ formatMoney(lineTotal(line)) }}</p></div></div>
+          <div class="col-span-6 flex justify-end md:col-span-12"><button type="button" class="btn-mini-outline h-8 px-3 text-xs" @click="editingIndex = null">Готово</button></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="mt-3 grid grid-cols-2 gap-2">
+      <button type="button" data-testid="add-service-line" class="btn-mini justify-center" @click="emit('add')">+ услуга</button>
+      <button type="button" class="btn-mini-outline justify-center" :class="showEstimateImport ? 'border-teal-200 bg-teal-50 text-teal-700' : ''" @click="emit('toggleEstimate')">Из сметы</button>
+    </div>
+    <div v-if="showEstimateImport" class="mt-3 grid gap-2 rounded-xl border border-gray-200 bg-gray-50 p-3">
+      <div class="grid gap-2 md:grid-cols-3">
+        <label class="space-y-1 md:col-span-3">
+          <span class="px-1 text-xs font-medium text-gray-500">Смета</span>
+          <select v-model="selectedEstimateId" class="field-input min-w-0" :disabled="estimateOptionsLoading">
+            <option :value="null">Выберите смету</option>
+            <option v-for="estimate in filteredEstimates" :key="estimate.id" :value="estimate.id">#{{ estimate.id }} · {{ estimate.title }} · {{ formatMoney(estimate.total) }} {{ estimate.currency }}</option>
+          </select>
+        </label>
+        <label class="space-y-1"><span class="px-1 text-xs font-medium text-gray-500">Поиск</span><input v-model="estimateSearchQuery" class="field-input" placeholder="ID или название" /></label>
+        <label class="space-y-1"><span class="px-1 text-xs font-medium text-gray-500">Структура</span><select v-model="estimateImportMode" class="field-input"><option value="detailed">По строкам</option><option value="collapsed">Одной строкой</option></select></label>
+        <div class="space-y-1"><span class="block px-1 text-xs font-medium text-gray-500">Текст позиции</span><ServiceDescriptionModeSwitch :model-value="descriptionMode" @update:model-value="updatePreferredMode" /></div>
+      </div>
+      <div class="flex flex-col gap-2 sm:flex-row">
+        <button type="button" data-testid="import-estimate" class="btn-mini justify-center whitespace-nowrap" :disabled="importingEstimate || !selectedEstimateId" @click="emit('importEstimate')">{{ importingEstimate ? 'Добавляю...' : 'Добавить из сметы' }}</button>
+        <button type="button" class="btn-mini-outline justify-center whitespace-nowrap" :disabled="estimateOptionsLoading" title="Обновить список смет" @click="emit('loadEstimates')">Обновить</button>
+      </div>
+      <p class="text-xs text-gray-500">Показываем 10 последних смет. Структура определяет количество строк, а формат текста — краткую или подробную формулировку.</p>
+    </div>
+  </section>
+</template>

--- a/manager_frontend/src/components/orders/OrderWebsiteIntakePanel.vue
+++ b/manager_frontend/src/components/orders/OrderWebsiteIntakePanel.vue
@@ -1,0 +1,177 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import type { ManagerOrderDetailResponse } from '../../client';
+import OrderDrawerSection from './OrderDrawerSection.vue';
+import { formatMoney } from './order-utils';
+
+const props = defineProps<{
+  order: ManagerOrderDetailResponse;
+  expanded: boolean;
+  deliveryAddress: string;
+  comment: string;
+}>();
+
+const emit = defineEmits<{
+  'update:expanded': [value: boolean];
+  copy: [payload: { value: string | null | undefined; label: string }];
+}>();
+
+const expandedModel = computed({
+  get: () => props.expanded,
+  set: (value: boolean) => emit('update:expanded', value),
+});
+
+const productLines = computed(() => (
+  (props.order.product_lines ?? []).map((line) => ({
+    id: line.id,
+    title: line.product_title || `Товар #${line.product_id}`,
+    quantity: line.quantity,
+    lineTotal: line.line_total,
+    installationIncluded: Boolean(line.is_installation_included),
+    installationPrice: Number(line.installation_price || 0),
+  }))
+));
+
+const serviceLines = computed(() => (
+  (props.order.service_lines ?? []).map((line) => ({
+    id: line.id,
+    title: line.service_title || 'Услуга',
+    quantity: line.quantity,
+    lineTotal: line.line_total,
+  }))
+));
+
+const formatDateTime = (value?: string | null) => {
+  if (!value) return null;
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed.toLocaleString('ru-RU', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+};
+
+const summary = computed(() => {
+  const parts: string[] = [];
+  const createdAt = formatDateTime(props.order.created_at);
+  if (createdAt) parts.push(`создан ${createdAt}`);
+  parts.push(`${productLines.value.length + serviceLines.value.length} поз.`);
+  if (props.deliveryAddress) parts.push(props.deliveryAddress);
+  return parts.join(' · ');
+});
+
+const copy = (value: string | null | undefined, label: string) => {
+  emit('copy', { value, label });
+};
+</script>
+
+<template>
+  <OrderDrawerSection
+    v-model:expanded="expandedModel"
+    title="Входящий заказ с сайта"
+    :summary="summary"
+    tone="emerald"
+  >
+    <div class="mb-4 flex flex-wrap items-start justify-between gap-3">
+      <div>
+        <p class="text-[11px] font-semibold uppercase tracking-[0.14em] text-emerald-700">Входящий заказ с сайта</p>
+        <p class="mt-1 text-sm text-gray-500">
+          <span v-if="formatDateTime(order.created_at)">Создан: {{ formatDateTime(order.created_at) }}</span>
+          <span v-if="order.status" class="ml-2 inline-flex items-center rounded-full bg-white px-2 py-0.5 text-[11px] font-medium text-gray-600 ring-1 ring-gray-200">
+            {{ order.status }}
+          </span>
+        </p>
+      </div>
+      <div class="flex flex-wrap gap-2">
+        <button
+          type="button"
+          class="inline-flex items-center gap-1 rounded-lg bg-white px-3 py-2 text-xs font-medium text-gray-700 shadow-sm ring-1 ring-gray-200 transition hover:bg-gray-50"
+          @click="copy(order.customer?.phone, 'Телефон')"
+        >
+          <span class="material-icons-round text-[16px]">content_copy</span>
+          Телефон
+        </button>
+        <button
+          type="button"
+          class="inline-flex items-center gap-1 rounded-lg bg-white px-3 py-2 text-xs font-medium text-gray-700 shadow-sm ring-1 ring-gray-200 transition hover:bg-gray-50"
+          @click="copy(deliveryAddress, 'Адрес')"
+        >
+          <span class="material-icons-round text-[16px]">content_copy</span>
+          Адрес
+        </button>
+      </div>
+    </div>
+
+    <div class="grid gap-3 md:grid-cols-2">
+      <div class="rounded-xl bg-white/90 p-3 ring-1 ring-emerald-100">
+        <p class="text-[11px] font-semibold uppercase tracking-[0.12em] text-gray-500">Клиент</p>
+        <p class="mt-2 text-sm font-semibold text-gray-900">{{ order.customer?.full_legal_name || order.customer?.name || 'Без имени' }}</p>
+        <p v-if="order.customer?.phone" class="mt-1 text-sm text-gray-700">{{ order.customer.phone }}</p>
+        <p v-if="order.customer?.email" class="mt-1 text-sm text-gray-500">{{ order.customer.email }}</p>
+      </div>
+
+      <div class="rounded-xl bg-white/90 p-3 ring-1 ring-emerald-100">
+        <p class="text-[11px] font-semibold uppercase tracking-[0.12em] text-gray-500">Адрес доставки</p>
+        <p class="mt-2 text-sm font-medium text-gray-900">{{ deliveryAddress || 'Адрес не указан' }}</p>
+      </div>
+
+      <div class="rounded-xl bg-white/90 p-3 ring-1 ring-emerald-100 md:col-span-2">
+        <div class="flex items-center justify-between gap-3">
+          <p class="text-[11px] font-semibold uppercase tracking-[0.12em] text-gray-500">Состав заказа</p>
+          <span class="text-xs font-medium text-emerald-700">
+            {{ productLines.length + serviceLines.length }} поз.
+          </span>
+        </div>
+        <div class="mt-3 space-y-2">
+          <div
+            v-for="line in productLines"
+            :key="`website-product-${line.id}`"
+            class="rounded-xl border border-gray-100 bg-gray-50 px-3 py-2"
+          >
+            <div class="flex items-start justify-between gap-3">
+              <div>
+                <p class="text-sm font-medium text-gray-900">{{ line.title }}</p>
+                <div class="mt-1 flex flex-wrap gap-2 text-xs text-gray-500">
+                  <span>Кол-во: {{ line.quantity }}</span>
+                  <span v-if="line.installationIncluded" class="inline-flex items-center gap-1 rounded-full bg-blue-50 px-2 py-0.5 text-blue-700">
+                    <span class="material-icons-round text-[14px]">construction</span>
+                    Монтаж включен
+                    <span v-if="line.installationPrice > 0">+ {{ formatMoney(line.installationPrice) }}</span>
+                  </span>
+                </div>
+              </div>
+              <span class="whitespace-nowrap text-sm font-semibold text-gray-800">{{ formatMoney(line.lineTotal) }}</span>
+            </div>
+          </div>
+
+          <div
+            v-for="line in serviceLines"
+            :key="`website-service-${line.id}`"
+            class="flex items-start justify-between gap-3 rounded-xl border border-gray-100 bg-gray-50 px-3 py-2"
+          >
+            <div>
+              <p class="text-sm font-medium text-gray-900">{{ line.title }}</p>
+              <p class="mt-1 text-xs text-gray-500">Кол-во: {{ line.quantity }}</p>
+            </div>
+            <span class="whitespace-nowrap text-sm font-semibold text-gray-800">{{ formatMoney(line.lineTotal) }}</span>
+          </div>
+
+          <p
+            v-if="!productLines.length && !serviceLines.length"
+            class="rounded-xl border border-dashed border-gray-200 px-3 py-4 text-sm text-gray-500"
+          >
+            Позиции заказа отсутствуют.
+          </p>
+        </div>
+      </div>
+
+      <div v-if="comment.trim()" class="rounded-xl bg-white/90 p-3 ring-1 ring-emerald-100 md:col-span-2">
+        <p class="text-[11px] font-semibold uppercase tracking-[0.12em] text-gray-500">Комментарий клиента</p>
+        <p class="mt-2 whitespace-pre-line text-sm text-gray-800">{{ comment }}</p>
+      </div>
+    </div>
+  </OrderDrawerSection>
+</template>

--- a/manager_frontend/src/components/orders/order-editor-types.ts
+++ b/manager_frontend/src/components/orders/order-editor-types.ts
@@ -1,0 +1,53 @@
+import type { ServiceDescriptionLine } from './service-description-mode';
+
+export type ProductOption = {
+  id: number;
+  title: string;
+  price: number;
+  cost?: number;
+  is_inverter: boolean;
+  power_cooling: number | null;
+  availability_status: string;
+  vitebsk_qty: number;
+  minsk_qty: number;
+  specs?: Record<string, any>;
+};
+
+export type LogisticsComponentKind = 'indoor' | 'outdoor' | 'accessory' | 'other';
+
+export type ProductLogisticsTemplateComponent = {
+  title: string;
+  country?: string | null;
+  unit?: string | null;
+  quantity_per_parent?: number | null;
+  price_weight?: number | null;
+  kind?: LogisticsComponentKind | null;
+};
+
+export type OrderLogisticsComponent = {
+  title: string;
+  country?: string | null;
+  unit: string;
+  quantity_per_parent: number;
+  unit_price: number;
+  kind?: LogisticsComponentKind | null;
+};
+
+export type ProductLine = {
+  link_id?: number | null;
+  product_id: number;
+  product_query: string;
+  quantity: number;
+  price: number;
+  cost: number;
+  product_country?: string | null;
+  product_logistics_components?: ProductLogisticsTemplateComponent[];
+  logistics_components?: OrderLogisticsComponent[] | null;
+};
+
+export type ServiceLine = ServiceDescriptionLine;
+
+export type OrderDrawerDraft = {
+  productLines: ProductLine[];
+  serviceLines: ServiceLine[];
+};

--- a/manager_frontend/src/composables/useOrderCommercialEditor.ts
+++ b/manager_frontend/src/composables/useOrderCommercialEditor.ts
@@ -1,0 +1,644 @@
+import { computed, ref, watch, type Ref } from 'vue';
+import { useDebounceFn } from '@vueuse/core';
+import { api } from '../api';
+import type {
+  ManagerOrderDetailResponse,
+  ManagerQuickTariffResponse,
+  ManagerServiceEstimateResponse,
+  OrderProductLineResponse,
+  OrderServiceLineResponse,
+} from '../client';
+import { confirmDialog } from '../services/ui-feedback';
+import { getApiErrorMessage } from '../utils/api-errors';
+import {
+  useServiceDescriptionMode,
+  type ServiceDescriptionMode,
+} from '../components/orders/service-description-mode';
+import type {
+  LogisticsComponentKind,
+  OrderLogisticsComponent,
+  ProductLine,
+  ProductLogisticsTemplateComponent,
+  ProductOption,
+  ServiceLine,
+} from '../components/orders/order-editor-types';
+
+type ToastHandler = (message: string, type?: 'success' | 'error') => void;
+
+type UseOrderCommercialEditorOptions = {
+  order: Readonly<Ref<ManagerOrderDetailResponse | null>>;
+  setToast: ToastHandler;
+  persistDraft: () => void;
+};
+
+const SUPPLY_STATUS_LABELS: Record<string, string> = {
+  draft: 'черновик',
+  awaiting_reply: 'ждем ответ',
+  reserved: 'бронь',
+  ordered: 'заказано',
+  ready_for_pickup: 'готово к забору',
+  picked_up: 'забрано',
+  received: 'получено',
+  canceled: 'отменено',
+};
+
+const LOGISTICS_COMPONENT_KINDS = new Set(['indoor', 'outdoor', 'accessory', 'other']);
+
+const toIntegerMoney = (value: number | null | undefined): number | null => {
+  if (value == null || Number.isNaN(Number(value))) return null;
+  return Math.round(Number(value));
+};
+
+const normalizeLogisticsKind = (value: unknown): LogisticsComponentKind => {
+  const raw = String(value || '').trim();
+  return LOGISTICS_COMPONENT_KINDS.has(raw) ? (raw as LogisticsComponentKind) : 'other';
+};
+
+const getProductCountryFromSpecs = (specs?: Record<string, any> | null) => {
+  if (!specs) return null;
+  return String(
+    specs.country
+    || specs.country_of_origin
+    || specs['Страна производства']
+    || specs['Страна-производитель']
+    || '',
+  ).trim() || null;
+};
+
+const normalizePositiveInteger = (value: unknown, fallback = 1) => {
+  const parsed = Math.trunc(Number(value));
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+};
+
+const normalizePositiveNumber = (value: unknown, fallback = 0) => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+};
+
+const normalizeProductLogisticsTemplate = (raw: unknown): ProductLogisticsTemplateComponent[] => {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .map((item): ProductLogisticsTemplateComponent | null => {
+      const source = (item || {}) as Record<string, any>;
+      const title = String(source.title || '').trim();
+      if (!title) return null;
+      return {
+        title,
+        country: String(source.country || '').trim() || null,
+        unit: String(source.unit || '').trim() || 'шт.',
+        quantity_per_parent: normalizePositiveInteger(source.quantity_per_parent, 1),
+        price_weight: normalizePositiveNumber(source.price_weight, 1),
+        kind: normalizeLogisticsKind(source.kind),
+      };
+    })
+    .filter((item): item is ProductLogisticsTemplateComponent => Boolean(item));
+};
+
+const normalizeOrderLogisticsComponents = (
+  components?: OrderLogisticsComponent[] | null,
+): OrderLogisticsComponent[] | null => {
+  if (!components?.length) return null;
+  const normalized = components
+    .map((component) => ({
+      title: String(component.title || '').trim(),
+      country: String(component.country || '').trim() || 'Китай',
+      unit: String(component.unit || '').trim() || 'шт.',
+      quantity_per_parent: normalizePositiveInteger(component.quantity_per_parent, 1),
+      unit_price: normalizePositiveNumber(component.unit_price, 0),
+      kind: normalizeLogisticsKind(component.kind),
+    }))
+    .filter((component) => Boolean(component.title));
+  return normalized.length ? normalized : null;
+};
+
+const mapProductLineFromResponse = (line: OrderProductLineResponse): ProductLine => ({
+  link_id: line.id,
+  product_id: line.product_id || 0,
+  product_query: line.product_title || '',
+  quantity: line.quantity,
+  price: line.price,
+  cost: line.cost,
+  product_country: (line as any).product_country || null,
+  product_logistics_components: Array.isArray((line as any).product_logistics_components)
+    ? ((line as any).product_logistics_components as ProductLogisticsTemplateComponent[])
+    : [],
+  logistics_components: Array.isArray((line as any).logistics_components) && (line as any).logistics_components.length
+    ? ((line as any).logistics_components as OrderLogisticsComponent[])
+    : null,
+});
+
+const mapServiceLineFromResponse = (line: OrderServiceLineResponse): ServiceLine => ({
+  service_id: line.service_id,
+  title: line.service_title,
+  quantity: Math.max(1, Number(line.quantity || 1)),
+  price: Number(line.price || 0),
+  cost: Number(line.cost || 0),
+});
+
+export const useOrderCommercialEditor = ({ order, setToast, persistDraft }: UseOrderCommercialEditorOptions) => {
+  const productOptions = ref<ProductOption[]>([]);
+  const productLookupById = ref<Record<number, ProductOption>>({});
+  const activeSuggestionIndex = ref<number | null>(null);
+  const productLookupLoading = ref(false);
+  const searchInStock = ref(false);
+  let productSearchRequestId = 0;
+
+  const productLines = ref<ProductLine[]>([]);
+  const supplyRequests = ref<any[]>([]);
+  const supplyActionLoadingLineId = ref<number | null>(null);
+  const serviceLines = ref<ServiceLine[]>([]);
+  const editingServiceLineIndex = ref<number | null>(null);
+  const activeServiceSuggestionIndex = ref<number | null>(null);
+  const serviceTariffOptions = ref<ManagerQuickTariffResponse[]>([]);
+  const serviceTariffLookupLoading = ref(false);
+  let serviceTariffSearchRequestId = 0;
+  const estimateOptions = ref<ManagerServiceEstimateResponse[]>([]);
+  const estimateOptionsLoading = ref(false);
+  const estimateImportMode = ref<'detailed' | 'collapsed'>('detailed');
+  const selectedEstimateId = ref<number | null>(null);
+  const estimateSearchQuery = ref('');
+  const importingEstimate = ref(false);
+  const showEstimateImport = ref(false);
+
+  const {
+    preferredMode: serviceDescriptionMode,
+    rememberMode: setDefaultServiceDescriptionMode,
+    applyTariffTemplate: applyTariffTemplateToLine,
+    replaceLineDescription,
+  } = useServiceDescriptionMode();
+
+  const total = computed(() => {
+    const products = productLines.value.reduce((sum, line) => sum + line.price * line.quantity, 0);
+    const services = serviceLines.value.reduce((sum, line) => sum + line.price * line.quantity, 0);
+    return products + services;
+  });
+
+  const margin = computed(() => {
+    const productCost = productLines.value.reduce((sum, line) => sum + line.cost * line.quantity, 0);
+    const serviceCost = serviceLines.value.reduce((sum, line) => sum + line.cost * line.quantity, 0);
+    return Math.round(total.value - productCost - serviceCost);
+  });
+
+  const rememberProductOption = (option: ProductOption) => {
+    productLookupById.value = { ...productLookupById.value, [option.id]: option };
+  };
+
+  const rememberProductOptions = (options: ProductOption[]) => {
+    if (!options.length) return;
+    const merged = { ...productLookupById.value };
+    for (const option of options) merged[option.id] = option;
+    productLookupById.value = merged;
+  };
+
+  const mapSmartSearchItemToOption = (item: any): ProductOption => ({
+    id: Number(item.id),
+    title: String(item.title ?? ''),
+    price: Number(item.price ?? 0),
+    cost: Number(item.min_cost_byn ?? 0),
+    is_inverter: Boolean(item.is_inverter),
+    power_cooling: item.power_cooling == null ? null : Number(item.power_cooling),
+    availability_status: String(item.availability_status ?? 'out_of_stock'),
+    vitebsk_qty: Number(item.vitebsk_qty ?? 0),
+    minsk_qty: Number(item.minsk_qty ?? 0),
+    specs: ((item.specs || {}) as Record<string, any>),
+  });
+
+  const syncProductLookupFromLines = () => {
+    for (const line of productLines.value) {
+      if (!line.product_id || productLookupById.value[line.product_id]) continue;
+      rememberProductOption({
+        id: line.product_id,
+        title: line.product_query,
+        price: line.price,
+        cost: line.cost,
+        is_inverter: false,
+        power_cooling: null,
+        availability_status: 'out_of_stock',
+        vitebsk_qty: 0,
+        minsk_qty: 0,
+      });
+    }
+  };
+
+  const loadOrderSupplyRequests = async (orderId: number) => {
+    try {
+      const response = await api.listSupplyRequests({ orderId, limit: 100 });
+      supplyRequests.value = response.items || [];
+    } catch (error) {
+      console.warn('Failed to load supply requests for order', error);
+      supplyRequests.value = [];
+    }
+  };
+
+  const supplyBadgeForLine = (line: ProductLine) => {
+    if (!line.link_id) return null;
+    for (const request of supplyRequests.value) {
+      const requestLine = (request.lines || []).find((item: any) => Number(item.order_product_link_id) === Number(line.link_id));
+      if (requestLine) {
+        return {
+          label: SUPPLY_STATUS_LABELS[requestLine.status] || requestLine.status,
+          requestId: request.id,
+          status: requestLine.status,
+        };
+      }
+    }
+    return null;
+  };
+
+  const createSupplyFromProductLine = async (line: ProductLine, intent: 'order' | 'reserve') => {
+    if (!order.value?.id) return;
+    if (!line.link_id) {
+      setToast('Сначала сохраните заказ, чтобы создать поставку по строке.', 'error');
+      return;
+    }
+    supplyActionLoadingLineId.value = line.link_id;
+    try {
+      await api.createSupplyRequestFromOrderLines({
+        order_product_link_ids: [line.link_id],
+        intent,
+      });
+      setToast(intent === 'reserve' ? 'Строка отправлена в бронирование.' : 'Строка добавлена в поставки.');
+      await loadOrderSupplyRequests(order.value.id);
+    } catch (error) {
+      setToast(`Не удалось создать поставку: ${getApiErrorMessage(error)}`, 'error');
+    } finally {
+      supplyActionLoadingLineId.value = null;
+    }
+  };
+
+  const debouncedLoadProductOptions = useDebounceFn(async (index: number, query: string, requestId: number) => {
+    try {
+      productLookupLoading.value = true;
+      const response = await api.smartSearchProducts(query, 20);
+      if (requestId !== productSearchRequestId || activeSuggestionIndex.value !== index) return;
+      let options = Array.isArray(response) ? response.map(mapSmartSearchItemToOption) : [];
+      if (searchInStock.value) {
+        options = options.filter((option) => (
+          option.vitebsk_qty > 0
+          || option.minsk_qty > 0
+          || option.availability_status === 'check_availability'
+        ));
+      }
+      productOptions.value = options;
+      rememberProductOptions(options);
+    } catch (error) {
+      setToast(`Ошибка поиска товаров: ${getApiErrorMessage(error)}`, 'error');
+      if (requestId === productSearchRequestId) productOptions.value = [];
+    } finally {
+      if (requestId === productSearchRequestId) productLookupLoading.value = false;
+    }
+  }, 400);
+
+  const onProductChanged = (index: number, applyCatalogPrice = false) => {
+    const row = productLines.value[index];
+    if (!row) return;
+    const selected = productLookupById.value[row.product_id];
+    if (!selected) return;
+    row.product_query = selected.title;
+    if (applyCatalogPrice) row.price = selected.price;
+  };
+
+  const onProductQueryInput = (index: number) => {
+    const row = productLines.value[index];
+    if (!row) return;
+    activeSuggestionIndex.value = index;
+    const query = row.product_query.trim();
+    row.product_id = 0;
+    productSearchRequestId += 1;
+    if (query.length < 2) {
+      productOptions.value = [];
+      productLookupLoading.value = false;
+      return;
+    }
+    debouncedLoadProductOptions(index, query, productSearchRequestId);
+  };
+
+  watch(searchInStock, () => {
+    if (activeSuggestionIndex.value !== null) onProductQueryInput(activeSuggestionIndex.value);
+  });
+
+  const onProductInputBlur = (index: number) => {
+    window.setTimeout(() => {
+      if (activeSuggestionIndex.value === index) activeSuggestionIndex.value = null;
+    }, 120);
+  };
+
+  const onProductInputFocus = (index: number) => {
+    activeSuggestionIndex.value = index;
+  };
+
+  const selectProductForLine = (index: number, option: ProductOption) => {
+    const row = productLines.value[index];
+    if (!row) return;
+    row.product_id = option.id;
+    row.product_query = option.title;
+    row.price = option.price;
+    row.product_country = getProductCountryFromSpecs(option.specs);
+    row.product_logistics_components = normalizeProductLogisticsTemplate(option.specs?.logistics_components);
+    row.logistics_components = null;
+    if (option.cost && option.cost > 0) row.cost = option.cost;
+    rememberProductOption(option);
+    activeSuggestionIndex.value = null;
+    productOptions.value = [];
+    onProductChanged(index, false);
+  };
+
+  const openSelectedProduct = (index: number) => {
+    const row = productLines.value[index];
+    if (!row?.product_id) return;
+    persistDraft();
+    const returnTo = `${window.location.pathname}${window.location.search}`;
+    const query = new URLSearchParams({
+      editProductId: String(row.product_id),
+      editProductQuery: row.product_query || '',
+      returnTo,
+    });
+    window.history.pushState({}, '', `/manager/products?${query.toString()}`);
+    window.dispatchEvent(new PopStateEvent('popstate'));
+  };
+
+  const addProductLine = () => {
+    productLines.value.push({
+      link_id: null,
+      product_id: 0,
+      product_query: '',
+      quantity: 1,
+      price: 0,
+      cost: 0,
+      product_country: null,
+      product_logistics_components: [],
+      logistics_components: null,
+    });
+  };
+
+  const addServiceLine = () => {
+    serviceLines.value.push({ title: '', quantity: 1, price: 0, cost: 0, service_id: null });
+    editingServiceLineIndex.value = serviceLines.value.length - 1;
+  };
+
+  const debouncedLoadServiceTariffOptions = useDebounceFn(async (index: number, query: string, requestId: number) => {
+    try {
+      serviceTariffLookupLoading.value = true;
+      const response = await api.listManagerQuickTariffs(query, null, 10);
+      if (requestId !== serviceTariffSearchRequestId || activeServiceSuggestionIndex.value !== index) return;
+      serviceTariffOptions.value = response.items || [];
+    } catch (error) {
+      setToast(`Ошибка поиска тарифов: ${getApiErrorMessage(error)}`, 'error');
+      if (requestId === serviceTariffSearchRequestId) serviceTariffOptions.value = [];
+    } finally {
+      if (requestId === serviceTariffSearchRequestId) serviceTariffLookupLoading.value = false;
+    }
+  }, 300);
+
+  const onServiceTitleInput = (index: number) => {
+    const row = serviceLines.value[index];
+    if (!row) return;
+    activeServiceSuggestionIndex.value = index;
+    row.service_id = null;
+    const query = row.title.trim();
+    serviceTariffSearchRequestId += 1;
+    if (query.length < 2) {
+      serviceTariffOptions.value = [];
+      serviceTariffLookupLoading.value = false;
+      return;
+    }
+    debouncedLoadServiceTariffOptions(index, query, serviceTariffSearchRequestId);
+  };
+
+  const onServiceTitleFocus = (index: number) => {
+    activeServiceSuggestionIndex.value = index;
+    const row = serviceLines.value[index];
+    if (row?.title.trim() && row.title.trim().length >= 2) onServiceTitleInput(index);
+  };
+
+  const onServiceTitleBlur = (index: number) => {
+    window.setTimeout(() => {
+      if (activeServiceSuggestionIndex.value === index) activeServiceSuggestionIndex.value = null;
+    }, 120);
+  };
+
+  const selectServiceTariffForLine = (index: number, option: ManagerQuickTariffResponse) => {
+    const row = serviceLines.value[index];
+    if (!row) return;
+    applyTariffTemplateToLine(row, option);
+    activeServiceSuggestionIndex.value = null;
+    serviceTariffOptions.value = [];
+  };
+
+  const setServiceLineDescriptionMode = async (index: number, mode: ServiceDescriptionMode) => {
+    const row = serviceLines.value[index];
+    if (!row) return;
+    await replaceLineDescription(row, mode, () => confirmDialog({
+      title: 'Заменить изменённое название?',
+      description: 'Текст был отредактирован вручную. При замене эти изменения будут потеряны.',
+      confirmText: mode === 'full' ? 'Заменить на подробное' : 'Заменить на краткое',
+      variant: 'warning',
+    }));
+  };
+
+  const loadEstimateOptions = async () => {
+    estimateOptionsLoading.value = true;
+    try {
+      const response = await api.listManagerServiceEstimates(1, 10);
+      estimateOptions.value = response.items;
+      if (!response.items.length) {
+        selectedEstimateId.value = null;
+        return;
+      }
+      if (!selectedEstimateId.value || !response.items.some((item) => item.id === selectedEstimateId.value)) {
+        selectedEstimateId.value = response.items[0]!.id;
+      }
+    } catch (error) {
+      console.warn('Failed to load service estimates', error);
+      estimateOptions.value = [];
+      selectedEstimateId.value = null;
+    } finally {
+      estimateOptionsLoading.value = false;
+    }
+  };
+
+  const toggleEstimateImport = async () => {
+    showEstimateImport.value = !showEstimateImport.value;
+    if (showEstimateImport.value && !estimateOptions.value.length && !estimateOptionsLoading.value) {
+      await loadEstimateOptions();
+    }
+  };
+
+  const applyEstimateToServices = async () => {
+    const estimateId = Number(selectedEstimateId.value);
+    if (!Number.isFinite(estimateId) || estimateId <= 0) {
+      setToast('Выберите смету для добавления', 'error');
+      return;
+    }
+    importingEstimate.value = true;
+    try {
+      const response = await api.getManagerServiceEstimateOrderLines(
+        estimateId,
+        estimateImportMode.value,
+        serviceDescriptionMode.value,
+      );
+      if (!response.services.length) {
+        setToast('В выбранной смете нет строк', 'error');
+        return;
+      }
+      const mappedLines: ServiceLine[] = response.services.map((line) => ({
+        service_id: line.service_id ?? null,
+        title: line.title || 'Услуга',
+        quantity: Math.max(1, Number(line.quantity || 1)),
+        price: Number(line.price || 0),
+        cost: Number(line.cost || 0),
+      }));
+      serviceLines.value = [...serviceLines.value, ...mappedLines];
+      showEstimateImport.value = false;
+      setToast(response.mode === 'collapsed'
+        ? `Смета #${response.estimate_id} добавлена одной строкой`
+        : `Смета #${response.estimate_id} добавлена: ${mappedLines.length} строк`);
+    } catch (error) {
+      setToast(`Ошибка импорта сметы: ${getApiErrorMessage(error)}`, 'error');
+    } finally {
+      importingEstimate.value = false;
+    }
+  };
+
+  const removeProductLine = async (index: number) => {
+    if (!await confirmDialog({ title: 'Удалить товар из заказа?', confirmText: 'Удалить', variant: 'danger' })) return;
+    productLines.value.splice(index, 1);
+    if (activeSuggestionIndex.value === index) {
+      activeSuggestionIndex.value = null;
+      productOptions.value = [];
+    }
+  };
+
+  const removeServiceLine = async (index: number) => {
+    if (!await confirmDialog({ title: 'Удалить услугу из заказа?', confirmText: 'Удалить', variant: 'danger' })) return;
+    serviceLines.value.splice(index, 1);
+    editingServiceLineIndex.value = null;
+    if (activeServiceSuggestionIndex.value === index) {
+      activeServiceSuggestionIndex.value = null;
+      serviceTariffOptions.value = [];
+    }
+  };
+
+  const buildLinesPayload = (proposalId: number | null) => ({
+    products: productLines.value.map((line) => ({
+      product_id: line.product_id || 0,
+      quantity: Math.trunc(Number(line.quantity) || 0),
+      price: Math.round(Number(line.price) || 0),
+      cost: (!line.cost && line.cost !== 0) ? null : toIntegerMoney(line.cost),
+      logistics_components: normalizeOrderLogisticsComponents(line.logistics_components),
+      link_id: line.link_id ?? null,
+      proposal_id: proposalId,
+    })),
+    services: serviceLines.value.map((line) => ({
+      service_id: line.service_id ?? null,
+      title: line.title,
+      quantity: Math.trunc(Number(line.quantity) || 0),
+      price: Math.round(Number(line.price) || 0),
+      cost: (!line.cost && line.cost !== 0) ? null : toIntegerMoney(line.cost),
+      link_id: null,
+      proposal_id: proposalId,
+    })),
+  });
+
+  const validateLines = () => {
+    if (productLines.value.some((line) => line.quantity <= 0)) return 'Количество товара должно быть больше 0';
+    if (productLines.value.some((line) => line.price < 0)) return 'Цена товара не может быть отрицательной';
+    if (productLines.value.some((line) => !line.product_id)) return 'Выберите товар из выпадающего списка';
+    if (serviceLines.value.some((line) => line.quantity <= 0)) return 'Количество услуги должно быть больше 0';
+    if (serviceLines.value.some((line) => line.price < 0)) return 'Цена услуги не может быть отрицательной';
+    if (serviceLines.value.some((line) => !line.title?.trim())) return 'Для услуги укажите название';
+    return '';
+  };
+
+  const currentLinesSnapshot = (activeProposalId: number | null) => JSON.stringify({
+    activeProposalId,
+    products: productLines.value.map((line) => ({
+      link_id: line.link_id ?? null,
+      product_id: Number(line.product_id || 0),
+      product_query: String(line.product_query || '').trim(),
+      quantity: Number(line.quantity || 0),
+      price: Number(line.price || 0),
+      cost: Number(line.cost || 0),
+      product_country: line.product_country || null,
+      product_logistics_components: line.product_logistics_components || [],
+      logistics_components: line.logistics_components || null,
+    })),
+    services: serviceLines.value.map((line) => ({
+      service_id: line.service_id ?? null,
+      title: String(line.title || '').trim(),
+      quantity: Number(line.quantity || 0),
+      price: Number(line.price || 0),
+      cost: Number(line.cost || 0),
+    })),
+  });
+
+  const loadLines = (products: OrderProductLineResponse[], services: OrderServiceLineResponse[]) => {
+    editingServiceLineIndex.value = null;
+    productLines.value = products.map(mapProductLineFromResponse);
+    serviceLines.value = services.map(mapServiceLineFromResponse);
+  };
+
+  const resetLookupState = () => {
+    productLookupById.value = {};
+    syncProductLookupFromLines();
+    productOptions.value = [];
+    activeSuggestionIndex.value = null;
+    productLookupLoading.value = false;
+    serviceTariffOptions.value = [];
+    activeServiceSuggestionIndex.value = null;
+    serviceTariffLookupLoading.value = false;
+  };
+
+  return {
+    activeServiceSuggestionIndex,
+    activeSuggestionIndex,
+    addProductLine,
+    addServiceLine,
+    applyEstimateToServices,
+    applyTariffTemplateToLine,
+    buildLinesPayload,
+    createSupplyFromProductLine,
+    currentLinesSnapshot,
+    editingServiceLineIndex,
+    estimateImportMode,
+    estimateOptions,
+    estimateOptionsLoading,
+    estimateSearchQuery,
+    importingEstimate,
+    loadEstimateOptions,
+    loadLines,
+    loadOrderSupplyRequests,
+    margin,
+    onProductInputBlur,
+    onProductInputFocus,
+    onProductQueryInput,
+    onServiceTitleBlur,
+    onServiceTitleFocus,
+    onServiceTitleInput,
+    openSelectedProduct,
+    productLines,
+    productLookupById,
+    productLookupLoading,
+    productOptions,
+    removeProductLine,
+    removeServiceLine,
+    resetLookupState,
+    searchInStock,
+    selectProductForLine,
+    selectServiceTariffForLine,
+    selectedEstimateId,
+    serviceDescriptionMode,
+    serviceLines,
+    serviceTariffLookupLoading,
+    serviceTariffOptions,
+    setDefaultServiceDescriptionMode,
+    setServiceLineDescriptionMode,
+    showEstimateImport,
+    supplyActionLoadingLineId,
+    supplyBadgeForLine,
+    syncProductLookupFromLines,
+    toggleEstimateImport,
+    total,
+    validateLines,
+  };
+};

--- a/manager_frontend/src/composables/useOrderDocumentStatus.ts
+++ b/manager_frontend/src/composables/useOrderDocumentStatus.ts
@@ -1,0 +1,109 @@
+import { computed, ref, type Ref } from 'vue';
+import type { ManagerOrderDetailResponse, OutgoingEmailResponse, PaymentResponse } from '../client';
+import { ManagerMailService } from '../client';
+
+type UseOrderDocumentStatusOptions = {
+  order: Readonly<Ref<ManagerOrderDetailResponse | null>>;
+  payments: Readonly<Ref<PaymentResponse[]>>;
+};
+
+const normalizeDocumentIdentity = (value: unknown) => (
+  String(value || '').toUpperCase().replace(/[^A-ZА-ЯЁ0-9]/g, '')
+);
+
+export const useOrderDocumentStatus = ({ order, payments }: UseOrderDocumentStatusOptions) => {
+  const orderEmails = ref<OutgoingEmailResponse[]>([]);
+  const orderEmailsLoaded = ref(false);
+  let orderEmailsRequestId = 0;
+  const orderDocuments = computed(() => order.value?.documents || []);
+
+  const documentEmailStatus = computed<'unknown' | 'none' | 'pending' | 'sent' | 'failed'>(() => {
+    if (!orderEmailsLoaded.value) return 'unknown';
+    const latest = [...orderEmails.value]
+      .filter((email) => Boolean(email.attachments?.length))
+      .sort((left, right) => Date.parse(right.created_at) - Date.parse(left.created_at))[0];
+    if (!latest) return 'none';
+    if (latest.status === 'sent') return 'sent';
+    if (latest.status === 'pending') return 'pending';
+    if (latest.status === 'failed') return 'failed';
+    return 'none';
+  });
+
+  const sentDocumentTypes = computed(() => {
+    const types = new Set<string>();
+    const documentsByNumber = new Map(
+      orderDocuments.value
+        .filter((document) => document.number)
+        .map((document) => [normalizeDocumentIdentity(document.number), document.doc_type]),
+    );
+    for (const email of orderEmails.value) {
+      if (email.status !== 'sent') continue;
+      for (const attachment of email.attachments || []) {
+        const metadata = attachment as typeof attachment & {
+          document_type?: string | null;
+          document_number?: string | null;
+        };
+        if (metadata.document_type) {
+          types.add(metadata.document_type);
+          continue;
+        }
+        const filename = normalizeDocumentIdentity(metadata.document_number || metadata.filename);
+        for (const [number, documentType] of documentsByNumber) {
+          if (number && filename.includes(number)) {
+            types.add(documentType);
+            break;
+          }
+        }
+      }
+    }
+    return [...types];
+  });
+
+  const missingReferencedInvoice = computed(() => {
+    const invoiceNumbers = new Set(
+      orderDocuments.value
+        .filter((document) => document.doc_type === 'invoice')
+        .map((document) => normalizeDocumentIdentity(document.number))
+        .filter(Boolean),
+    );
+    for (const payment of payments.value) {
+      const purpose = payment.bank_receipt?.payment_purpose || payment.comment || '';
+      const match = purpose.match(/сч[её]т(?:у|а|ом|е)?\s*(?:№\s*)?([A-ZА-ЯЁ0-9][A-ZА-ЯЁ0-9/-]{2,})/iu);
+      const referencedNumber = match?.[1]?.trim();
+      if (referencedNumber && !invoiceNumbers.has(normalizeDocumentIdentity(referencedNumber))) {
+        return referencedNumber;
+      }
+    }
+    return null;
+  });
+
+  const resetOrderEmails = () => {
+    orderEmailsRequestId += 1;
+    orderEmails.value = [];
+    orderEmailsLoaded.value = false;
+  };
+
+  const loadOrderEmails = async (orderId: number) => {
+    const requestId = ++orderEmailsRequestId;
+    try {
+      const response = await ManagerMailService.listManagerOrderOutgoingEmails(orderId, 20);
+      if (requestId !== orderEmailsRequestId || order.value?.id !== orderId) return;
+      orderEmails.value = response.items || [];
+      orderEmailsLoaded.value = true;
+    } catch (error) {
+      if (requestId !== orderEmailsRequestId) return;
+      console.warn('Failed to load order email summary', error);
+      orderEmails.value = [];
+      orderEmailsLoaded.value = false;
+    }
+  };
+
+  return {
+    documentEmailStatus,
+    loadOrderEmails,
+    missingReferencedInvoice,
+    orderDocuments,
+    resetOrderEmails,
+    sentDocumentTypes,
+  };
+};

--- a/manager_frontend/src/composables/useOrderDrawerActions.ts
+++ b/manager_frontend/src/composables/useOrderDrawerActions.ts
@@ -1,0 +1,119 @@
+import type { Ref } from 'vue';
+import { api } from '../api';
+import type { ManagerOrderDetailResponse } from '../client';
+import { ManagerOrdersService } from '../client';
+import { confirmDialog } from '../services/ui-feedback';
+import { getApiErrorMessage } from '../utils/api-errors';
+
+type ToastHandler = (message: string, type?: 'success' | 'error') => void;
+
+type UseOrderDrawerActionsOptions = {
+  order: Readonly<Ref<ManagerOrderDetailResponse | null>>;
+  displayOrderTitle: Readonly<Ref<string>>;
+  hasUnsavedChanges: Readonly<Ref<boolean>>;
+  localFormError: Ref<string>;
+  persistDraft: () => void;
+  clearDraft: () => void;
+  setToast: ToastHandler;
+  onBeforeClose: () => void;
+  onModelValue: (open: boolean) => void;
+  onUpdated: (order: ManagerOrderDetailResponse) => void;
+  onDeleted: (orderId: number) => void;
+};
+
+export const useOrderDrawerActions = ({
+  order,
+  displayOrderTitle,
+  hasUnsavedChanges,
+  localFormError,
+  persistDraft,
+  clearDraft,
+  setToast,
+  onBeforeClose,
+  onModelValue,
+  onUpdated,
+  onDeleted,
+}: UseOrderDrawerActionsOptions) => {
+  const copyText = async (value: string | null | undefined, label: string) => {
+    const normalized = String(value || '').trim();
+    if (!normalized) {
+      setToast(`${label} отсутствует`, 'error');
+      return;
+    }
+    try {
+      if (navigator.clipboard?.writeText) await navigator.clipboard.writeText(normalized);
+      else {
+        const textarea = document.createElement('textarea');
+        textarea.value = normalized;
+        textarea.setAttribute('readonly', 'true');
+        textarea.style.position = 'absolute';
+        textarea.style.left = '-9999px';
+        document.body.appendChild(textarea);
+        textarea.select();
+        document.execCommand('copy');
+        document.body.removeChild(textarea);
+      }
+      setToast(`${label} скопирован`, 'success');
+    } catch {
+      setToast(`Не удалось скопировать ${label.toLowerCase()}`, 'error');
+    }
+  };
+
+  const toggleHold = async () => {
+    if (!order.value) return;
+    const hold = !order.value.is_on_hold;
+    try {
+      const updatedOrder = await api.patchManagerOrder(order.value.id, {
+        is_on_hold: hold,
+        on_hold_reason: hold ? 'Переговоры / Ручная пауза' : '',
+      });
+      onUpdated(updatedOrder);
+      setToast(hold ? 'Сделка поставлена на паузу' : 'Сделка снята с паузы', 'success');
+    } catch {
+      setToast('Ошибка паузы', 'error');
+    }
+  };
+
+  const closeDrawer = async (options?: { force?: boolean } | Event) => {
+    const isDomEvent = typeof Event !== 'undefined' && options instanceof Event;
+    const force = Boolean(options && !isDomEvent && (options as { force?: boolean }).force);
+    if (!force && hasUnsavedChanges.value) {
+      persistDraft();
+      const discard = await confirmDialog({
+        title: 'Закрыть без сохранения?',
+        description: 'В карточке есть несохранённые изменения. Они будут потеряны.',
+        confirmText: 'Закрыть без сохранения',
+        variant: 'warning',
+      });
+      if (!discard) return;
+    }
+    onBeforeClose();
+    clearDraft();
+    onModelValue(false);
+  };
+
+  const deleteOrder = async () => {
+    if (!order.value?.id) return;
+    const currentOrder = order.value;
+    const label = `Заказ №${currentOrder.id}${displayOrderTitle.value ? ` «${displayOrderTitle.value}»` : ''}`;
+    const proceed = await confirmDialog({
+      title: `Удалить ${label}?`,
+      description: 'Заказ будет безвозвратно удалён вместе со связанными документами, выездами и платежами.',
+      confirmText: 'Удалить заказ',
+      variant: 'danger',
+    });
+    if (!proceed) return;
+    try {
+      await ManagerOrdersService.deleteManagerOrder(currentOrder.id);
+      setToast('Заказ успешно удален', 'success');
+      window.setTimeout(() => {
+        onDeleted(currentOrder.id);
+        void closeDrawer({ force: true });
+      }, 1500);
+    } catch (error) {
+      localFormError.value = getApiErrorMessage(error) || 'Ошибка при удалении заказа';
+    }
+  };
+
+  return { closeDrawer, copyText, deleteOrder, toggleHold };
+};

--- a/manager_frontend/src/composables/useOrderDrawerForm.ts
+++ b/manager_frontend/src/composables/useOrderDrawerForm.ts
@@ -1,0 +1,433 @@
+import { computed, ref, watch, type Ref } from 'vue';
+import { api } from '../api';
+import type {
+  FxRateResponse,
+  ManagerInstallerResponse,
+  ManagerOrderDetailResponse,
+  ManagerOrderUpdatePayload,
+  PaymentCurrency,
+  PaymentResponse,
+} from '../client';
+import { ManagerSettingsService } from '../client';
+import { confirmDialog } from '../services/ui-feedback';
+import { fromLocalDateTimeInput, toLocalDateTimeInput } from '../utils/datetime';
+import { getApiErrorMessage } from '../utils/api-errors';
+import type { OrderWorkflowType } from '../components/orders/order-workspace';
+import { normalizeOrderWorkflowType } from '../components/orders/order-workspace';
+import { emptyRepairMeta, normalizeRepairMeta, type RepairMeta } from '../components/orders/repair-meta';
+import type { ProductLine, ServiceLine } from '../components/orders/order-editor-types';
+
+type ToastHandler = (message: string, type?: 'success' | 'error') => void;
+type LinePayload = Pick<ManagerOrderUpdatePayload, 'products' | 'services'>;
+
+type UseOrderDrawerFormOptions = {
+  total: Readonly<Ref<number>>;
+  productLines: Ref<ProductLine[]>;
+  serviceLines: Ref<ServiceLine[]>;
+  serviceTariffOptions: Ref<unknown[]>;
+  activeServiceSuggestionIndex: Ref<number | null>;
+  applyTariffTemplateToLine: (line: ServiceLine, option: any) => void;
+  buildLinesPayload: () => LinePayload;
+  validateLines: () => string;
+  setToast: ToastHandler;
+};
+
+export const useOrderDrawerForm = ({
+  total,
+  productLines,
+  serviceLines,
+  serviceTariffOptions,
+  activeServiceSuggestionIndex,
+  applyTariffTemplateToLine,
+  buildLinesPayload,
+  validateLines,
+  setToast,
+}: UseOrderDrawerFormOptions) => {
+  const status = ref('new_lead');
+  const orderTitle = ref('');
+  const workflowType = ref<OrderWorkflowType>('sales_installation');
+  const repairMeta = ref<RepairMeta>(emptyRepairMeta());
+  const managerLabels = ref<string[]>([]);
+  const managerLabelDraft = ref('');
+  const nextFollowupDate = ref('');
+  const assessmentDate = ref('');
+  const installationDate = ref('');
+  const comment = ref('');
+  const isPaid = ref(false);
+  const installerId = ref<number | null>(null);
+  const customerDeliveryAddress = ref('');
+  const customerBranchId = ref<number | null>(null);
+  const newBranchAddress = ref('');
+  const targetCurrency = ref<PaymentCurrency | null>(null);
+  const targetCurrencyAmount = ref<number | null>(null);
+  const enableCurrency = ref(false);
+  const currentFxRate = ref<FxRateResponse | null>(null);
+  const measurementRequired = ref(false);
+  const measurerId = ref<number | null>(null);
+  const measurementResult = ref('');
+  const additionalConditions = ref('');
+  const negotiationStatus = ref('awaiting_offer');
+  const executionStatus = ref('needs_schedule');
+  const executionWithoutPayment = ref(false);
+  const executionWithoutPaymentReason = ref('');
+  const autoExecutionOnPayment = ref(false);
+  const autoCloseOnPayment = ref(false);
+  const installersList = ref<ManagerInstallerResponse[]>([]);
+  const payments = ref<PaymentResponse[]>([]);
+  const localServerErrors = ref<Record<string, string>>({});
+  const localFormError = ref('');
+
+  const isRepairWorkflow = computed(() => workflowType.value === 'repair');
+  const showProductLinesSection = computed(() => workflowType.value === 'sales_installation');
+  const isB2cCustomer = (order: Readonly<Ref<ManagerOrderDetailResponse | null>>) => computed(() => (
+    order.value?.customer ? order.value.customer.type !== 'company' : true
+  ));
+  const executorOptions = computed(() => {
+    const selectedIds = new Set<number>();
+    if (installerId.value !== null) selectedIds.add(installerId.value);
+    if (measurerId.value !== null) selectedIds.add(measurerId.value);
+    return installersList.value.filter((installer) => installer.is_active || selectedIds.has(installer.id));
+  });
+
+  const hasManualEurRate = computed(() => Boolean(currentFxRate.value?.eur_byn));
+  const getActiveFxRate = (currency: PaymentCurrency | null): number | null => {
+    if (!currentFxRate.value || !currency) return null;
+    if (currency === 'USD') return currentFxRate.value.usd_byn ?? null;
+    if (currency === 'EUR') return currentFxRate.value.eur_byn ?? null;
+    return null;
+  };
+  const syncTargetCurrencyAmountFromRate = () => {
+    const rate = getActiveFxRate(targetCurrency.value);
+    if (!enableCurrency.value || !rate || total.value <= 0) return;
+    targetCurrencyAmount.value = Number((total.value / rate).toFixed(2));
+  };
+
+  watch(enableCurrency, async (enabled) => {
+    if (!enabled) {
+      targetCurrency.value = null;
+      targetCurrencyAmount.value = null;
+    } else if (!targetCurrency.value) {
+      targetCurrency.value = 'USD';
+      try {
+        currentFxRate.value = await ManagerSettingsService.getFxRate();
+        syncTargetCurrencyAmountFromRate();
+      } catch (error) {
+        console.warn('Failed to fetch FX rate', error);
+        enableCurrency.value = false;
+        setToast('Не удалось загрузить курс валют', 'error');
+      }
+    }
+  });
+
+  watch(targetCurrency, (currency) => {
+    if (currency === 'EUR' && !hasManualEurRate.value) {
+      targetCurrency.value = 'USD';
+      return;
+    }
+    syncTargetCurrencyAmountFromRate();
+  });
+
+  const totalPayments = computed(() => {
+    const bynPaid = payments.value
+      .filter((payment) => payment.currency === 'BYN')
+      .reduce((sum, payment) => sum + payment.amount, 0);
+    if (!enableCurrency.value || !currentFxRate.value || !targetCurrency.value) return bynPaid;
+    const foreignPaid = payments.value
+      .filter((payment) => payment.currency === targetCurrency.value)
+      .reduce((sum, payment) => sum + payment.amount, 0);
+    const rate = getActiveFxRate(targetCurrency.value);
+    return rate ? bynPaid + foreignPaid * rate : bynPaid;
+  });
+  const calculatedTargetCurrencyPayments = computed(() => payments.value.reduce((sum, payment) => {
+    if (payment.currency === targetCurrency.value) return sum + payment.amount;
+    if (payment.currency === 'BYN' && targetCurrency.value) {
+      const rate = getActiveFxRate(targetCurrency.value);
+      if (rate) return sum + payment.amount / rate;
+    }
+    return sum;
+  }, 0));
+  const targetCurrencyBalanceDue = computed(() => (
+    Math.max(0, (targetCurrencyAmount.value || 0) - calculatedTargetCurrencyPayments.value)
+  ));
+  const balanceDue = computed(() => {
+    if (enableCurrency.value && currentFxRate.value && targetCurrency.value) {
+      const rate = getActiveFxRate(targetCurrency.value);
+      if (rate) return targetCurrencyBalanceDue.value * rate;
+    }
+    return Math.max(0, total.value - totalPayments.value);
+  });
+
+  const buildRepairMetaPayload = () => normalizeRepairMeta(
+    repairMeta.value,
+    { defaultRepairStatus: isRepairWorkflow.value },
+  );
+
+  const hydrateOrder = (order: ManagerOrderDetailResponse) => {
+    localServerErrors.value = {};
+    localFormError.value = '';
+    status.value = order.status;
+    orderTitle.value = order.title ?? '';
+    workflowType.value = normalizeOrderWorkflowType((order as any).workflow_type);
+    repairMeta.value = normalizeRepairMeta(((order as any).repair_meta || {}) as Partial<RepairMeta>, {
+      defaultRepairStatus: workflowType.value === 'repair',
+    });
+    managerLabels.value = [...(order.manager_labels ?? [])];
+    managerLabelDraft.value = '';
+    nextFollowupDate.value = toLocalDateTimeInput(order.next_followup_date);
+    assessmentDate.value = toLocalDateTimeInput(order.measurement_date);
+    installationDate.value = toLocalDateTimeInput(order.installation_date);
+    comment.value = order.comment ?? '';
+    isPaid.value = order.is_paid;
+    installerId.value = order.installer_id ?? null;
+    customerDeliveryAddress.value = order.delivery_address || '';
+    customerBranchId.value = order.customer_branch?.id ?? null;
+    measurementRequired.value = order.measurement_required ?? false;
+    measurerId.value = order.measurer_id ?? null;
+    measurementResult.value = order.measurement_result ?? '';
+    additionalConditions.value = order.additional_conditions ?? '';
+    negotiationStatus.value = order.negotiation_status || 'awaiting_offer';
+    executionStatus.value = order.execution_status || 'needs_schedule';
+    executionWithoutPayment.value = Boolean(order.execution_without_payment);
+    executionWithoutPaymentReason.value = order.execution_without_payment_reason || '';
+    autoExecutionOnPayment.value = Boolean(order.auto_execution_on_payment);
+    autoCloseOnPayment.value = Boolean(order.auto_close_on_payment);
+    targetCurrency.value = order.target_currency || null;
+    targetCurrencyAmount.value = order.target_currency_amount || null;
+    enableCurrency.value = Boolean(order.target_currency);
+    payments.value = [...(order.payments || [])];
+
+    if (enableCurrency.value && !currentFxRate.value) {
+      void ManagerSettingsService.getFxRate().then((rate) => {
+        currentFxRate.value = rate;
+        if (targetCurrency.value === 'EUR' && !rate.eur_byn) targetCurrency.value = 'USD';
+      }).catch((error) => console.warn('Failed to load fx rate on init', error));
+    }
+    if (!installersList.value.length) {
+      void api.getManagerInstallers(1, 100).then((response) => {
+        installersList.value = response.items;
+      }).catch((error) => console.error('Failed to load installers', error));
+    }
+  };
+
+  const currentFormSnapshot = (proposalStatus: string) => JSON.stringify({
+    status: status.value,
+    title: orderTitle.value.trim(),
+    workflowType: workflowType.value,
+    repairMeta: buildRepairMetaPayload(),
+    managerLabels: [...managerLabels.value],
+    nextFollowupDate: nextFollowupDate.value,
+    assessmentDate: assessmentDate.value,
+    installationDate: installationDate.value,
+    comment: comment.value,
+    installerId: installerId.value,
+    customerDeliveryAddress: customerDeliveryAddress.value.trim(),
+    customerBranchId: customerBranchId.value,
+    measurementRequired: measurementRequired.value,
+    measurerId: measurerId.value,
+    measurementResult: measurementResult.value,
+    additionalConditions: additionalConditions.value,
+    proposalStatus,
+    negotiationStatus: negotiationStatus.value,
+    executionStatus: executionStatus.value,
+    executionWithoutPayment: executionWithoutPayment.value,
+    executionWithoutPaymentReason: executionWithoutPaymentReason.value,
+    autoExecutionOnPayment: autoExecutionOnPayment.value,
+    autoCloseOnPayment: autoCloseOnPayment.value,
+    enableCurrency: enableCurrency.value,
+    targetCurrency: targetCurrency.value,
+    targetCurrencyAmount: targetCurrencyAmount.value,
+  });
+
+  const normalizeManagerLabel = (value: string) => value.trim().replace(/\s+/g, ' ');
+  const addManagerLabel = () => {
+    const label = normalizeManagerLabel(managerLabelDraft.value);
+    if (!label) return;
+    const exists = managerLabels.value.some((item) => (
+      item.toLocaleLowerCase('ru-RU') === label.toLocaleLowerCase('ru-RU')
+    ));
+    if (!exists) managerLabels.value.push(label);
+    managerLabelDraft.value = '';
+  };
+  const removeManagerLabel = (label: string) => {
+    managerLabels.value = managerLabels.value.filter((item) => item !== label);
+  };
+
+  const hasDiagnosticServiceLine = () => serviceLines.value.some((line) => /диагност/i.test(line.title || ''));
+  let workflowChangeRequestId = 0;
+  const addDefaultRepairDiagnostic = async (requestId: number) => {
+    if (hasDiagnosticServiceLine()) return;
+    const fallback: ServiceLine = {
+      service_id: null,
+      title: 'Диагностика кондиционера на объекте',
+      quantity: 1,
+      price: 0,
+      cost: 0,
+    };
+    try {
+      const response = await api.listManagerQuickTariffs('диагностика', 'repair' as any, 5);
+      if (requestId !== workflowChangeRequestId || workflowType.value !== 'repair') return;
+      const line = { ...fallback };
+      const option = (response.items || [])[0];
+      if (option) applyTariffTemplateToLine(line, option);
+      serviceLines.value = [line, ...serviceLines.value];
+      setToast('Добавили базовую диагностику для ремонта');
+    } catch (error) {
+      if (requestId !== workflowChangeRequestId || workflowType.value !== 'repair') return;
+      serviceLines.value = [fallback, ...serviceLines.value];
+      setToast(`Не нашли тариф диагностики: ${getApiErrorMessage(error)}`, 'error');
+    }
+  };
+
+  const setWorkflowType = async (next: OrderWorkflowType) => {
+    if (workflowType.value === next) return;
+    const hasScenarioData = productLines.value.length > 0
+      || serviceLines.value.length > 0
+      || Boolean(comment.value.trim())
+      || Boolean(installationDate.value)
+      || Boolean(measurementResult.value.trim());
+    if (hasScenarioData && !await confirmDialog({
+      title: 'Сменить сценарий заказа?',
+      description: 'В заказе уже есть данные. Скрытые разделы сохранятся и останутся доступны после возврата к сценарию.',
+      confirmText: 'Сменить сценарий',
+      variant: 'warning',
+    })) return;
+    const requestId = ++workflowChangeRequestId;
+    workflowType.value = next;
+    serviceTariffOptions.value = [];
+    activeServiceSuggestionIndex.value = null;
+    if (next === 'repair') {
+      repairMeta.value = normalizeRepairMeta(repairMeta.value, { defaultRepairStatus: true });
+      await addDefaultRepairDiagnostic(requestId);
+    }
+  };
+
+  const buildSavePayload = (activeProposalLocked: boolean): ManagerOrderUpdatePayload | null => {
+    localServerErrors.value = {};
+    localFormError.value = '';
+    const errors: Record<string, string> = {};
+    if (!status.value) errors.status = 'Укажите статус';
+    if (assessmentDate.value && installationDate.value && installationDate.value < assessmentDate.value) {
+      errors.installation_date = 'Дата монтажа не может быть раньше даты замера';
+    }
+    const lineError = validateLines();
+    if (lineError) {
+      if (lineError.includes('товар')) errors.products = lineError;
+      else errors.services = lineError;
+    }
+    if (Object.keys(errors).length) {
+      localServerErrors.value = errors;
+      localFormError.value = 'Исправьте ошибки в форме';
+      return null;
+    }
+    if (status.value === 'execution' && total.value <= 0) {
+      localFormError.value = 'Нельзя перевести в монтаж с пустой сметой';
+      return null;
+    }
+    if (status.value === 'execution' && measurementRequired.value && !measurementResult.value.trim()) {
+      localFormError.value = 'Требуется замер: заполните результат замера';
+      return null;
+    }
+    if (enableCurrency.value) {
+      if (!targetCurrency.value) {
+        localFormError.value = 'Выберите валюту сделки';
+        return null;
+      }
+      if (!getActiveFxRate(targetCurrency.value)) {
+        localFormError.value = 'Для выбранной валюты сейчас нет доступного курса';
+        return null;
+      }
+      if (!targetCurrencyAmount.value || targetCurrencyAmount.value <= 0) {
+        localFormError.value = 'Укажите зафиксированную сумму в валюте';
+        return null;
+      }
+    } else if (payments.value.some((payment) => payment.currency !== 'BYN')) {
+      localFormError.value = 'Нельзя отключить валютный режим, пока в заказе есть валютные платежи';
+      return null;
+    }
+    repairMeta.value = buildRepairMetaPayload();
+    const lines = buildLinesPayload();
+    return {
+      status: status.value,
+      title: orderTitle.value,
+      workflow_type: workflowType.value as any,
+      repair_meta: buildRepairMetaPayload() as any,
+      manager_labels: managerLabels.value,
+      next_followup_date: fromLocalDateTimeInput(nextFollowupDate.value),
+      measurement_date: fromLocalDateTimeInput(assessmentDate.value),
+      installation_date: fromLocalDateTimeInput(installationDate.value),
+      comment: comment.value,
+      is_paid: isPaid.value,
+      installer_id: installerId.value,
+      customer_branch_id: customerBranchId.value,
+      customer_delivery_address: customerDeliveryAddress.value,
+      products: activeProposalLocked ? undefined : lines.products,
+      services: activeProposalLocked ? undefined : lines.services,
+      measurement_required: measurementRequired.value,
+      measurer_id: measurerId.value,
+      measurement_result: measurementResult.value,
+      additional_conditions: additionalConditions.value,
+      negotiation_status: status.value === 'negotiation' ? negotiationStatus.value : undefined,
+      execution_status: status.value === 'execution' ? executionStatus.value : undefined,
+      execution_without_payment: status.value === 'execution' ? executionWithoutPayment.value : false,
+      execution_without_payment_reason: status.value === 'execution' && executionWithoutPayment.value
+        ? executionWithoutPaymentReason.value
+        : null,
+      auto_execution_on_payment: autoExecutionOnPayment.value,
+      auto_close_on_payment: status.value === 'execution' ? autoCloseOnPayment.value : false,
+      target_currency: enableCurrency.value ? targetCurrency.value : null,
+      target_currency_amount: enableCurrency.value && targetCurrencyAmount.value
+        ? Number(String(targetCurrencyAmount.value).replace(',', '.'))
+        : null,
+    };
+  };
+
+  return {
+    addManagerLabel,
+    additionalConditions,
+    assessmentDate,
+    autoCloseOnPayment,
+    autoExecutionOnPayment,
+    balanceDue,
+    buildRepairMetaPayload,
+    buildSavePayload,
+    calculatedTargetCurrencyPayments,
+    comment,
+    currentFormSnapshot,
+    currentFxRate,
+    customerBranchId,
+    customerDeliveryAddress,
+    enableCurrency,
+    executionStatus,
+    executionWithoutPayment,
+    executionWithoutPaymentReason,
+    executorOptions,
+    hydrateOrder,
+    installationDate,
+    installerId,
+    isB2cCustomer,
+    isPaid,
+    isRepairWorkflow,
+    localFormError,
+    localServerErrors,
+    managerLabelDraft,
+    managerLabels,
+    measurementRequired,
+    measurementResult,
+    measurerId,
+    negotiationStatus,
+    newBranchAddress,
+    nextFollowupDate,
+    orderTitle,
+    payments,
+    removeManagerLabel,
+    repairMeta,
+    setWorkflowType,
+    showProductLinesSection,
+    status,
+    targetCurrency,
+    targetCurrencyAmount,
+    targetCurrencyBalanceDue,
+    totalPayments,
+    workflowType,
+  };
+};

--- a/manager_frontend/src/composables/useOrderDrawerPersistence.ts
+++ b/manager_frontend/src/composables/useOrderDrawerPersistence.ts
@@ -1,0 +1,165 @@
+import { computed, ref, watch, type Ref } from 'vue';
+import type { ManagerOrderDetailResponse } from '../client';
+import type {
+  OrderDrawerDraft,
+  OrderLogisticsComponent,
+  ProductLine,
+  ProductLogisticsTemplateComponent,
+  ServiceLine,
+} from '../components/orders/order-editor-types';
+
+const createDefaultDrawerSections = () => ({
+  website: false,
+  clientDetails: false,
+  planningDetails: false,
+  repair: true,
+  proposals: false,
+  documents: false,
+  payments: false,
+  execution: false,
+});
+
+export type OrderDrawerSectionsState = ReturnType<typeof createDefaultDrawerSections>;
+
+type UseOrderDrawerPersistenceOptions = {
+  order: Readonly<Ref<ManagerOrderDetailResponse | null>>;
+  activeProposalId: Readonly<Ref<number | null>>;
+  productLines: Ref<ProductLine[]>;
+  serviceLines: Ref<ServiceLine[]>;
+  savedLinesSnapshot: Ref<string>;
+  savedFormSnapshot: Ref<string>;
+  currentLinesSnapshot: () => string;
+  currentFormSnapshot: () => string;
+};
+
+export const useOrderDrawerPersistence = ({
+  order,
+  activeProposalId,
+  productLines,
+  serviceLines,
+  savedLinesSnapshot,
+  savedFormSnapshot,
+  currentLinesSnapshot,
+  currentFormSnapshot,
+}: UseOrderDrawerPersistenceOptions) => {
+  const expandedDrawerSections = ref(createDefaultDrawerSections());
+  const initializedOrderId = ref<number | null>(null);
+  const pendingDraftClearOrderId = ref<number | null>(null);
+  const draftKey = computed(() => (
+    order.value ? `manager_order_drawer_draft_${order.value.id}_${activeProposalId.value || 'default'}` : ''
+  ));
+  const drawerSectionsKey = computed(() => (
+    order.value ? `manager_order_drawer_sections_${order.value.id}` : ''
+  ));
+  const hasUnsavedChanges = computed(() => (
+    Boolean(order.value?.id)
+    && (
+      (Boolean(savedLinesSnapshot.value) && currentLinesSnapshot() !== savedLinesSnapshot.value)
+      || (Boolean(savedFormSnapshot.value) && currentFormSnapshot() !== savedFormSnapshot.value)
+    )
+  ));
+
+  const persistDraft = () => {
+    if (!draftKey.value) return;
+    try {
+      const payload: OrderDrawerDraft = {
+        productLines: productLines.value.map((line) => ({ ...line })),
+        serviceLines: serviceLines.value.map((line) => ({ ...line })),
+      };
+      window.sessionStorage.setItem(draftKey.value, JSON.stringify(payload));
+    } catch (error) {
+      console.warn('Failed to persist order drawer draft', error);
+    }
+  };
+
+  const restoreDraft = () => {
+    if (!draftKey.value) return;
+    try {
+      const raw = window.sessionStorage.getItem(draftKey.value);
+      if (!raw) return;
+      const payload = JSON.parse(raw) as Partial<OrderDrawerDraft>;
+      if (Array.isArray(payload.productLines)) {
+        productLines.value = payload.productLines.map((line) => ({
+          link_id: Number((line as any).link_id || 0) || null,
+          product_id: Number(line.product_id || 0),
+          product_query: String(line.product_query || ''),
+          quantity: Number(line.quantity || 1),
+          price: Number(line.price || 0),
+          cost: Number(line.cost || 0),
+          product_country: (line as any).product_country || null,
+          product_logistics_components: Array.isArray((line as any).product_logistics_components)
+            ? [...((line as any).product_logistics_components as ProductLogisticsTemplateComponent[])]
+            : [],
+          logistics_components: Array.isArray((line as any).logistics_components)
+            ? [...((line as any).logistics_components as OrderLogisticsComponent[])]
+            : null,
+        }));
+      }
+      if (Array.isArray(payload.serviceLines)) {
+        serviceLines.value = payload.serviceLines.map((line) => ({
+          service_id: line.service_id ?? null,
+          title: String(line.title || ''),
+          quantity: Number(line.quantity || 1),
+          price: Number(line.price || 0),
+          cost: Number(line.cost || 0),
+          tariff_id: Number(line.tariff_id || 0) || null,
+          template_short_name: line.template_short_name || null,
+          template_full_description: line.template_full_description || null,
+          template_applied_text: line.template_applied_text || null,
+          description_mode: line.description_mode === 'full' ? 'full' : 'short',
+        }));
+      }
+    } catch (error) {
+      console.warn('Failed to restore order drawer draft', error);
+    }
+  };
+
+  const persistDrawerSections = () => {
+    if (!drawerSectionsKey.value) return;
+    try {
+      window.sessionStorage.setItem(drawerSectionsKey.value, JSON.stringify(expandedDrawerSections.value));
+    } catch (error) {
+      console.warn('Failed to persist order drawer sections', error);
+    }
+  };
+
+  const restoreDrawerSections = (): OrderDrawerSectionsState => {
+    if (!drawerSectionsKey.value) return createDefaultDrawerSections();
+    try {
+      const raw = window.sessionStorage.getItem(drawerSectionsKey.value);
+      if (!raw) return createDefaultDrawerSections();
+      const stored = JSON.parse(raw) as Partial<OrderDrawerSectionsState>;
+      return {
+        ...createDefaultDrawerSections(),
+        ...Object.fromEntries(Object.entries(stored).filter(([, value]) => typeof value === 'boolean')),
+      } as OrderDrawerSectionsState;
+    } catch (error) {
+      console.warn('Failed to restore order drawer sections', error);
+      return createDefaultDrawerSections();
+    }
+  };
+
+  const clearDraft = () => {
+    if (!draftKey.value) return;
+    try {
+      window.sessionStorage.removeItem(draftKey.value);
+    } catch (error) {
+      console.warn('Failed to clear order drawer draft', error);
+    }
+  };
+
+  watch(productLines, persistDraft, { deep: true });
+  watch(serviceLines, persistDraft, { deep: true });
+  watch(expandedDrawerSections, persistDrawerSections, { deep: true });
+
+  return {
+    clearDraft,
+    expandedDrawerSections,
+    hasUnsavedChanges,
+    initializedOrderId,
+    pendingDraftClearOrderId,
+    persistDraft,
+    restoreDraft,
+    restoreDrawerSections,
+  };
+};

--- a/manager_frontend/src/composables/useOrderProposalLifecycle.ts
+++ b/manager_frontend/src/composables/useOrderProposalLifecycle.ts
@@ -1,0 +1,334 @@
+import { computed, ref, type Ref } from 'vue';
+import type {
+  ManagerOrderDetailResponse,
+  OrderProductLineResponse,
+  OrderProposalResponse,
+  OrderServiceLineResponse,
+} from '../client';
+import { ManagerOrdersService } from '../client';
+import { confirmDialog, promptDialog } from '../services/ui-feedback';
+import { getApiErrorMessage } from '../utils/api-errors';
+import { formatMoney } from '../components/orders/order-utils';
+import {
+  isProposalRevisionLocked,
+  normalizeProposalStatus,
+  proposalStatusLabel,
+  type ProposalLifecycleStatus,
+} from '../components/orders/proposal-lifecycle';
+
+type ToastHandler = (message: string, type?: 'success' | 'error') => void;
+
+type UseOrderProposalLifecycleOptions = {
+  order: Readonly<Ref<ManagerOrderDetailResponse | null>>;
+  negotiationStatus: Ref<string>;
+  total: Readonly<Ref<number>>;
+  localFormError: Ref<string>;
+  buildLinesPayload: (proposalId: number | null) => Record<string, unknown>;
+  validateLines: () => string;
+  loadLines: (products: OrderProductLineResponse[], services: OrderServiceLineResponse[]) => void;
+  resetLookupState: () => void;
+  loadSupplyRequests: (orderId: number) => Promise<void>;
+  clearDraft: () => void;
+  currentLinesSnapshot: (proposalId: number | null) => string;
+  savedLinesSnapshot: Ref<string>;
+  setToast: ToastHandler;
+  onUpdated: (order: ManagerOrderDetailResponse) => void;
+  onReload: (orderId: number) => void;
+};
+
+export const useOrderProposalLifecycle = ({
+  order,
+  negotiationStatus,
+  total,
+  localFormError,
+  buildLinesPayload,
+  validateLines,
+  loadLines,
+  resetLookupState,
+  loadSupplyRequests,
+  clearDraft,
+  currentLinesSnapshot,
+  savedLinesSnapshot,
+  setToast,
+  onUpdated,
+  onReload,
+}: UseOrderProposalLifecycleOptions) => {
+  const proposalStatus = ref<ProposalLifecycleStatus>('draft');
+  const activeProposalId = ref<number | null>(null);
+  const proposalActionLoading = ref(false);
+
+  const proposals = computed(() => [...(order.value?.proposals || [])]
+    .filter((proposal) => !proposal.is_archived)
+    .sort((left, right) => (
+      Number(left.sort_order || 0) - Number(right.sort_order || 0)
+      || Number(left.id) - Number(right.id)
+    )));
+  const selectedProposal = computed(() => (
+    proposals.value.find((proposal) => proposal.is_selected)
+    || proposals.value[0]
+    || null
+  ));
+  const activeProposal = computed(() => (
+    proposals.value.find((proposal) => proposal.id === activeProposalId.value)
+    || selectedProposal.value
+  ));
+  const activeProposalStatus = computed(() => (
+    normalizeProposalStatus(activeProposal.value?.status || proposalStatus.value)
+  ));
+  const activeProposalLocked = computed(() => isProposalRevisionLocked(activeProposalStatus.value));
+  const activeProposalLineLabel = computed(() => {
+    const proposal = activeProposal.value;
+    if (!proposal) return 'Предложение не создано';
+    const count = (proposal.product_lines?.length || 0) + (proposal.service_lines?.length || 0);
+    const mod100 = count % 100;
+    const mod10 = count % 10;
+    const noun = mod100 >= 11 && mod100 <= 14
+      ? 'позиций'
+      : mod10 === 1
+        ? 'позиция'
+        : mod10 >= 2 && mod10 <= 4
+          ? 'позиции'
+          : 'позиций';
+    return `${proposal.name} · ${proposalStatusLabel(proposal.status)} · ${count} ${noun} · ${formatMoney(proposal.total_amount || 0)}`;
+  });
+
+  const loadProposalLines = (
+    proposal: OrderProposalResponse | null | undefined,
+    fallbackOrder?: ManagerOrderDetailResponse | null,
+  ) => {
+    if (proposal) {
+      activeProposalId.value = proposal.id;
+      proposalStatus.value = normalizeProposalStatus(proposal.status);
+      loadLines(proposal.product_lines || [], proposal.service_lines || []);
+      return;
+    }
+    activeProposalId.value = null;
+    loadLines(fallbackOrder?.product_lines ?? [], fallbackOrder?.service_lines ?? []);
+  };
+
+  const applyOrderResponse = async (
+    updatedOrder: ManagerOrderDetailResponse,
+    preferredProposalId?: number | null,
+    emitReload = true,
+  ) => {
+    onUpdated(updatedOrder);
+    const nextProposal = preferredProposalId
+      ? (updatedOrder.proposals || []).find((proposal) => proposal.id === preferredProposalId && !proposal.is_archived)
+      : ((updatedOrder.proposals || []).find((proposal) => proposal.is_selected && !proposal.is_archived)
+        || (updatedOrder.proposals || []).find((proposal) => !proposal.is_archived));
+    loadProposalLines(nextProposal || null, updatedOrder);
+    resetLookupState();
+    await loadSupplyRequests(updatedOrder.id);
+    if (emitReload) onReload(updatedOrder.id);
+  };
+
+  const saveCurrentProposalLines = async () => {
+    if (!order.value?.id) return order.value || null;
+    if (activeProposalLocked.value) return order.value;
+    const validationError = validateLines();
+    if (validationError) {
+      localFormError.value = validationError;
+      throw new Error(validationError);
+    }
+    const currentProposalId = activeProposalId.value;
+    const updatedOrder = await ManagerOrdersService.patchManagerOrder(
+      order.value.id,
+      buildLinesPayload(currentProposalId),
+    );
+    clearDraft();
+    await applyOrderResponse(updatedOrder, currentProposalId, false);
+    savedLinesSnapshot.value = currentLinesSnapshot(activeProposalId.value);
+    return updatedOrder;
+  };
+
+  const setActiveProposal = async (proposal: OrderProposalResponse) => {
+    if (!proposal || activeProposalId.value === proposal.id || proposalActionLoading.value) return;
+    proposalActionLoading.value = true;
+    try {
+      await saveCurrentProposalLines();
+    } catch (error) {
+      setToast(`Сначала сохраните текущий вариант: ${getApiErrorMessage(error)}`, 'error');
+      return;
+    } finally {
+      proposalActionLoading.value = false;
+    }
+    loadProposalLines(proposal, order.value);
+    resetLookupState();
+  };
+
+  const createProposal = async () => {
+    if (!order.value?.id || proposalActionLoading.value) return;
+    const name = await promptDialog({
+      title: 'Новое предложение',
+      inputLabel: 'Название',
+      initialValue: `Вариант ${proposals.value.length + 1}`,
+      required: true,
+      confirmText: 'Создать',
+    });
+    if (name === null) return;
+    proposalActionLoading.value = true;
+    try {
+      await saveCurrentProposalLines();
+      const updatedOrder = await ManagerOrdersService.createManagerOrderProposal(order.value.id, { name });
+      const created = updatedOrder.proposals?.[Math.max(0, (updatedOrder.proposals?.length || 1) - 1)] || null;
+      await applyOrderResponse(updatedOrder, created?.id || null);
+      setToast('Предложение создано', 'success');
+    } catch (error) {
+      setToast(`Ошибка создания предложения: ${getApiErrorMessage(error)}`, 'error');
+    } finally {
+      proposalActionLoading.value = false;
+    }
+  };
+
+  const duplicateProposal = async () => {
+    if (!order.value?.id || !activeProposal.value?.id || proposalActionLoading.value) return;
+    const name = await promptDialog({
+      title: 'Копия предложения',
+      inputLabel: 'Название',
+      initialValue: `${activeProposal.value.name} копия`,
+      required: true,
+      confirmText: 'Создать копию',
+    });
+    if (name === null) return;
+    proposalActionLoading.value = true;
+    try {
+      const sourceProposalId = activeProposal.value.id;
+      await saveCurrentProposalLines();
+      const updatedOrder = await ManagerOrdersService.duplicateManagerOrderProposal(order.value.id, sourceProposalId, { name });
+      const created = updatedOrder.proposals?.[Math.max(0, (updatedOrder.proposals?.length || 1) - 1)] || null;
+      await applyOrderResponse(updatedOrder, created?.id || null);
+      setToast('Предложение скопировано', 'success');
+    } catch (error) {
+      setToast(`Ошибка копирования предложения: ${getApiErrorMessage(error)}`, 'error');
+    } finally {
+      proposalActionLoading.value = false;
+    }
+  };
+
+  const renameProposal = async () => {
+    if (!order.value?.id || !activeProposal.value?.id || proposalActionLoading.value) return;
+    const name = await promptDialog({
+      title: 'Переименовать предложение',
+      inputLabel: 'Название',
+      initialValue: activeProposal.value.name,
+      required: true,
+      confirmText: 'Переименовать',
+    });
+    if (name === null || !name.trim()) return;
+    proposalActionLoading.value = true;
+    try {
+      const proposalId = activeProposal.value.id;
+      await saveCurrentProposalLines();
+      const updatedOrder = await ManagerOrdersService.patchManagerOrderProposal(order.value.id, proposalId, { name });
+      await applyOrderResponse(updatedOrder, proposalId);
+      setToast('Название обновлено', 'success');
+    } catch (error) {
+      setToast(`Ошибка переименования: ${getApiErrorMessage(error)}`, 'error');
+    } finally {
+      proposalActionLoading.value = false;
+    }
+  };
+
+  const archiveProposal = async () => {
+    if (!order.value?.id || !activeProposal.value?.id || proposalActionLoading.value) return;
+    if (proposals.value.length <= 1) {
+      setToast('Нельзя удалить единственное предложение', 'error');
+      return;
+    }
+    if (!await confirmDialog({
+      title: 'Архивировать предложение?',
+      description: activeProposal.value.name,
+      confirmText: 'Архивировать',
+      variant: 'warning',
+    })) return;
+    const archivedId = activeProposal.value.id;
+    proposalActionLoading.value = true;
+    try {
+      const updatedOrder = await ManagerOrdersService.archiveManagerOrderProposal(order.value.id, archivedId);
+      const next = (updatedOrder.proposals || []).find((proposal) => proposal.is_selected && !proposal.is_archived)
+        || (updatedOrder.proposals || []).find((proposal) => proposal.id !== archivedId && !proposal.is_archived)
+        || null;
+      await applyOrderResponse(updatedOrder, next?.id || null);
+      setToast('Предложение архивировано', 'success');
+    } catch (error) {
+      setToast(`Ошибка архивации: ${getApiErrorMessage(error)}`, 'error');
+    } finally {
+      proposalActionLoading.value = false;
+    }
+  };
+
+  const selectProposalForOrder = async (proposal?: OrderProposalResponse) => {
+    const target = proposal || activeProposal.value;
+    if (!order.value?.id || !target?.id || target.is_selected || proposalActionLoading.value) return;
+    proposalActionLoading.value = true;
+    try {
+      await saveCurrentProposalLines();
+      const updatedOrder = await ManagerOrdersService.selectManagerOrderProposal(order.value.id, target.id);
+      await applyOrderResponse(updatedOrder, target.id);
+      setToast('Предложение выбрано для заказа', 'success');
+    } catch (error) {
+      setToast(`Ошибка выбора предложения: ${getApiErrorMessage(error)}`, 'error');
+    } finally {
+      proposalActionLoading.value = false;
+    }
+  };
+
+  const changeActiveProposalStatus = async (nextStatus: ProposalLifecycleStatus) => {
+    const proposal = activeProposal.value;
+    if (!order.value?.id || !proposal?.id || proposalActionLoading.value) return;
+    if (nextStatus === activeProposalStatus.value) return;
+    if (nextStatus === 'ready_to_send') {
+      const validationError = validateLines();
+      if (validationError || total.value <= 0) {
+        setToast(validationError || 'Добавьте хотя бы одну позицию с ненулевой суммой', 'error');
+        return;
+      }
+    }
+    if (nextStatus === 'sent' && !await confirmDialog({
+      title: 'Отметить предложение отправленным?',
+      description: 'Используйте это действие, если предложение отправлено не через CRM. Для email используйте основную кнопку отправки.',
+      confirmText: 'Отметить отправленным',
+      variant: 'warning',
+    })) return;
+    if (nextStatus === 'draft' && activeProposalLocked.value && !await confirmDialog({
+      title: 'Вернуть предложение в черновик?',
+      description: 'После этого предложение снова можно будет редактировать.',
+      confirmText: 'Вернуть в черновик',
+      variant: 'warning',
+    })) return;
+    proposalActionLoading.value = true;
+    try {
+      if (nextStatus === 'ready_to_send') await saveCurrentProposalLines();
+      const updatedOrder = await ManagerOrdersService.patchManagerOrderProposal(order.value.id, proposal.id, { status: nextStatus });
+      proposalStatus.value = nextStatus;
+      negotiationStatus.value = updatedOrder.negotiation_status || negotiationStatus.value;
+      await applyOrderResponse(updatedOrder, proposal.id);
+      setToast(`Статус предложения: ${proposalStatusLabel(nextStatus)}`, 'success');
+    } catch (error) {
+      setToast(`Не удалось изменить статус: ${getApiErrorMessage(error)}`, 'error');
+    } finally {
+      proposalActionLoading.value = false;
+    }
+  };
+
+  return {
+    activeProposal,
+    activeProposalId,
+    activeProposalLineLabel,
+    activeProposalLocked,
+    activeProposalStatus,
+    archiveProposal,
+    changeActiveProposalStatus,
+    createProposal,
+    duplicateProposal,
+    loadProposalLines,
+    onProposalClick: (proposal: OrderProposalResponse) => void setActiveProposal(proposal),
+    proposalActionLoading,
+    proposalStatus,
+    proposals,
+    renameProposal,
+    saveCurrentProposalLines,
+    selectProposalForOrder,
+    selectedProposal,
+  };
+};

--- a/manager_frontend/src/composables/useOrderWorkspaceNavigation.ts
+++ b/manager_frontend/src/composables/useOrderWorkspaceNavigation.ts
@@ -1,0 +1,110 @@
+import { nextTick, ref, type Ref } from 'vue';
+import type { ManagerOrderDocumentItem, OrderProposalResponse } from '../client';
+import type { OrderDrawerSectionsState } from './useOrderDrawerPersistence';
+import type { OrderWorkflowType, OrderWorkspaceTarget } from '../components/orders/order-workspace';
+
+type ToastHandler = (message: string, type?: 'success' | 'error') => void;
+type EquipmentPanelHandle = { collapse: () => void; expand: () => Promise<void> | void };
+type DocumentsWorkspaceHandle = { openSend: () => void; openCreate: () => void };
+
+type UseOrderWorkspaceNavigationOptions = {
+  status: Readonly<Ref<string>>;
+  workflowType: Readonly<Ref<OrderWorkflowType>>;
+  expandedSections: Ref<OrderDrawerSectionsState>;
+  equipmentPanelRef: Ref<EquipmentPanelHandle | null>;
+  documentsWorkspaceRef: Ref<DocumentsWorkspaceHandle | null>;
+  setToast: ToastHandler;
+};
+
+export const useOrderWorkspaceNavigation = ({
+  status,
+  workflowType,
+  expandedSections,
+  equipmentPanelRef,
+  documentsWorkspaceRef,
+  setToast,
+}: UseOrderWorkspaceNavigationOptions) => {
+  const executionWorkspaceOpen = ref(false);
+  const activeWorkspaceTarget = ref<OrderWorkspaceTarget | null>(null);
+
+  const resetWorkspaceNavigation = () => {
+    executionWorkspaceOpen.value = false;
+    activeWorkspaceTarget.value = null;
+  };
+
+  const openWorkspaceTarget = async (target: OrderWorkspaceTarget, allowToggle = false) => {
+    const shouldClose = allowToggle && activeWorkspaceTarget.value === target;
+    if (activeWorkspaceTarget.value === 'equipment') equipmentPanelRef.value?.collapse();
+    if (workflowType.value === 'sales_installation' && target !== 'object') {
+      expandedSections.value.proposals = false;
+      expandedSections.value.documents = false;
+      expandedSections.value.payments = false;
+      expandedSections.value.execution = false;
+      executionWorkspaceOpen.value = false;
+    }
+    if (shouldClose) {
+      activeWorkspaceTarget.value = null;
+      return;
+    }
+    if (target !== 'object') activeWorkspaceTarget.value = target;
+    if (target === 'object') expandedSections.value.clientDetails = true;
+    if (target === 'planning') {
+      if (workflowType.value === 'sales_installation') expandedSections.value.proposals = true;
+      if (status.value === 'execution') expandedSections.value.execution = true;
+      else expandedSections.value.planningDetails = true;
+    }
+    if (target === 'proposal') expandedSections.value.proposals = true;
+    if (target === 'documents') expandedSections.value.documents = true;
+    if (target === 'payments') {
+      if (status.value === 'execution') executionWorkspaceOpen.value = true;
+      else expandedSections.value.payments = true;
+    }
+    await nextTick();
+    if (target === 'equipment') {
+      expandedSections.value.proposals = true;
+      await equipmentPanelRef.value?.expand();
+      await nextTick();
+    }
+    const elementId = status.value === 'execution' && target === 'payments'
+      ? 'order-workspace-execution-details'
+      : `order-workspace-${target}`;
+    document.getElementById(elementId)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  };
+
+  const openProposalSend = async (
+    proposal: OrderProposalResponse | null | undefined,
+    documents: ManagerOrderDocumentItem[],
+  ) => {
+    if (!proposal) return;
+    expandedSections.value.documents = true;
+    activeWorkspaceTarget.value = 'documents';
+    await nextTick();
+    const offerExists = documents.some((document) => (
+      document.doc_type === 'offer'
+      && (!document.proposal_id || document.proposal_id === proposal.id)
+    ));
+    if (offerExists) documentsWorkspaceRef.value?.openSend();
+    else {
+      documentsWorkspaceRef.value?.openCreate();
+      setToast('Сначала создайте коммерческое предложение для активного варианта', 'error');
+    }
+    document.getElementById('order-workspace-documents')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  };
+
+  const openDocumentsSend = async () => {
+    expandedSections.value.documents = true;
+    activeWorkspaceTarget.value = 'documents';
+    await nextTick();
+    documentsWorkspaceRef.value?.openSend();
+    document.getElementById('order-workspace-documents')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  };
+
+  return {
+    activeWorkspaceTarget,
+    executionWorkspaceOpen,
+    openDocumentsSend,
+    openProposalSend,
+    openWorkspaceTarget,
+    resetWorkspaceNavigation,
+  };
+};

--- a/manager_frontend/tests/order-commercial-editor.spec.ts
+++ b/manager_frontend/tests/order-commercial-editor.spec.ts
@@ -1,0 +1,117 @@
+import { effectScope, ref, type EffectScope } from 'vue';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ManagerOrderDetailResponse } from '../src/client';
+import { useOrderCommercialEditor } from '../src/composables/useOrderCommercialEditor';
+
+const apiMock = vi.hoisted(() => ({
+  smartSearchProducts: vi.fn(),
+}));
+
+vi.mock('../src/api', () => ({ api: apiMock }));
+vi.mock('../src/services/ui-feedback', () => ({
+  confirmDialog: vi.fn().mockResolvedValue(true),
+}));
+
+const order = ref({ id: 42 } as ManagerOrderDetailResponse);
+let scope: EffectScope;
+
+const createEditor = () => {
+  scope = effectScope();
+  return scope.run(() => useOrderCommercialEditor({
+    order,
+    setToast: vi.fn(),
+    persistDraft: vi.fn(),
+  }))!;
+};
+
+beforeEach(() => {
+  apiMock.smartSearchProducts.mockResolvedValue([]);
+});
+
+afterEach(() => {
+  scope?.stop();
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+describe('useOrderCommercialEditor', () => {
+  it('owns line validation and normalizes the proposal command payload', () => {
+    const editor = createEditor();
+    editor.productLines.value = [{
+      link_id: 5,
+      product_id: 9,
+      product_query: 'Gree Pular',
+      quantity: 2,
+      price: 1_500.4,
+      cost: 1_000.4,
+      logistics_components: [{
+        title: 'Наружный блок',
+        country: '',
+        unit: '',
+        quantity_per_parent: 0,
+        unit_price: -5,
+        kind: 'unknown' as any,
+      }],
+    }];
+    editor.serviceLines.value = [{
+      service_id: 7,
+      title: 'Монтаж',
+      quantity: 1,
+      price: 500,
+      cost: 200,
+    }];
+
+    expect(editor.validateLines()).toBe('');
+    expect(editor.buildLinesPayload(17)).toEqual({
+      products: [{
+        product_id: 9,
+        quantity: 2,
+        price: 1_500,
+        cost: 1_000,
+        logistics_components: [{
+          title: 'Наружный блок',
+          country: 'Китай',
+          unit: 'шт.',
+          quantity_per_parent: 1,
+          unit_price: 0,
+          kind: 'other',
+        }],
+        link_id: 5,
+        proposal_id: 17,
+      }],
+      services: [{
+        service_id: 7,
+        title: 'Монтаж',
+        quantity: 1,
+        price: 500,
+        cost: 200,
+        link_id: null,
+        proposal_id: 17,
+      }],
+    });
+  });
+
+  it('keeps stock filtering and product lookup inside the commercial boundary', async () => {
+    vi.useFakeTimers();
+    apiMock.smartSearchProducts.mockResolvedValue([
+      { id: 1, title: 'Есть на складе', vitebsk_qty: 1, minsk_qty: 0, availability_status: 'in_stock' },
+      { id: 2, title: 'Нет на складе', vitebsk_qty: 0, minsk_qty: 0, availability_status: 'out_of_stock' },
+    ]);
+    const editor = createEditor();
+    editor.productLines.value = [{
+      link_id: null,
+      product_id: 0,
+      product_query: 'Gree',
+      quantity: 1,
+      price: 0,
+      cost: 0,
+    }];
+    editor.searchInStock.value = true;
+    editor.onProductQueryInput(0);
+    await vi.advanceTimersByTimeAsync(450);
+
+    expect(apiMock.smartSearchProducts).toHaveBeenCalledWith('Gree', 20);
+    expect(editor.productOptions.value.map((item) => item.id)).toEqual([1]);
+    expect(editor.productLookupById.value[1]?.title).toBe('Есть на складе');
+  });
+});

--- a/manager_frontend/tests/order-commercial-lines.spec.ts
+++ b/manager_frontend/tests/order-commercial-lines.spec.ts
@@ -1,0 +1,142 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import OrderProductLinesEditor from '../src/components/orders/OrderProductLinesEditor.vue';
+import OrderServiceLinesEditor from '../src/components/orders/OrderServiceLinesEditor.vue';
+import type {
+  ProductLine,
+  ProductOption,
+  ServiceLine,
+} from '../src/components/orders/order-editor-types';
+
+const productLine: ProductLine = {
+  link_id: 301,
+  product_id: 0,
+  product_query: 'Gr',
+  quantity: 1,
+  price: 1_500,
+  cost: 1_000,
+};
+const productOption: ProductOption = {
+  id: 501,
+  title: 'Gree Pular',
+  price: 1_700,
+  cost: 1_100,
+  is_inverter: true,
+  power_cooling: 2.5,
+  availability_status: 'in_stock',
+  vitebsk_qty: 2,
+  minsk_qty: 1,
+};
+const serviceLine: ServiceLine = {
+  service_id: null,
+  title: 'Монтаж',
+  quantity: 1,
+  price: 500,
+  cost: 200,
+};
+const serviceOption = {
+  tariff_id: 91,
+  service_kind: 'installation' as const,
+  short_name: 'Стандартный монтаж',
+  full_description: 'Стандартный монтаж кондиционера с трассой до 3 метров',
+  title: 'Стандартный монтаж',
+  price: 600,
+  category: 'Монтаж',
+  included_route_meters: 3,
+};
+const estimate = {
+  id: 81,
+  title: 'Смета объекта',
+  service_kind: 'installation',
+  currency: 'BYN',
+  subtotal: 1_000,
+  discount_amount: 0,
+  total: 1_000,
+  status: 'draft',
+  created_at: '2026-07-31T10:00:00Z',
+};
+
+const mountedWrappers: VueWrapper[] = [];
+
+afterEach(() => {
+  for (const wrapper of mountedWrappers.splice(0)) wrapper.unmount();
+});
+
+describe('OrderProductLinesEditor', () => {
+  it('renders catalog guidance and delegates product and supply commands', async () => {
+    const supplyBadgeForLine = vi.fn(() => ({
+      label: 'бронь',
+      requestId: 1,
+      status: 'reserved',
+    }));
+    const wrapper = mount(OrderProductLinesEditor, {
+      props: {
+        lines: [
+          { ...productLine },
+          {
+            ...productLine,
+            link_id: 302,
+            product_id: productOption.id,
+            product_query: productOption.title,
+          },
+        ],
+        searchInStock: false,
+        productOptions: [productOption],
+        productLookupById: { [productOption.id]: productOption },
+        productLookupLoading: false,
+        activeSuggestionIndex: 0,
+        supplyActionLoadingLineId: null,
+        supplyBadgeForLine,
+      },
+    });
+    mountedWrappers.push(wrapper);
+
+    expect(wrapper.text()).toContain('Gree Pular');
+    expect(wrapper.text()).toContain('Поставка: бронь');
+    await wrapper.get(`[data-testid="select-product-${productOption.id}"]`).trigger('click');
+    const reserveButtons = wrapper.findAll('button').filter((button) => (
+      button.text().includes('Забронировать')
+    ));
+    await reserveButtons[1]?.trigger('click');
+    await wrapper.get('[data-testid="add-product-line"]').trigger('click');
+
+    expect(wrapper.emitted('select')).toEqual([[{ index: 0, option: productOption }]]);
+    expect(wrapper.emitted('supply')).toEqual([[{
+      line: expect.objectContaining({ link_id: 302 }),
+      intent: 'reserve',
+    }]]);
+    expect(wrapper.emitted('add')).toEqual([[]]);
+  });
+});
+
+describe('OrderServiceLinesEditor', () => {
+  it('delegates tariff selection and estimate import while keeping draft models controlled', async () => {
+    const wrapper = mount(OrderServiceLinesEditor, {
+      props: {
+        lines: [{ ...serviceLine }],
+        editingIndex: 0,
+        showEstimateImport: true,
+        selectedEstimateId: estimate.id,
+        estimateSearchQuery: '',
+        estimateImportMode: 'detailed',
+        descriptionMode: 'short',
+        serviceOptions: [serviceOption],
+        serviceLookupLoading: false,
+        activeSuggestionIndex: 0,
+        estimateOptions: [estimate],
+        estimateOptionsLoading: false,
+        importingEstimate: false,
+        formatServiceKind: () => 'монтаж',
+      },
+    });
+    mountedWrappers.push(wrapper);
+
+    await wrapper.get(`[data-testid="select-service-${serviceOption.tariff_id}"]`).trigger('click');
+    await wrapper.get('[data-testid="import-estimate"]').trigger('click');
+    await wrapper.get('[data-testid="add-service-line"]').trigger('click');
+
+    expect(wrapper.emitted('select')).toEqual([[{ index: 0, option: serviceOption }]]);
+    expect(wrapper.emitted('importEstimate')).toEqual([[]]);
+    expect(wrapper.emitted('add')).toEqual([[]]);
+  });
+});

--- a/manager_frontend/tests/order-customer-context.spec.ts
+++ b/manager_frontend/tests/order-customer-context.spec.ts
@@ -1,0 +1,125 @@
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ManagerOrderDetailResponse } from '../src/client';
+import OrderCustomerContext from '../src/components/orders/OrderCustomerContext.vue';
+
+const apiMock = vi.hoisted(() => ({
+  createManagerCustomerBranch: vi.fn(),
+  getManagerCustomerBranches: vi.fn(),
+  getManagerCustomers: vi.fn(),
+  patchManagerCustomer: vi.fn(),
+  patchManagerOrder: vi.fn(),
+}));
+
+vi.mock('../src/api', () => ({ api: apiMock }));
+
+const order = {
+  id: 42,
+  status: 'new_lead',
+  created_at: '2026-07-31T10:00:00Z',
+  total_amount: 0,
+  total_cost: 0,
+  margin: 0,
+  is_paid: false,
+  customer: {
+    id: 11,
+    type: 'individual',
+    name: 'Анна',
+    phone: '+375291112233',
+    email: 'anna@example.test',
+  },
+  customer_branch: null,
+  product_lines: [],
+  service_lines: [],
+  needs_attention: false,
+  awaiting_measurement: false,
+  client_thinking: false,
+  ready_for_execution: false,
+} as ManagerOrderDetailResponse;
+
+const branches = [
+  {
+    id: 31,
+    customer_id: 11,
+    name: 'Склад',
+    delivery_address: 'Минск, ул. Складская, 1',
+    is_default: true,
+  },
+  {
+    id: 32,
+    customer_id: 11,
+    name: 'Офис',
+    delivery_address: 'Минск, ул. Офисная, 2',
+    is_default: false,
+  },
+];
+
+const mountedWrappers: VueWrapper[] = [];
+
+const mountContext = () => {
+  const wrapper = mount(OrderCustomerContext, {
+    props: {
+      order,
+      deliveryAddress: '',
+      customerBranchId: null,
+      comment: '',
+      expanded: false,
+      newBranchAddress: '',
+    },
+  });
+  mountedWrappers.push(wrapper);
+  return wrapper;
+};
+
+beforeEach(() => {
+  apiMock.getManagerCustomerBranches.mockResolvedValue({ items: branches });
+  apiMock.getManagerCustomers.mockResolvedValue({
+    items: [{ id: 22, name: 'Новый клиент', phone: '+375291234567' }],
+  });
+  apiMock.patchManagerOrder.mockResolvedValue({
+    ...order,
+    customer: { id: 22, name: 'Новый клиент', phone: '+375291234567' },
+  });
+});
+
+afterEach(() => {
+  for (const wrapper of mountedWrappers.splice(0)) wrapper.unmount();
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+describe('OrderCustomerContext', () => {
+  it('loads branches and keeps branch selection coupled to the object address', async () => {
+    const wrapper = mountContext();
+    await flushPromises();
+
+    expect(apiMock.getManagerCustomerBranches).toHaveBeenCalledWith(11);
+    await wrapper.get('button[aria-label="Редактировать объект"]').trigger('click');
+    await wrapper.findAll('button').find((button) => button.text().includes('Выбрать филиал'))?.trigger('click');
+    await wrapper.get('[data-testid="customer-branch"]').setValue('32');
+
+    expect(wrapper.emitted('update:customerBranchId')).toContainEqual([32]);
+    expect(wrapper.emitted('update:deliveryAddress')).toContainEqual(['Минск, ул. Офисная, 2']);
+  });
+
+  it('searches and reassigns the customer through the order API', async () => {
+    vi.useFakeTimers();
+    const wrapper = mountContext();
+    await flushPromises();
+
+    await wrapper.get('button[aria-label="Редактировать клиента"]').trigger('click');
+    await wrapper.findAll('button').find((button) => button.text().includes('Сменить клиента'))?.trigger('click');
+    await wrapper.get('[data-testid="customer-search"]').setValue('Новый');
+    await vi.advanceTimersByTimeAsync(450);
+    await flushPromises();
+    await wrapper.get('[data-testid="assign-customer-22"]').trigger('click');
+    await flushPromises();
+
+    expect(apiMock.getManagerCustomers).toHaveBeenCalledWith(1, 10, 'Новый');
+    expect(apiMock.patchManagerOrder).toHaveBeenCalledWith(42, { customer_id: 22 });
+    expect(wrapper.emitted('updated')?.[0]?.[0]).toEqual(expect.objectContaining({
+      customer: expect.objectContaining({ id: 22 }),
+    }));
+    expect(wrapper.emitted('reload')).toEqual([[42]]);
+  });
+});

--- a/manager_frontend/tests/order-document-status.spec.ts
+++ b/manager_frontend/tests/order-document-status.spec.ts
@@ -1,0 +1,48 @@
+import { effectScope, ref, type EffectScope } from 'vue';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ManagerOrderDetailResponse, PaymentResponse } from '../src/client';
+import { useOrderDocumentStatus } from '../src/composables/useOrderDocumentStatus';
+
+const mailMock = vi.hoisted(() => ({
+  listManagerOrderOutgoingEmails: vi.fn(),
+}));
+
+vi.mock('../src/client', () => ({ ManagerMailService: mailMock }));
+
+let scope: EffectScope;
+
+afterEach(() => {
+  scope?.stop();
+  vi.clearAllMocks();
+});
+
+describe('useOrderDocumentStatus', () => {
+  it('derives sent document types and detects a payment referencing an absent invoice', async () => {
+    const order = ref({
+      id: 42,
+      documents: [{ id: 1, doc_type: 'invoice', number: 'INV-1' }],
+    } as ManagerOrderDetailResponse);
+    const payments = ref([{
+      id: 8,
+      amount: 100,
+      currency: 'BYN',
+      comment: 'Оплата по счету ABC-2',
+    }] as PaymentResponse[]);
+    mailMock.listManagerOrderOutgoingEmails.mockResolvedValue({
+      items: [{
+        id: 9,
+        status: 'sent',
+        created_at: '2026-07-31T10:00:00Z',
+        attachments: [{ filename: 'invoice-INV-1.pdf' }],
+      }],
+    });
+    scope = effectScope();
+    const status = scope.run(() => useOrderDocumentStatus({ order, payments }))!;
+
+    await status.loadOrderEmails(42);
+
+    expect(status.documentEmailStatus.value).toBe('sent');
+    expect(status.sentDocumentTypes.value).toEqual(['invoice']);
+    expect(status.missingReferencedInvoice.value).toBe('ABC-2');
+  });
+});

--- a/manager_frontend/tests/order-documents-workspace.spec.ts
+++ b/manager_frontend/tests/order-documents-workspace.spec.ts
@@ -1,0 +1,82 @@
+import { shallowMount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { ManagerOrderDetailResponse } from '../src/client';
+import OrderDocumentsWorkspace from '../src/components/orders/OrderDocumentsWorkspace.vue';
+
+const documentStubs = {
+  OrderDrawerSection: {
+    name: 'OrderDrawerSection',
+    props: ['summary', 'hasError'],
+    template: '<section><slot /></section>',
+  },
+  OrderDocumentsPanel: true,
+};
+
+const baseOrder = {
+  id: 42,
+  status: 'negotiation',
+  created_at: '2026-07-31T10:00:00Z',
+  total_amount: 3_200,
+  total_cost: 2_000,
+  margin: 1_200,
+  is_paid: false,
+  customer: {
+    id: 11,
+    type: 'individual',
+    name: 'Анна',
+    phone: '+375291112233',
+  },
+  documents: [],
+  product_lines: [],
+  service_lines: [],
+  needs_attention: false,
+  awaiting_measurement: false,
+  client_thinking: false,
+  ready_for_execution: false,
+} as ManagerOrderDetailResponse;
+
+const mountedWrappers: VueWrapper[] = [];
+
+afterEach(() => {
+  for (const wrapper of mountedWrappers.splice(0)) wrapper.unmount();
+});
+
+describe('OrderDocumentsWorkspace', () => {
+  it('keeps customer messaging links next to the document workspace', () => {
+    const wrapper = shallowMount(OrderDocumentsWorkspace, {
+      props: {
+        order: baseOrder,
+        expanded: true,
+        productLines: [],
+        total: 3_200,
+      },
+      global: { stubs: documentStubs },
+    });
+    mountedWrappers.push(wrapper);
+
+    const whatsapp = wrapper.get('a[href^="https://wa.me/"]');
+    expect(whatsapp.attributes('href')).toContain('375291112233');
+    expect(decodeURIComponent(whatsapp.attributes('href'))).toContain('3 200 BYN');
+    expect(wrapper.get('a[href^="viber://"]').attributes('href')).toContain('375291112233');
+  });
+
+  it('marks a company without a base document as incomplete', () => {
+    const wrapper = shallowMount(OrderDocumentsWorkspace, {
+      props: {
+        order: {
+          ...baseOrder,
+          customer: { id: 12, type: 'company', name: 'ООО Климат', inn: '123456789' },
+        } as ManagerOrderDetailResponse,
+        expanded: true,
+        productLines: [],
+        total: 0,
+      },
+      global: { stubs: documentStubs },
+    });
+    mountedWrappers.push(wrapper);
+
+    const section = wrapper.getComponent({ name: 'OrderDrawerSection' });
+    expect(section.props('summary')).toBe('Документов нет');
+    expect(section.props('hasError')).toBe(true);
+  });
+});

--- a/manager_frontend/tests/order-drawer-actions.spec.ts
+++ b/manager_frontend/tests/order-drawer-actions.spec.ts
@@ -1,0 +1,59 @@
+import { ref } from 'vue';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ManagerOrderDetailResponse } from '../src/client';
+import { useOrderDrawerActions } from '../src/composables/useOrderDrawerActions';
+
+const apiMock = vi.hoisted(() => ({ patchManagerOrder: vi.fn() }));
+const ordersMock = vi.hoisted(() => ({ deleteManagerOrder: vi.fn() }));
+const confirmDialog = vi.hoisted(() => vi.fn());
+
+vi.mock('../src/api', () => ({ api: apiMock }));
+vi.mock('../src/client', () => ({ ManagerOrdersService: ordersMock }));
+vi.mock('../src/services/ui-feedback', () => ({ confirmDialog }));
+
+const order = ref({ id: 42, is_on_hold: false } as ManagerOrderDetailResponse);
+
+const createActions = (dirty = false) => {
+  const options = {
+    order,
+    displayOrderTitle: ref('Монтаж в офисе'),
+    hasUnsavedChanges: ref(dirty),
+    localFormError: ref(''),
+    persistDraft: vi.fn(),
+    clearDraft: vi.fn(),
+    setToast: vi.fn(),
+    onBeforeClose: vi.fn(),
+    onModelValue: vi.fn(),
+    onUpdated: vi.fn(),
+    onDeleted: vi.fn(),
+  };
+  return { actions: useOrderDrawerActions(options), options };
+};
+
+afterEach(() => vi.clearAllMocks());
+
+describe('useOrderDrawerActions', () => {
+  it('keeps the drawer open when the manager rejects discarding a dirty draft', async () => {
+    confirmDialog.mockResolvedValue(false);
+    const { actions, options } = createActions(true);
+
+    await actions.closeDrawer();
+
+    expect(options.persistDraft).toHaveBeenCalledOnce();
+    expect(options.clearDraft).not.toHaveBeenCalled();
+    expect(options.onModelValue).not.toHaveBeenCalled();
+  });
+
+  it('updates the hold flag through the order command and reports the new state', async () => {
+    apiMock.patchManagerOrder.mockResolvedValue({ ...order.value, is_on_hold: true });
+    const { actions, options } = createActions();
+
+    await actions.toggleHold();
+
+    expect(apiMock.patchManagerOrder).toHaveBeenCalledWith(42, {
+      is_on_hold: true,
+      on_hold_reason: 'Переговоры / Ручная пауза',
+    });
+    expect(options.onUpdated).toHaveBeenCalledWith(expect.objectContaining({ is_on_hold: true }));
+  });
+});

--- a/manager_frontend/tests/order-drawer-form.spec.ts
+++ b/manager_frontend/tests/order-drawer-form.spec.ts
@@ -1,0 +1,115 @@
+import { effectScope, ref, type EffectScope } from 'vue';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ManagerOrderDetailResponse } from '../src/client';
+import { useOrderDrawerForm } from '../src/composables/useOrderDrawerForm';
+
+const apiMock = vi.hoisted(() => ({
+  getManagerInstallers: vi.fn(),
+  listManagerQuickTariffs: vi.fn(),
+}));
+const settingsMock = vi.hoisted(() => ({ getFxRate: vi.fn() }));
+
+vi.mock('../src/api', () => ({ api: apiMock }));
+vi.mock('../src/client', () => ({ ManagerSettingsService: settingsMock }));
+vi.mock('../src/services/ui-feedback', () => ({
+  confirmDialog: vi.fn().mockResolvedValue(true),
+}));
+
+let scope: EffectScope;
+
+const order = {
+  id: 42,
+  status: 'negotiation',
+  title: 'Монтаж в офисе',
+  workflow_type: 'sales_installation',
+  created_at: '2026-07-31T10:00:00Z',
+  total_amount: 3_500,
+  total_cost: 2_000,
+  margin: 1_500,
+  is_paid: false,
+  manager_labels: ['важный'],
+  comment: 'Позвонить заранее',
+  delivery_address: 'Минск, ул. Ленина, 1',
+  negotiation_status: 'awaiting_offer',
+  product_lines: [],
+  service_lines: [],
+  payments: [],
+  needs_attention: false,
+  awaiting_measurement: false,
+  client_thinking: false,
+  ready_for_execution: false,
+} as ManagerOrderDetailResponse;
+
+const createForm = (validationError = '') => {
+  const productLines = ref([{
+    link_id: null,
+    product_id: 9,
+    product_query: 'Gree Pular',
+    quantity: 1,
+    price: 3_000,
+    cost: 2_000,
+  }]);
+  const serviceLines = ref([{
+    service_id: 7,
+    title: 'Монтаж',
+    quantity: 1,
+    price: 500,
+    cost: 0,
+  }]);
+  scope = effectScope();
+  const buildLinesPayload = vi.fn().mockReturnValue({ products: [{ product_id: 9 }], services: [{ service_id: 7 }] });
+  const form = scope.run(() => useOrderDrawerForm({
+    total: ref(3_500),
+    productLines,
+    serviceLines,
+    serviceTariffOptions: ref([]),
+    activeServiceSuggestionIndex: ref(null),
+    applyTariffTemplateToLine: vi.fn(),
+    buildLinesPayload,
+    validateLines: vi.fn().mockReturnValue(validationError),
+    setToast: vi.fn(),
+  }))!;
+  return { form, buildLinesPayload };
+};
+
+beforeEach(() => {
+  apiMock.getManagerInstallers.mockResolvedValue({ items: [] });
+  apiMock.listManagerQuickTariffs.mockResolvedValue({ items: [] });
+  settingsMock.getFxRate.mockResolvedValue({ usd_byn: 3.2, eur_byn: null });
+});
+
+afterEach(() => {
+  scope?.stop();
+  vi.clearAllMocks();
+});
+
+describe('useOrderDrawerForm', () => {
+  it('hydrates the editable fields and builds the unchanged manager order contract', () => {
+    const { form, buildLinesPayload } = createForm();
+    form.hydrateOrder(order);
+
+    const payload = form.buildSavePayload(false);
+
+    expect(form.orderTitle.value).toBe('Монтаж в офисе');
+    expect(form.customerDeliveryAddress.value).toBe('Минск, ул. Ленина, 1');
+    expect(buildLinesPayload).toHaveBeenCalledOnce();
+    expect(payload).toEqual(expect.objectContaining({
+      status: 'negotiation',
+      title: 'Монтаж в офисе',
+      manager_labels: ['важный'],
+      customer_delivery_address: 'Минск, ул. Ленина, 1',
+      products: [{ product_id: 9 }],
+      services: [{ service_id: 7 }],
+    }));
+  });
+
+  it('keeps commercial validation errors out of the save command', () => {
+    const { form, buildLinesPayload } = createForm('Выберите товар из выпадающего списка');
+    form.hydrateOrder(order);
+
+    expect(form.buildSavePayload(false)).toBeNull();
+    expect(form.localServerErrors.value.products).toBe('Выберите товар из выпадающего списка');
+    expect(form.localFormError.value).toBe('Исправьте ошибки в форме');
+    expect(buildLinesPayload).not.toHaveBeenCalled();
+  });
+});

--- a/manager_frontend/tests/order-drawer-persistence.spec.ts
+++ b/manager_frontend/tests/order-drawer-persistence.spec.ts
@@ -1,0 +1,76 @@
+import { effectScope, nextTick, ref, type EffectScope } from 'vue';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { ManagerOrderDetailResponse } from '../src/client';
+import { useOrderDrawerPersistence } from '../src/composables/useOrderDrawerPersistence';
+
+let scope: EffectScope;
+
+beforeEach(() => window.sessionStorage.clear());
+
+afterEach(() => {
+  scope?.stop();
+  window.sessionStorage.clear();
+});
+
+describe('useOrderDrawerPersistence', () => {
+  it('isolates drafts by order and proposal and restores normalized line values', async () => {
+    const order = ref({ id: 42 } as ManagerOrderDetailResponse);
+    const activeProposalId = ref<number | null>(17);
+    const productLines = ref<any[]>([]);
+    const serviceLines = ref<any[]>([]);
+    scope = effectScope();
+    const persistence = scope.run(() => useOrderDrawerPersistence({
+      order,
+      activeProposalId,
+      productLines,
+      serviceLines,
+      savedLinesSnapshot: ref('saved-lines'),
+      savedFormSnapshot: ref('saved-form'),
+      currentLinesSnapshot: () => 'saved-lines',
+      currentFormSnapshot: () => 'saved-form',
+    }))!;
+
+    productLines.value = [{
+      product_id: 9,
+      product_query: 'Gree Pular',
+      quantity: 1,
+      price: 3_000,
+      cost: 2_000,
+    }];
+    await nextTick();
+
+    const key = 'manager_order_drawer_draft_42_17';
+    expect(window.sessionStorage.getItem(key)).toContain('Gree Pular');
+    productLines.value = [];
+    persistence.restoreDraft();
+    expect(productLines.value[0]).toEqual(expect.objectContaining({
+      product_id: 9,
+      quantity: 1,
+      product_logistics_components: [],
+      logistics_components: null,
+    }));
+  });
+
+  it('persists disclosure state without treating it as a form change', async () => {
+    const order = ref({ id: 43 } as ManagerOrderDetailResponse);
+    scope = effectScope();
+    const persistence = scope.run(() => useOrderDrawerPersistence({
+      order,
+      activeProposalId: ref(null),
+      productLines: ref([]),
+      serviceLines: ref([]),
+      savedLinesSnapshot: ref('same'),
+      savedFormSnapshot: ref('same'),
+      currentLinesSnapshot: () => 'same',
+      currentFormSnapshot: () => 'same',
+    }))!;
+
+    persistence.expandedDrawerSections.value.documents = true;
+    await nextTick();
+
+    expect(JSON.parse(window.sessionStorage.getItem('manager_order_drawer_sections_43') || '{}')).toEqual(
+      expect.objectContaining({ documents: true }),
+    );
+    expect(persistence.hasUnsavedChanges.value).toBe(false);
+  });
+});

--- a/manager_frontend/tests/order-execution-panel.spec.ts
+++ b/manager_frontend/tests/order-execution-panel.spec.ts
@@ -1,0 +1,46 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, describe, expect, it } from 'vitest';
+import OrderExecutionPanel from '../src/components/orders/OrderExecutionPanel.vue';
+
+const mountedWrappers: VueWrapper[] = [];
+const baseProps = {
+  workflowType: 'sales_installation' as const,
+  expanded: true,
+  executionStatus: 'needs_schedule',
+  executionWithoutPayment: false,
+  executionWithoutPaymentReason: '',
+  autoCloseOnPayment: false,
+};
+
+afterEach(() => {
+  for (const wrapper of mountedWrappers.splice(0)) wrapper.unmount();
+});
+
+describe('OrderExecutionPanel', () => {
+  it('uses a select for installation orders and emits the selected stage', async () => {
+    const wrapper = mount(OrderExecutionPanel, { props: baseProps });
+    mountedWrappers.push(wrapper);
+
+    await wrapper.get('[data-testid="execution-status"]').setValue('scheduled');
+
+    expect(wrapper.emitted('update:executionStatus')).toEqual([['scheduled']]);
+  });
+
+  it('uses direct status buttons for repair work and controls debt exceptions', async () => {
+    const wrapper = mount(OrderExecutionPanel, {
+      props: { ...baseProps, workflowType: 'repair' },
+    });
+    mountedWrappers.push(wrapper);
+
+    await wrapper.get('[data-testid="execution-status-work_done"]').trigger('click');
+    await wrapper.get('[data-testid="execution-without-payment"]').setValue(true);
+    await wrapper.setProps({ executionWithoutPayment: true });
+    await wrapper.get('[data-testid="execution-without-payment-reason"]').setValue('Оплата по факту');
+    await wrapper.get('[data-testid="auto-close-on-payment"]').setValue(true);
+
+    expect(wrapper.emitted('update:executionStatus')).toEqual([['work_done']]);
+    expect(wrapper.emitted('update:executionWithoutPayment')).toEqual([[true]]);
+    expect(wrapper.emitted('update:executionWithoutPaymentReason')).toEqual([['Оплата по факту']]);
+    expect(wrapper.emitted('update:autoCloseOnPayment')).toEqual([[true]]);
+  });
+});

--- a/manager_frontend/tests/order-manager-labels.spec.ts
+++ b/manager_frontend/tests/order-manager-labels.spec.ts
@@ -1,0 +1,23 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import OrderManagerLabels from '../src/components/orders/OrderManagerLabels.vue';
+
+describe('OrderManagerLabels', () => {
+  it('adds normalized unique labels and removes them by direct click', async () => {
+    const wrapper = mount(OrderManagerLabels, { props: { modelValue: ['Срочно'] } });
+
+    await wrapper.get('[data-testid="add-manager-label"]').trigger('click');
+    await wrapper.get('[data-testid="manager-label-draft"]').setValue('  срочно  ');
+    await wrapper.get('[data-testid="manager-label-draft"]').trigger('keydown.enter');
+    expect(wrapper.emitted('update:modelValue')).toBeUndefined();
+
+    await wrapper.get('[data-testid="add-manager-label"]').trigger('click');
+    await wrapper.get('[data-testid="manager-label-draft"]').setValue('  Новый   клиент ');
+    await wrapper.get('[data-testid="manager-label-draft"]').trigger('keydown.enter');
+    expect(wrapper.emitted('update:modelValue')).toEqual([[['Срочно', 'Новый клиент']]]);
+
+    await wrapper.setProps({ modelValue: ['Срочно', 'Новый клиент'] });
+    await wrapper.get('button[aria-label="Удалить метку Срочно"]').trigger('click');
+    expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual([['Новый клиент']]);
+  });
+});

--- a/manager_frontend/tests/order-payments-panel.spec.ts
+++ b/manager_frontend/tests/order-payments-panel.spec.ts
@@ -1,0 +1,206 @@
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  BankReceiptResponse,
+  ManagerOrderDetailResponse,
+  PaymentResponse,
+} from '../src/client';
+import { ManagerMailService, ManagerOrdersService } from '../src/client';
+import OrderPaymentsPanel from '../src/components/orders/OrderPaymentsPanel.vue';
+
+vi.mock('../src/client', () => ({
+  ManagerMailService: {
+    listManagerBankReceipts: vi.fn(),
+    attachManagerBankReceipt: vi.fn(),
+  },
+  ManagerOrdersService: {
+    addManagerOrderPayment: vi.fn(),
+    deleteManagerOrderPayment: vi.fn(),
+  },
+}));
+
+const payment: PaymentResponse = {
+  id: 801,
+  amount: 500,
+  currency: 'BYN',
+  date: '2026-07-31T12:00:00Z',
+  type: 'prepayment',
+  created_at: '2026-07-31T12:00:00Z',
+};
+
+const receipt: BankReceiptResponse = {
+  id: 901,
+  status: 'requires_review',
+  operation_type: 'credit',
+  sender_email: 'bank@example.test',
+  subject: 'Поступление',
+  fingerprint: 'receipt-901',
+  received_at: '2026-07-31T11:30:00Z',
+  amount: 1_200,
+  currency: 'BYN',
+  payer_name: 'ООО Климат',
+  payer_unp: '190000001',
+  payment_document_number: '42',
+  payment_purpose: 'Оплата по заказу',
+  raw_body: 'test fixture',
+  created_at: '2026-07-31T11:31:00Z',
+};
+
+const order = {
+  id: 42,
+  status: 'new_lead',
+  created_at: '2026-07-31T10:00:00Z',
+  total_amount: 2_000,
+  total_cost: 1_200,
+  margin: 800,
+  is_paid: false,
+  customer: {
+    id: 11,
+    name: 'ООО Климат',
+    inn: '190000001',
+  },
+  needs_attention: false,
+  awaiting_measurement: false,
+  client_thinking: false,
+  ready_for_execution: false,
+} as ManagerOrderDetailResponse;
+
+const listReceiptsMock = vi.mocked(ManagerMailService.listManagerBankReceipts);
+const attachReceiptMock = vi.mocked(ManagerMailService.attachManagerBankReceipt);
+const addPaymentMock = vi.mocked(ManagerOrdersService.addManagerOrderPayment);
+const deletePaymentMock = vi.mocked(ManagerOrdersService.deleteManagerOrderPayment);
+const mountedWrappers: VueWrapper[] = [];
+
+const mountPanel = (payments: PaymentResponse[] = []) => {
+  const wrapper = mount(OrderPaymentsPanel, {
+    attachTo: document.body,
+    props: {
+      order,
+      expanded: true,
+      payments,
+      enableCurrency: false,
+      targetCurrency: null,
+      targetCurrencyAmount: null,
+      currentFxRate: { usd_byn: 3.25, eur_byn: 3.55, source: 'nbrb' },
+      isB2cCustomer: false,
+      total: 2_000,
+      totalPayments: payments.reduce((sum, item) => sum + item.amount, 0),
+      balanceDue: 1_500,
+      margin: 800,
+      calculatedTargetCurrencyPayments: 0,
+      targetCurrencyBalanceDue: 0,
+    },
+  });
+  mountedWrappers.push(wrapper);
+  return wrapper;
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  listReceiptsMock.mockResolvedValue({ items: [receipt], total: 1 });
+  attachReceiptMock.mockResolvedValue(receipt);
+  addPaymentMock.mockResolvedValue([payment]);
+  deletePaymentMock.mockResolvedValue([]);
+});
+
+afterEach(() => {
+  for (const wrapper of mountedWrappers.splice(0)) wrapper.unmount();
+  document.body.innerHTML = '';
+});
+
+describe('OrderPaymentsPanel', () => {
+  it('loads review candidates by customer UNP and attaches a receipt to the order', async () => {
+    const wrapper = mountPanel();
+    await flushPromises();
+
+    expect(listReceiptsMock).toHaveBeenCalledWith(
+      1,
+      20,
+      'requires_review',
+      order.customer?.inn,
+    );
+    await wrapper.get(`[data-testid="attach-receipt-${receipt.id}"]`).trigger('click');
+    await flushPromises();
+
+    expect(attachReceiptMock).toHaveBeenCalledWith(receipt.id, {
+      order_id: order.id,
+      payment_type: 'postpayment',
+    });
+    expect(wrapper.emitted('reload')).toEqual([[order.id]]);
+    expect(wrapper.emitted('toast')).toContainEqual([{
+      message: 'Поступление прикреплено к заказу',
+      type: 'success',
+    }]);
+    expect(listReceiptsMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('adds a payment and returns the updated payment projection to the drawer', async () => {
+    const wrapper = mountPanel();
+    await flushPromises();
+
+    await wrapper.get('[data-testid="payment-amount"]').setValue('500');
+    await wrapper.get('[data-testid="add-payment"]').trigger('click');
+    await flushPromises();
+
+    expect(addPaymentMock).toHaveBeenCalledWith(order.id, {
+      amount: 500,
+      type: 'prepayment',
+      currency: 'BYN',
+    });
+    expect(wrapper.emitted('update:payments')).toEqual([[[payment]]]);
+    expect(wrapper.emitted('toast')).toContainEqual([{
+      message: 'Платеж добавлен',
+      type: 'success',
+    }]);
+  });
+
+  it('requires an available exchange rate and keeps invalid payments local', async () => {
+    const wrapper = mount(OrderPaymentsPanel, {
+      props: {
+        order,
+        expanded: true,
+        payments: [],
+        enableCurrency: true,
+        targetCurrency: 'EUR',
+        targetCurrencyAmount: null,
+        currentFxRate: { usd_byn: 3.25, eur_byn: null, source: 'manual' },
+        isB2cCustomer: true,
+        total: 2_000,
+        totalPayments: 0,
+        balanceDue: 2_000,
+        margin: 800,
+        calculatedTargetCurrencyPayments: 0,
+        targetCurrencyBalanceDue: 0,
+      },
+    });
+    mountedWrappers.push(wrapper);
+    await flushPromises();
+
+    await wrapper.get('[data-testid="payment-amount"]').setValue('100');
+    await wrapper.get('[data-testid="add-payment"]').trigger('click');
+    await flushPromises();
+
+    expect(addPaymentMock).not.toHaveBeenCalled();
+    expect(wrapper.emitted('toast')).toEqual([[{
+      message: 'Для выбранной валюты нет доступного курса',
+      type: 'error',
+    }]]);
+  });
+
+  it('deletes a payment only after the inline confirmation', async () => {
+    const wrapper = mountPanel([payment]);
+    await flushPromises();
+
+    await wrapper.get('button[title="Удалить платеж"]').trigger('click');
+    expect(deletePaymentMock).not.toHaveBeenCalled();
+    await wrapper.get(`[data-testid="delete-payment-${payment.id}"]`).trigger('click');
+    await flushPromises();
+
+    expect(deletePaymentMock).toHaveBeenCalledWith(order.id, payment.id);
+    expect(wrapper.emitted('update:payments')).toEqual([[[]]]);
+    expect(wrapper.emitted('toast')).toContainEqual([{
+      message: 'Платеж удален',
+      type: 'success',
+    }]);
+  });
+});

--- a/manager_frontend/tests/order-planning-panel.spec.ts
+++ b/manager_frontend/tests/order-planning-panel.spec.ts
@@ -1,0 +1,82 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, describe, expect, it } from 'vitest';
+import OrderPlanningPanel from '../src/components/orders/OrderPlanningPanel.vue';
+
+const installers = [
+  { id: 7, name: 'Иван', is_active: true },
+  { id: 8, name: 'Архивный мастер', is_active: false },
+];
+
+const mountedWrappers: VueWrapper[] = [];
+
+const baseProps = {
+  workflowType: 'sales_installation' as const,
+  executorOptions: installers,
+  customerBranchId: null,
+  newBranchAddress: '',
+  measurementRequired: false,
+  assessmentDate: '',
+  negotiationStatus: 'awaiting_offer',
+  autoExecutionOnPayment: false,
+  detailsExpanded: true,
+  measurerId: null,
+  measurementResult: '',
+  installationDate: '',
+  installerId: null,
+};
+
+afterEach(() => {
+  for (const wrapper of mountedWrappers.splice(0)) wrapper.unmount();
+});
+
+describe('OrderPlanningPanel', () => {
+  it('keeps planning state controlled and asks the parent to enable a measurement', async () => {
+    const wrapper = mount(OrderPlanningPanel, { props: baseProps });
+    mountedWrappers.push(wrapper);
+
+    expect(wrapper.text()).toContain('Замер не требуется');
+    await wrapper.get('[data-testid="enable-measurement"]').trigger('click');
+
+    expect(wrapper.emitted('update:measurementRequired')).toEqual([[true]]);
+  });
+
+  it('uses repair terminology and emits negotiation and executor changes', async () => {
+    const wrapper = mount(OrderPlanningPanel, {
+      props: {
+        ...baseProps,
+        workflowType: 'repair',
+        measurementRequired: true,
+        assessmentDate: '2026-08-01T10:00',
+        customerBranchId: 5,
+      },
+    });
+    mountedWrappers.push(wrapper);
+
+    expect(wrapper.text()).toContain('Диагностика и выезд');
+    expect(wrapper.text()).toContain('Дата диагностики / ремонта');
+    expect(wrapper.text()).toContain('выбран филиал');
+
+    await wrapper.get('[data-testid="negotiation-status"]').setValue('awaiting_visit');
+    await wrapper.get('[data-testid="measurer"]').setValue('7');
+    await wrapper.get('[data-testid="installer"]').setValue('8');
+
+    expect(wrapper.emitted('update:negotiationStatus')).toEqual([['awaiting_visit']]);
+    expect(wrapper.emitted('update:measurerId')).toEqual([[7]]);
+    expect(wrapper.emitted('update:installerId')).toEqual([[8]]);
+  });
+
+  it('surfaces both scheduling validation errors in the extracted section', () => {
+    const wrapper = mount(OrderPlanningPanel, {
+      props: {
+        ...baseProps,
+        measurementRequired: true,
+        measurementError: 'Дата замера обязательна',
+        installationError: 'Монтаж раньше замера',
+      },
+    });
+    mountedWrappers.push(wrapper);
+
+    expect(wrapper.text()).toContain('Дата замера обязательна');
+    expect(wrapper.text()).toContain('Монтаж раньше замера');
+  });
+});

--- a/manager_frontend/tests/order-proposal-lifecycle.spec.ts
+++ b/manager_frontend/tests/order-proposal-lifecycle.spec.ts
@@ -1,0 +1,98 @@
+import { effectScope, ref, type EffectScope } from 'vue';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ManagerOrderDetailResponse } from '../src/client';
+import { useOrderProposalLifecycle } from '../src/composables/useOrderProposalLifecycle';
+
+const ordersMock = vi.hoisted(() => ({
+  patchManagerOrder: vi.fn(),
+  patchManagerOrderProposal: vi.fn(),
+}));
+const dialogMock = vi.hoisted(() => ({
+  confirmDialog: vi.fn().mockResolvedValue(true),
+  promptDialog: vi.fn(),
+}));
+
+vi.mock('../src/client', () => ({ ManagerOrdersService: ordersMock }));
+vi.mock('../src/services/ui-feedback', () => dialogMock);
+
+const proposal = {
+  id: 17,
+  name: 'Основной вариант',
+  status: 'draft',
+  is_selected: true,
+  is_archived: false,
+  sort_order: 0,
+  total_amount: 3_000,
+  product_lines: [],
+  service_lines: [],
+};
+const order = ref({
+  id: 42,
+  proposals: [proposal],
+  product_lines: [],
+  service_lines: [],
+} as ManagerOrderDetailResponse);
+let scope: EffectScope;
+
+const createLifecycle = (overrides: Partial<Parameters<typeof useOrderProposalLifecycle>[0]> = {}) => {
+  scope = effectScope();
+  const options = {
+    order,
+    negotiationStatus: ref('awaiting_offer'),
+    total: ref(3_000),
+    localFormError: ref(''),
+    buildLinesPayload: vi.fn().mockReturnValue({ products: [], services: [] }),
+    validateLines: vi.fn().mockReturnValue(''),
+    loadLines: vi.fn(),
+    resetLookupState: vi.fn(),
+    loadSupplyRequests: vi.fn().mockResolvedValue(undefined),
+    clearDraft: vi.fn(),
+    currentLinesSnapshot: vi.fn().mockReturnValue('snapshot'),
+    savedLinesSnapshot: ref(''),
+    setToast: vi.fn(),
+    onUpdated: vi.fn(),
+    onReload: vi.fn(),
+    ...overrides,
+  };
+  const lifecycle = scope.run(() => useOrderProposalLifecycle(options))!;
+  return { lifecycle, options };
+};
+
+beforeEach(() => {
+  ordersMock.patchManagerOrder.mockResolvedValue(order.value);
+  ordersMock.patchManagerOrderProposal.mockResolvedValue(order.value);
+});
+
+afterEach(() => {
+  scope?.stop();
+  vi.clearAllMocks();
+});
+
+describe('useOrderProposalLifecycle', () => {
+  it('loads the selected proposal and saves its lines as one proposal command', async () => {
+    const { lifecycle, options } = createLifecycle();
+    lifecycle.loadProposalLines(proposal as any, order.value);
+
+    expect(lifecycle.activeProposalId.value).toBe(17);
+    expect(options.loadLines).toHaveBeenCalledWith([], []);
+
+    await lifecycle.saveCurrentProposalLines();
+
+    expect(options.buildLinesPayload).toHaveBeenCalledWith(17);
+    expect(ordersMock.patchManagerOrder).toHaveBeenCalledWith(42, { products: [], services: [] });
+    expect(options.clearDraft).toHaveBeenCalledOnce();
+    expect(options.savedLinesSnapshot.value).toBe('snapshot');
+  });
+
+  it('blocks ready-to-send when the commercial boundary reports invalid lines', async () => {
+    const validateLines = vi.fn().mockReturnValue('Выберите товар');
+    const setToast = vi.fn();
+    const { lifecycle } = createLifecycle({ validateLines, setToast });
+    lifecycle.loadProposalLines(proposal as any, order.value);
+
+    await lifecycle.changeActiveProposalStatus('ready_to_send');
+
+    expect(ordersMock.patchManagerOrderProposal).not.toHaveBeenCalled();
+    expect(setToast).toHaveBeenCalledWith('Выберите товар', 'error');
+  });
+});

--- a/manager_frontend/tests/order-proposal-workspace.spec.ts
+++ b/manager_frontend/tests/order-proposal-workspace.spec.ts
@@ -1,0 +1,79 @@
+import { mount } from '@vue/test-utils';
+import { ref } from 'vue';
+import { describe, expect, it, vi } from 'vitest';
+import OrderProposalWorkspace from '../src/components/orders/OrderProposalWorkspace.vue';
+
+const sectionStub = {
+  name: 'OrderDrawerSection',
+  template: '<section><slot /></section>',
+};
+
+describe('OrderProposalWorkspace', () => {
+  it('keeps locked-revision actions inside the proposal workspace', async () => {
+    const duplicateProposal = vi.fn();
+    const changeActiveProposalStatus = vi.fn();
+    const proposal = {
+      activeProposalLineLabel: ref('Основной · принят'),
+      activeProposal: ref({ id: 17 }),
+      activeProposalLocked: ref(true),
+      activeProposalStatus: ref('approved'),
+      proposals: ref([]),
+      proposalActionLoading: ref(false),
+      duplicateProposal,
+      changeActiveProposalStatus,
+      onProposalClick: vi.fn(),
+      selectProposalForOrder: vi.fn(),
+      createProposal: vi.fn(),
+      renameProposal: vi.fn(),
+      archiveProposal: vi.fn(),
+    } as any;
+    const commercial = {
+      productLines: ref([]),
+      serviceLines: ref([]),
+      searchInStock: ref(false),
+      editingServiceLineIndex: ref(null),
+      showEstimateImport: ref(false),
+      selectedEstimateId: ref(null),
+      estimateSearchQuery: ref(''),
+      estimateImportMode: ref('detailed'),
+      serviceDescriptionMode: ref('short'),
+      productOptions: ref([]),
+      productLookupById: ref({}),
+      productLookupLoading: ref(false),
+      activeSuggestionIndex: ref(null),
+      supplyActionLoadingLineId: ref(null),
+      serviceTariffOptions: ref([]),
+      serviceTariffLookupLoading: ref(false),
+      activeServiceSuggestionIndex: ref(null),
+      estimateOptions: ref([]),
+      estimateOptionsLoading: ref(false),
+      importingEstimate: ref(false),
+      supplyBadgeForLine: vi.fn(),
+    } as any;
+    const wrapper = mount(OrderProposalWorkspace, {
+      props: {
+        commercial,
+        proposal,
+        expanded: true,
+        title: 'Предложения',
+        showProductLines: true,
+        formatServiceKind: (kind?: string | null) => kind || '',
+      },
+      global: {
+        stubs: {
+          OrderDrawerSection: sectionStub,
+          OrderProposalToolbar: true,
+          OrderProductLinesEditor: true,
+          OrderServiceLinesEditor: true,
+        },
+      },
+    });
+
+    expect(wrapper.text()).toContain('принята клиентом');
+    await wrapper.findAll('button').find((button) => button.text().includes('Создать копию'))?.trigger('click');
+    await wrapper.findAll('button').find((button) => button.text().includes('В черновик'))?.trigger('click');
+
+    expect(duplicateProposal).toHaveBeenCalledOnce();
+    expect(changeActiveProposalStatus).toHaveBeenCalledWith('draft');
+  });
+});

--- a/manager_frontend/tests/order-repair-panel.spec.ts
+++ b/manager_frontend/tests/order-repair-panel.spec.ts
@@ -1,0 +1,200 @@
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ManagerOrderDetailResponse } from '../src/client';
+import {
+  ManagerEquipmentService,
+  ManagerOrdersService,
+  ManagerRepairComplaintsService,
+} from '../src/client';
+import OrderRepairEquipmentPanel from '../src/components/orders/OrderRepairEquipmentPanel.vue';
+import OrderRepairPanel from '../src/components/orders/OrderRepairPanel.vue';
+import { emptyRepairMeta } from '../src/components/orders/repair-meta';
+
+vi.mock('../src/client', () => ({
+  ManagerEquipmentService: {
+    listManagerEquipment: vi.fn(),
+    getManagerEquipment: vi.fn(),
+    createManagerEquipment: vi.fn(),
+    createManagerEquipmentHistoryFromRepairOrder: vi.fn(),
+  },
+  ManagerOrdersService: {
+    patchManagerOrder: vi.fn(),
+  },
+  ManagerRepairComplaintsService: {
+    listManagerRepairComplaintPresets: vi.fn(),
+    generateManagerRepairActAiDraft: vi.fn(),
+  },
+}));
+
+const order = {
+  id: 42,
+  status: 'negotiation',
+  title: 'Ремонт кондиционера',
+  created_at: '2026-07-31T10:00:00Z',
+  total_amount: 0,
+  total_cost: 0,
+  margin: 0,
+  is_paid: false,
+  customer: { id: 11, name: 'Анна' },
+  needs_attention: false,
+  awaiting_measurement: false,
+  client_thinking: false,
+  ready_for_execution: false,
+} as ManagerOrderDetailResponse;
+
+const preset = {
+  id: 17,
+  complaint_group: 'cooling',
+  customer_phrase: 'Не холодит',
+  document_wording: 'Оборудование не обеспечивает охлаждение',
+  likely_diagnosis: 'Требуется диагностика холодильного контура',
+  is_favorite: true,
+  created_at: '2026-07-31T10:00:00Z',
+};
+
+const equipment = {
+  id: 71,
+  customer_id: 11,
+  customer_branch_id: null,
+  display_name: 'Gree Pular',
+  brand: 'Gree',
+  model: 'Pular',
+  serial: 'SN-71',
+  created_at: '2026-07-31T10:00:00Z',
+};
+
+const mountedWrappers: VueWrapper[] = [];
+const listPresetsMock = vi.mocked(
+  ManagerRepairComplaintsService.listManagerRepairComplaintPresets,
+);
+const generateDraftMock = vi.mocked(
+  ManagerRepairComplaintsService.generateManagerRepairActAiDraft,
+);
+const patchOrderMock = vi.mocked(ManagerOrdersService.patchManagerOrder);
+const listEquipmentMock = vi.mocked(ManagerEquipmentService.listManagerEquipment);
+const getEquipmentMock = vi.mocked(ManagerEquipmentService.getManagerEquipment);
+const recordHistoryMock = vi.mocked(
+  ManagerEquipmentService.createManagerEquipmentHistoryFromRepairOrder,
+);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  listPresetsMock.mockResolvedValue({ items: [preset], total: 1 } as any);
+  generateDraftMock.mockResolvedValue({
+    repair_meta: { diagnostic_result: 'Недостаточное давление хладагента' },
+    model: 'test-model',
+  });
+  patchOrderMock.mockResolvedValue(order);
+  listEquipmentMock.mockResolvedValue({ items: [equipment], total: 1 } as any);
+  getEquipmentMock.mockResolvedValue({
+    ...equipment,
+    recent_history: [{
+      id: 501,
+      equipment_id: equipment.id,
+      event_type: 'diagnostic',
+      event_date: '2026-07-31T11:00:00Z',
+      diagnostic_result: 'Проверено давление',
+      created_at: '2026-07-31T11:00:00Z',
+    }],
+  } as any);
+  recordHistoryMock.mockResolvedValue({} as any);
+});
+
+afterEach(() => {
+  for (const wrapper of mountedWrappers.splice(0)) wrapper.unmount();
+  document.body.innerHTML = '';
+});
+
+describe('OrderRepairPanel', () => {
+  it('loads the complaint library and applies a controlled preset to repair meta', async () => {
+    const repairMeta = emptyRepairMeta();
+    const wrapper = mount(OrderRepairPanel, {
+      props: {
+        order,
+        orderTitle: order.title || '',
+        measurementResult: '',
+        customerBranchId: null,
+        objectAddress: 'Минск',
+        expanded: true,
+        repairMeta,
+      },
+    });
+    mountedWrappers.push(wrapper);
+    await flushPromises();
+
+    expect(listPresetsMock).toHaveBeenCalledWith('', null, false, false, 100);
+    await wrapper.get(`[data-testid="repair-preset-${preset.id}"]`).trigger('click');
+
+    expect(repairMeta.customer_complaint).toBe(preset.customer_phrase);
+    expect(repairMeta.complaint_official).toBe(preset.document_wording);
+    expect(repairMeta.likely_diagnosis).toBe(preset.likely_diagnosis);
+  });
+
+  it('persists an AI draft through the order command and requests a projection reload', async () => {
+    const repairMeta = emptyRepairMeta();
+    repairMeta.customer_complaint = 'Не холодит';
+    const wrapper = mount(OrderRepairPanel, {
+      props: {
+        order,
+        orderTitle: order.title || '',
+        measurementResult: 'Выезд выполнен',
+        customerBranchId: null,
+        objectAddress: 'Минск',
+        expanded: true,
+        repairMeta,
+      },
+    });
+    mountedWrappers.push(wrapper);
+    await flushPromises();
+
+    await wrapper.get('[data-testid="generate-repair-ai"]').trigger('click');
+    await flushPromises();
+
+    expect(generateDraftMock).toHaveBeenCalledTimes(1);
+    expect(patchOrderMock).toHaveBeenCalledWith(order.id, expect.objectContaining({
+      measurement_result: 'Выезд выполнен',
+      repair_meta: expect.objectContaining({
+        diagnostic_result: 'Недостаточное давление хладагента',
+      }),
+    }));
+    expect(wrapper.emitted('reload')).toEqual([[order.id]]);
+    expect(wrapper.emitted('toast')).toContainEqual([{
+      message: 'Черновик дефектного акта заполнен и сохранен',
+      type: 'success',
+    }]);
+  });
+});
+
+describe('OrderRepairEquipmentPanel', () => {
+  it('loads branch equipment and records history without changing the order status', async () => {
+    const wrapper = mount(OrderRepairEquipmentPanel, {
+      props: {
+        orderId: order.id,
+        orderTitle: order.title || '',
+        customerId: order.customer?.id || null,
+        customerBranchId: null,
+        objectAddress: 'Минск',
+        repairMeta: emptyRepairMeta(),
+      },
+    });
+    mountedWrappers.push(wrapper);
+    await flushPromises();
+
+    expect(listEquipmentMock).toHaveBeenCalledWith(11, null, 1, 50, false);
+    expect(wrapper.text()).toContain('Gree Pular');
+    expect(wrapper.text()).toContain('Проверено давление');
+
+    await wrapper.get('[data-testid="record-repair-history"]').trigger('click');
+    await flushPromises();
+
+    expect(recordHistoryMock).toHaveBeenCalledWith(equipment.id, {
+      order_id: order.id,
+      event_type: null,
+      notes: null,
+    });
+    expect(wrapper.emitted('toast')).toEqual([[{
+      message: 'Событие записано в историю оборудования',
+      type: 'success',
+    }]]);
+  });
+});

--- a/manager_frontend/tests/order-website-intake-panel.spec.ts
+++ b/manager_frontend/tests/order-website-intake-panel.spec.ts
@@ -1,0 +1,96 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { ManagerOrderDetailResponse } from '../src/client';
+import OrderWebsiteIntakePanel from '../src/components/orders/OrderWebsiteIntakePanel.vue';
+
+const order = {
+  id: 42,
+  status: 'new_lead',
+  created_at: '2026-07-31T10:00:00Z',
+  total_amount: 3_200,
+  total_cost: 2_000,
+  margin: 1_200,
+  is_paid: false,
+  customer: {
+    id: 11,
+    name: 'Анна',
+    phone: '+375291112233',
+    email: 'anna@example.test',
+  },
+  product_lines: [{
+    id: 101,
+    product_id: 501,
+    product_title: 'Кондиционер',
+    quantity: 1,
+    price: 3_000,
+    cost: 2_000,
+    line_total: 3_000,
+    is_installation_included: true,
+    installation_price: 300,
+  }],
+  service_lines: [{
+    id: 102,
+    service_title: 'Доставка',
+    quantity: 1,
+    price: 200,
+    cost: 0,
+    line_total: 200,
+  }],
+  needs_attention: false,
+  awaiting_measurement: false,
+  client_thinking: false,
+  ready_for_execution: false,
+} as ManagerOrderDetailResponse;
+
+const mountedWrappers: VueWrapper[] = [];
+
+afterEach(() => {
+  for (const wrapper of mountedWrappers.splice(0)) wrapper.unmount();
+});
+
+describe('OrderWebsiteIntakePanel', () => {
+  it('renders the immutable website intake summary and delegates copy actions', async () => {
+    const wrapper = mount(OrderWebsiteIntakePanel, {
+      props: {
+        order,
+        expanded: true,
+        deliveryAddress: 'Минск, пр-т Победителей, 1',
+        comment: 'Позвонить перед доставкой',
+      },
+    });
+    mountedWrappers.push(wrapper);
+
+    expect(wrapper.text()).toContain('2 поз.');
+    expect(wrapper.text()).toContain('Кондиционер');
+    expect(wrapper.text()).toContain('Монтаж включен');
+    expect(wrapper.text()).toContain('Доставка');
+    expect(wrapper.text()).toContain('Позвонить перед доставкой');
+
+    const copyButtons = wrapper.findAll('button').filter((button) => (
+      button.text().includes('Телефон') || button.text().includes('Адрес')
+    ));
+    await copyButtons[0]?.trigger('click');
+    await copyButtons[1]?.trigger('click');
+
+    expect(wrapper.emitted('copy')).toEqual([
+      [{ value: '+375291112233', label: 'Телефон' }],
+      [{ value: 'Минск, пр-т Победителей, 1', label: 'Адрес' }],
+    ]);
+  });
+
+  it('keeps the section disclosure controlled by the parent', async () => {
+    const wrapper = mount(OrderWebsiteIntakePanel, {
+      props: {
+        order,
+        expanded: false,
+        deliveryAddress: '',
+        comment: '',
+      },
+    });
+    mountedWrappers.push(wrapper);
+
+    expect(wrapper.text()).not.toContain('Состав заказа');
+    await wrapper.get('button[aria-expanded="false"]').trigger('click');
+    expect(wrapper.emitted('update:expanded')).toEqual([[true]]);
+  });
+});

--- a/manager_frontend/tests/order-workspace-navigation.spec.ts
+++ b/manager_frontend/tests/order-workspace-navigation.spec.ts
@@ -1,0 +1,58 @@
+import { ref } from 'vue';
+import { describe, expect, it, vi } from 'vitest';
+import { useOrderWorkspaceNavigation } from '../src/composables/useOrderWorkspaceNavigation';
+
+const sections = () => ({
+  website: false,
+  clientDetails: false,
+  planningDetails: false,
+  repair: true,
+  proposals: false,
+  documents: false,
+  payments: false,
+  execution: false,
+});
+
+const createNavigation = (status = 'negotiation') => {
+  const documentsWorkspaceRef = ref({ openSend: vi.fn(), openCreate: vi.fn() });
+  const equipmentPanelRef = ref({ collapse: vi.fn(), expand: vi.fn() });
+  const setToast = vi.fn();
+  const expandedSections = ref(sections());
+  const navigation = useOrderWorkspaceNavigation({
+    status: ref(status),
+    workflowType: ref('sales_installation'),
+    expandedSections,
+    equipmentPanelRef,
+    documentsWorkspaceRef,
+    setToast,
+  });
+  return { navigation, expandedSections, documentsWorkspaceRef, setToast };
+};
+
+describe('useOrderWorkspaceNavigation', () => {
+  it('opens one sales workspace target and supports direct toggle close', async () => {
+    const { navigation, expandedSections } = createNavigation();
+
+    await navigation.openWorkspaceTarget('proposal', true);
+    expect(navigation.activeWorkspaceTarget.value).toBe('proposal');
+    expect(expandedSections.value.proposals).toBe(true);
+
+    await navigation.openWorkspaceTarget('proposal', true);
+    expect(navigation.activeWorkspaceTarget.value).toBeNull();
+  });
+
+  it('routes proposal sending to create or send based on an existing offer', async () => {
+    const { navigation, documentsWorkspaceRef, setToast } = createNavigation();
+    const proposal = { id: 17 } as any;
+
+    await navigation.openProposalSend(proposal, []);
+    expect(documentsWorkspaceRef.value.openCreate).toHaveBeenCalledOnce();
+    expect(setToast).toHaveBeenCalledWith(
+      'Сначала создайте коммерческое предложение для активного варианта',
+      'error',
+    );
+
+    await navigation.openProposalSend(proposal, [{ doc_type: 'offer', proposal_id: 17 }] as any);
+    expect(documentsWorkspaceRef.value.openSend).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary
- reduce `OrderEditDrawer.vue` from 4,206 lines to a 640-line orchestration shell
- extract payments, intake/planning, repair, commercial lines, customer context, execution, documents and proposal workspaces
- move state, persistence, lifecycle, navigation and actions into focused composables
- add component and logic coverage for every extracted boundary

## Validation
- `npm run test:components` (18 files, 39 tests)
- `npm run test:ui-logic`
- `npm run build`

## Compatibility
No API or database contract changes. Existing Manager behavior and generated client remain unchanged.