### PR TITLE
Add trusted public storefront context

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,12 @@ CORS_ORIGINS=["https://mvn.by","https://dev.mvn.by","http://localhost:4321"]
 WEBSITE_URL=http://localhost:4321
 # Public storefront base URL used by backend catalog freshness purges.
 PUBLIC_SITE_URL=https://mvn.by
+# Optional rollout gate for a second storefront. Keep blank while only the
+# canonical MVN storefront is active. The same 32+ byte random secret is held
+# only by air-api and the trusted mvn-web server/edge runtime.
+STOREFRONT_CONTEXT_SIGNING_SECRET=
+STOREFRONT_CONTEXT_PREVIOUS_SIGNING_SECRET=
+STOREFRONT_CONTEXT_MAX_AGE_SECONDS=300
 
 # --- Standalone storefront catalog synchronization ---
 # Use a narrowly scoped token with Actions access to the private mvn-web repo.

--- a/core/config.py
+++ b/core/config.py
@@ -115,6 +115,35 @@ class Settings(BaseSettings):
     STATIC_DIR: str = "static"
     UPLOAD_DIR: str = "static/uploads"
     PUBLIC_SITE_URL: str = "https://mvn.by"
+    # Optional shared secret for a trusted storefront SSR/proxy. When unset,
+    # public writes keep using the canonical MVN storefront; a request that
+    # tries to select another storefront still fails closed.
+    STOREFRONT_CONTEXT_SIGNING_SECRET: str = ""
+    STOREFRONT_CONTEXT_PREVIOUS_SIGNING_SECRET: str = ""
+    STOREFRONT_CONTEXT_MAX_AGE_SECONDS: int = 300
+
+    @field_validator(
+        "STOREFRONT_CONTEXT_SIGNING_SECRET",
+        "STOREFRONT_CONTEXT_PREVIOUS_SIGNING_SECRET",
+    )
+    @classmethod
+    def _validate_storefront_context_secret(cls, value: str) -> str:
+        normalized = str(value or "")
+        if normalized and len(normalized.encode("utf-8")) < 32:
+            raise ValueError(
+                "STOREFRONT_CONTEXT_SIGNING_SECRET must contain at least 32 bytes"
+            )
+        return normalized
+
+    @field_validator("STOREFRONT_CONTEXT_MAX_AGE_SECONDS")
+    @classmethod
+    def _validate_storefront_context_max_age(cls, value: int) -> int:
+        normalized = int(value)
+        if normalized < 30 or normalized > 900:
+            raise ValueError(
+                "STOREFRONT_CONTEXT_MAX_AGE_SECONDS must be between 30 and 900"
+            )
+        return normalized
 
     # Product media storage. Default stays local so CI/deploy do not require
     # R2/S3 secrets unless PRODUCT_MEDIA_STORAGE_PROVIDER is changed.

--- a/core/tenant_scope.py
+++ b/core/tenant_scope.py
@@ -1,10 +1,15 @@
-"""Trusted tenant-scope dependencies for the single-tenant rollout stage."""
+"""Trusted tenant/storefront dependencies for public and internal callers."""
 
-from fastapi import Depends
+from fastapi import Depends, Header, HTTPException, Request, Response, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from core.config import settings
 from core.database import get_session
 from services.tenant_scope_service import SystemTenantScopeResolver, TenantScope
+from services.storefront_context_service import StorefrontContextService
+from services.storefront_context_signature_service import (
+    StorefrontContextSignatureService,
+)
 
 
 async def get_system_tenant_scope(
@@ -12,3 +17,85 @@ async def get_system_tenant_scope(
 ) -> TenantScope:
     """Resolve the canonical MVN scope without accepting client-owned input."""
     return await SystemTenantScopeResolver.resolve(session)
+
+
+async def get_public_tenant_scope(
+    request: Request,
+    response: Response,
+    session: AsyncSession = Depends(get_session),
+    storefront_host: str | None = Header(
+        default=None,
+        alias="X-MVN-Storefront-Host",
+    ),
+    storefront_timestamp: str | None = Header(
+        default=None,
+        alias="X-MVN-Storefront-Timestamp",
+    ),
+    storefront_signature: str | None = Header(
+        default=None,
+        alias="X-MVN-Storefront-Signature",
+    ),
+) -> TenantScope:
+    """Resolve public provenance without trusting browser-owned tenant IDs.
+
+    No headers preserves the current canonical MVN behaviour. Selecting any
+    other active storefront requires the complete short-lived HMAC envelope
+    produced by a trusted website server or edge proxy.
+    """
+
+    supplied = (
+        storefront_host is not None,
+        storefront_timestamp is not None,
+        storefront_signature is not None,
+    )
+    if not any(supplied):
+        return await SystemTenantScopeResolver.resolve(session)
+    if not all(supplied):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Incomplete storefront context",
+        )
+
+    primary_secret = settings.STOREFRONT_CONTEXT_SIGNING_SECRET
+    if not primary_secret:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid storefront context",
+        )
+
+    try:
+        timestamp = int(str(storefront_timestamp))
+        hostname = StorefrontContextSignatureService.verify_any(
+            secrets=(
+                primary_secret,
+                settings.STOREFRONT_CONTEXT_PREVIOUS_SIGNING_SECRET,
+            ),
+            timestamp=timestamp,
+            method=request.method,
+            path=request.url.path,
+            hostname=str(storefront_host),
+            signature=str(storefront_signature),
+            max_age_seconds=settings.STOREFRONT_CONTEXT_MAX_AGE_SECONDS,
+        )
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid storefront context",
+        ) from exc
+
+    context = await StorefrontContextService.resolve_by_host(session, hostname)
+    if context is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Storefront is unavailable",
+        )
+    # Signed projections vary by a trusted header rather than by URL. Never
+    # let a shared browser/CDN cache replay one storefront into another.
+    response.headers["Cache-Control"] = "private, no-store"
+    response.headers["CDN-Cache-Control"] = "no-store"
+    response.headers["Vary"] = "X-MVN-Storefront-Host"
+    return TenantScope(
+        tenant_id=context.tenant_id,
+        storefront_id=context.storefront_id,
+        is_system=context.tenant_is_system,
+    )

--- a/crud/tenancy.py
+++ b/crud/tenancy.py
@@ -20,6 +20,7 @@ class StorefrontContextRow:
     city: str | None
     default_locale: str
     currency: str
+    tenant_is_system: bool = False
 
 
 @dataclass(frozen=True)
@@ -144,4 +145,44 @@ class TenancyDAO:
             city=storefront.city,
             default_locale=storefront.default_locale,
             currency=storefront.currency,
+            tenant_is_system=bool(tenant.is_system),
+        )
+
+    @staticmethod
+    async def get_active_storefront_by_scope(
+        session: AsyncSession,
+        *,
+        tenant_id: int,
+        storefront_id: int,
+    ) -> StorefrontContextRow | None:
+        statement = (
+            select(Tenant, Storefront, StorefrontDomain)
+            .join(Storefront, Storefront.tenant_id == Tenant.id)
+            .join(StorefrontDomain, StorefrontDomain.storefront_id == Storefront.id)
+            .where(
+                Tenant.id == tenant_id,
+                Tenant.status == "active",
+                Storefront.id == storefront_id,
+                Storefront.status == "active",
+                StorefrontDomain.status == "active",
+                StorefrontDomain.is_primary.is_(True),
+            )
+        )
+        row = (await session.execute(statement)).first()
+        if row is None:
+            return None
+
+        tenant, storefront, domain = row
+        return StorefrontContextRow(
+            tenant_id=int(tenant.id),
+            tenant_slug=tenant.slug,
+            tenant_kind=tenant.kind,
+            storefront_id=int(storefront.id),
+            storefront_slug=storefront.slug,
+            storefront_name=storefront.display_name,
+            hostname=domain.hostname,
+            city=storefront.city,
+            default_locale=storefront.default_locale,
+            currency=storefront.currency,
+            tenant_is_system=bool(tenant.is_system),
         )

--- a/docs/storefront-context-contract.md
+++ b/docs/storefront-context-contract.md
@@ -1,0 +1,99 @@
+# Trusted public storefront context
+
+## Purpose
+
+Public Lead and Order provenance must come from the storefront serving the
+request, never from a browser-provided tenant or storefront ID. The canonical
+MVN website keeps working without extra headers. A second storefront is enabled
+only through a short-lived context signed by its trusted SSR or edge proxy.
+
+## Request envelope
+
+The trusted runtime sends all three headers:
+
+- `X-MVN-Storefront-Host`: normalized public hostname, for example
+  `orsha.mvn.by`;
+- `X-MVN-Storefront-Timestamp`: Unix timestamp in seconds;
+- `X-MVN-Storefront-Signature`: `v1=<lowercase sha256 hex>`.
+
+The HMAC-SHA256 input is UTF-8 text with no trailing newline:
+
+```text
+v1
+<timestamp>
+<UPPERCASE HTTP method>
+<request path beginning with />
+<lowercase IDNA hostname without port or trailing dot>
+```
+
+The signing key is `STOREFRONT_CONTEXT_SIGNING_SECRET` and must contain at
+least 32 bytes. The API accepts a timestamp no more than
+`STOREFRONT_CONTEXT_MAX_AGE_SECONDS` in the past or future; the allowed range
+for that setting is 30–900 seconds.
+
+Signatures are bound to method, path and hostname. Query parameters and request
+bodies are deliberately excluded: this envelope selects public provenance; it
+does not replace endpoint validation, idempotency or authentication.
+
+## Fail-closed behaviour
+
+- no context headers: resolve canonical active `mvn/main` exactly as before;
+- incomplete, malformed, expired or forged envelope: `401`;
+- envelope supplied while signing is not configured securely: `401`;
+- valid signature for an unknown, disabled or non-public hostname: `404`;
+- valid context: resolve the active `StorefrontDomain -> Storefront -> Tenant`
+  relation and pass the resulting immutable `TenantScope` to the command.
+
+Neither `tenant_id` nor `storefront_id` is accepted from public payloads. The
+public `GET /api/v1/storefront/context` projection exposes slugs, branding
+identity, domain, city, locale and currency, but no internal IDs.
+
+## Proxy boundary
+
+The browser must not know the signing secret. A non-canonical storefront sends
+browser writes to a same-origin server route; that trusted route strips any
+incoming `X-MVN-Storefront-*` headers, signs the API target itself and forwards
+the request. Direct client-controlled headers are not authority.
+
+The same rule applies to server-rendered catalog and configuration reads. Edge
+or SSR logs must not record the secret or the complete signature envelope.
+Every successfully signed API response is marked `Cache-Control: private,
+no-store` and `CDN-Cache-Control: no-store`; shared caching belongs behind the
+same-origin storefront runtime and must be keyed by storefront identity.
+
+The current key is platform-wide and is suitable only for MVN-owned runtimes.
+Do not distribute it to an external tenant. Before an external white-label
+runtime is operated outside MVN-controlled infrastructure, replace this key
+with a per-runtime credential/key ID or keep signing in one centrally managed
+edge boundary.
+
+## Rotation without downtime
+
+1. Generate a new random secret of at least 32 bytes.
+2. Deploy the API with the new value in
+   `STOREFRONT_CONTEXT_SIGNING_SECRET` and the old value in
+   `STOREFRONT_CONTEXT_PREVIOUS_SIGNING_SECRET`.
+3. Switch every trusted storefront runtime to the new primary secret.
+4. Verify both Lead and Order canaries and wait longer than the maximum
+   signature lifetime.
+5. Clear `STOREFRONT_CONTEXT_PREVIOUS_SIGNING_SECRET` from the API.
+
+The previous key is accepted only while a non-empty primary key is configured.
+Clearing the primary key is the fail-closed kill switch and disables signed
+context even if a stale previous-key variable remains in the environment.
+
+Never reuse `SECRET_KEY`, bot credentials or a Cloudflare token for this
+contract.
+
+## Canary gate
+
+Before enabling traffic for a second storefront:
+
+1. create its `Storefront` and primary active `StorefrontDomain`;
+2. call `GET /api/v1/storefront/context` with a valid signed envelope and check
+   the expected slug, hostname, city, locale and currency;
+3. create one test Lead and one test Order through the same trusted proxy;
+4. verify their persisted `tenant_id/storefront_id` pair and Manager visibility;
+5. repeat each mutation with a forged signature and verify `401` with no row;
+6. test rollback by removing the new domain from routing while keeping
+   canonical `mvn/main` healthy.

--- a/docs/tenant-scope-rollout.md
+++ b/docs/tenant-scope-rollout.md
@@ -44,16 +44,25 @@ membership role is authoritative; a role stored in an old token is ignored.
 Until the Manager UI has an explicit tenant switcher, zero or more than one
 active membership candidate fails closed with `403`.
 
-Before a second storefront is enabled, this temporary resolver must be replaced:
+Canonical MVN fallback remains available for compatibility. A second
+storefront now uses the signed server-to-server contract documented in
+[`storefront-context-contract.md`](storefront-context-contract.md). Public Lead
+and Order endpoints accept only that complete short-lived envelope when
+selecting a non-canonical storefront; internal IDs and unsigned host headers
+remain untrusted.
 
-- public requests need a trusted proxy or signed server-to-server storefront
-  context;
+Before a second storefront receives traffic, the remaining consumers must use
+the same boundary:
+
+- storefront catalog/config requests must pass through its trusted proxy or
+  signed server runtime;
 - Manager needs an explicit, server-validated membership selector before one
   user may actively work in more than one tenant;
 - scheduled integrations need a tenant-bound server configuration.
 
 Plain `X-Tenant-*`, `X-Storefront-*`, query/body fields, `Origin`, or an
-untrusted forwarded host are not accepted as authority.
+untrusted forwarded host are not accepted as authority. Only the versioned
+`X-MVN-Storefront-*` HMAC envelope is authoritative.
 
 ## Constructor contract
 

--- a/manager_frontend/src/client/index.ts
+++ b/manager_frontend/src/client/index.ts
@@ -463,6 +463,7 @@ export type { PublicProductCollectionPlacementResponse } from './models/PublicPr
 export type { PublicProductCollectionResponse } from './models/PublicProductCollectionResponse';
 export type { PublicRelatedSeriesResponse } from './models/PublicRelatedSeriesResponse';
 export type { PublicSeriesPageResponse } from './models/PublicSeriesPageResponse';
+export type { PublicStorefrontContextResponse } from './models/PublicStorefrontContextResponse';
 export type { RepairDiagnosticLeadResponse } from './models/RepairDiagnosticLeadResponse';
 export type { ServiceResponse } from './models/ServiceResponse';
 export type { SpecRegistryItemResponse } from './models/SpecRegistryItemResponse';

--- a/manager_frontend/src/client/models/PublicStorefrontContextResponse.ts
+++ b/manager_frontend/src/client/models/PublicStorefrontContextResponse.ts
@@ -1,0 +1,15 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type PublicStorefrontContextResponse = {
+    tenant_slug: string;
+    tenant_kind: string;
+    storefront_slug: string;
+    display_name: string;
+    hostname: string;
+    city?: (string | null);
+    default_locale: string;
+    currency: string;
+};
+

--- a/manager_frontend/src/client/services/ApiService.ts
+++ b/manager_frontend/src/client/services/ApiService.ts
@@ -22,6 +22,7 @@ import type { PublicContactLeadPayload } from '../models/PublicContactLeadPayloa
 import type { PublicContactLeadResponse } from '../models/PublicContactLeadResponse';
 import type { PublicProductCollectionPlacementResponse } from '../models/PublicProductCollectionPlacementResponse';
 import type { PublicSeriesPageResponse } from '../models/PublicSeriesPageResponse';
+import type { PublicStorefrontContextResponse } from '../models/PublicStorefrontContextResponse';
 import type { RepairDiagnosticLeadResponse } from '../models/RepairDiagnosticLeadResponse';
 import type { ServiceResponse } from '../models/ServiceResponse';
 import type { SpecRegistryResponse } from '../models/SpecRegistryResponse';
@@ -294,15 +295,26 @@ export class ApiService {
     /**
      * Create Public Contact Lead
      * @param requestBody
+     * @param xMvnStorefrontHost
+     * @param xMvnStorefrontTimestamp
+     * @param xMvnStorefrontSignature
      * @returns PublicContactLeadResponse Successful Response
      * @throws ApiError
      */
     public static createPublicContactLead(
         requestBody: PublicContactLeadPayload,
+        xMvnStorefrontHost?: (string | null),
+        xMvnStorefrontTimestamp?: (string | null),
+        xMvnStorefrontSignature?: (string | null),
     ): CancelablePromise<PublicContactLeadResponse> {
         return __request(OpenAPI, {
             method: 'POST',
             url: '/api/v1/leads/contact',
+            headers: {
+                'X-MVN-Storefront-Host': xMvnStorefrontHost,
+                'X-MVN-Storefront-Timestamp': xMvnStorefrontTimestamp,
+                'X-MVN-Storefront-Signature': xMvnStorefrontSignature,
+            },
             body: requestBody,
             mediaType: 'application/json',
             errors: {
@@ -314,18 +326,27 @@ export class ApiService {
      * Create Installation Estimate Lead
      * @param idempotencyKey
      * @param formData
+     * @param xMvnStorefrontHost
+     * @param xMvnStorefrontTimestamp
+     * @param xMvnStorefrontSignature
      * @returns InstallationEstimateLeadResponse Successful Response
      * @throws ApiError
      */
     public static createInstallationEstimateLead(
         idempotencyKey: string,
         formData: Body_create_installation_estimate_lead,
+        xMvnStorefrontHost?: (string | null),
+        xMvnStorefrontTimestamp?: (string | null),
+        xMvnStorefrontSignature?: (string | null),
     ): CancelablePromise<InstallationEstimateLeadResponse> {
         return __request(OpenAPI, {
             method: 'POST',
             url: '/api/v1/leads/installation-estimate',
             headers: {
                 'Idempotency-Key': idempotencyKey,
+                'X-MVN-Storefront-Host': xMvnStorefrontHost,
+                'X-MVN-Storefront-Timestamp': xMvnStorefrontTimestamp,
+                'X-MVN-Storefront-Signature': xMvnStorefrontSignature,
             },
             formData: formData,
             mediaType: 'multipart/form-data',
@@ -340,15 +361,26 @@ export class ApiService {
     /**
      * Create Product Availability Lead
      * @param requestBody
+     * @param xMvnStorefrontHost
+     * @param xMvnStorefrontTimestamp
+     * @param xMvnStorefrontSignature
      * @returns ProductAvailabilityLeadResponse Successful Response
      * @throws ApiError
      */
     public static createProductAvailabilityLead(
         requestBody: ProductAvailabilityLeadPayload,
+        xMvnStorefrontHost?: (string | null),
+        xMvnStorefrontTimestamp?: (string | null),
+        xMvnStorefrontSignature?: (string | null),
     ): CancelablePromise<ProductAvailabilityLeadResponse> {
         return __request(OpenAPI, {
             method: 'POST',
             url: '/api/v1/leads/product-availability',
+            headers: {
+                'X-MVN-Storefront-Host': xMvnStorefrontHost,
+                'X-MVN-Storefront-Timestamp': xMvnStorefrontTimestamp,
+                'X-MVN-Storefront-Signature': xMvnStorefrontSignature,
+            },
             body: requestBody,
             mediaType: 'application/json',
             errors: {
@@ -359,15 +391,26 @@ export class ApiService {
     /**
      * Create Repair Diagnostic Lead
      * @param formData
+     * @param xMvnStorefrontHost
+     * @param xMvnStorefrontTimestamp
+     * @param xMvnStorefrontSignature
      * @returns RepairDiagnosticLeadResponse Successful Response
      * @throws ApiError
      */
     public static createRepairDiagnosticLead(
         formData: Body_create_repair_diagnostic_lead,
+        xMvnStorefrontHost?: (string | null),
+        xMvnStorefrontTimestamp?: (string | null),
+        xMvnStorefrontSignature?: (string | null),
     ): CancelablePromise<RepairDiagnosticLeadResponse> {
         return __request(OpenAPI, {
             method: 'POST',
             url: '/api/v1/leads/repair-diagnostic',
+            headers: {
+                'X-MVN-Storefront-Host': xMvnStorefrontHost,
+                'X-MVN-Storefront-Timestamp': xMvnStorefrontTimestamp,
+                'X-MVN-Storefront-Signature': xMvnStorefrontSignature,
+            },
             formData: formData,
             mediaType: 'multipart/form-data',
             errors: {
@@ -380,15 +423,26 @@ export class ApiService {
      * Create a new order from website.
      * Accepts customer information and cart items.
      * @param requestBody
+     * @param xMvnStorefrontHost
+     * @param xMvnStorefrontTimestamp
+     * @param xMvnStorefrontSignature
      * @returns OrderResponse Successful Response
      * @throws ApiError
      */
     public static createOrder(
         requestBody: OrderPayload,
+        xMvnStorefrontHost?: (string | null),
+        xMvnStorefrontTimestamp?: (string | null),
+        xMvnStorefrontSignature?: (string | null),
     ): CancelablePromise<OrderResponse> {
         return __request(OpenAPI, {
             method: 'POST',
             url: '/api/v1/orders',
+            headers: {
+                'X-MVN-Storefront-Host': xMvnStorefrontHost,
+                'X-MVN-Storefront-Timestamp': xMvnStorefrontTimestamp,
+                'X-MVN-Storefront-Signature': xMvnStorefrontSignature,
+            },
             body: requestBody,
             mediaType: 'application/json',
             errors: {
@@ -743,6 +797,32 @@ export class ApiService {
             path: {
                 'surface_key': surfaceKey,
                 'slot_key': slotKey,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Get Public Storefront Context
+     * @param xMvnStorefrontHost
+     * @param xMvnStorefrontTimestamp
+     * @param xMvnStorefrontSignature
+     * @returns PublicStorefrontContextResponse Successful Response
+     * @throws ApiError
+     */
+    public static getPublicStorefrontContext(
+        xMvnStorefrontHost?: (string | null),
+        xMvnStorefrontTimestamp?: (string | null),
+        xMvnStorefrontSignature?: (string | null),
+    ): CancelablePromise<PublicStorefrontContextResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v1/storefront/context',
+            headers: {
+                'X-MVN-Storefront-Host': xMvnStorefrontHost,
+                'X-MVN-Storefront-Timestamp': xMvnStorefrontTimestamp,
+                'X-MVN-Storefront-Signature': xMvnStorefrontSignature,
             },
             errors: {
                 422: `Validation Error`,

--- a/openapi.json
+++ b/openapi.json
@@ -2456,15 +2456,65 @@
         ],
         "summary": "Create Public Contact Lead",
         "operationId": "create_public_contact_lead",
+        "parameters": [
+          {
+            "name": "X-MVN-Storefront-Host",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Mvn-Storefront-Host"
+            }
+          },
+          {
+            "name": "X-MVN-Storefront-Timestamp",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Mvn-Storefront-Timestamp"
+            }
+          },
+          {
+            "name": "X-MVN-Storefront-Signature",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Mvn-Storefront-Signature"
+            }
+          }
+        ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/PublicContactLeadPayload"
               }
             }
-          },
-          "required": true
+          }
         },
         "responses": {
           "200": {
@@ -2509,6 +2559,54 @@
               "maxLength": 128,
               "pattern": "^[A-Za-z0-9._:-]+$",
               "title": "Idempotency-Key"
+            }
+          },
+          {
+            "name": "X-MVN-Storefront-Host",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Mvn-Storefront-Host"
+            }
+          },
+          {
+            "name": "X-MVN-Storefront-Timestamp",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Mvn-Storefront-Timestamp"
+            }
+          },
+          {
+            "name": "X-MVN-Storefront-Signature",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Mvn-Storefront-Signature"
             }
           }
         ],
@@ -2563,15 +2661,65 @@
         ],
         "summary": "Create Product Availability Lead",
         "operationId": "create_product_availability_lead",
+        "parameters": [
+          {
+            "name": "X-MVN-Storefront-Host",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Mvn-Storefront-Host"
+            }
+          },
+          {
+            "name": "X-MVN-Storefront-Timestamp",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Mvn-Storefront-Timestamp"
+            }
+          },
+          {
+            "name": "X-MVN-Storefront-Signature",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Mvn-Storefront-Signature"
+            }
+          }
+        ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/ProductAvailabilityLeadPayload"
               }
             }
-          },
-          "required": true
+          }
         },
         "responses": {
           "200": {
@@ -2605,15 +2753,65 @@
         ],
         "summary": "Create Repair Diagnostic Lead",
         "operationId": "create_repair_diagnostic_lead",
+        "parameters": [
+          {
+            "name": "X-MVN-Storefront-Host",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Mvn-Storefront-Host"
+            }
+          },
+          {
+            "name": "X-MVN-Storefront-Timestamp",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Mvn-Storefront-Timestamp"
+            }
+          },
+          {
+            "name": "X-MVN-Storefront-Signature",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Mvn-Storefront-Signature"
+            }
+          }
+        ],
         "requestBody": {
+          "required": true,
           "content": {
             "multipart/form-data": {
               "schema": {
                 "$ref": "#/components/schemas/Body_create_repair_diagnostic_lead"
               }
             }
-          },
-          "required": true
+          }
         },
         "responses": {
           "200": {
@@ -2648,15 +2846,65 @@
         "summary": "Create Order",
         "description": "Create a new order from website.\nAccepts customer information and cart items.",
         "operationId": "create_order",
+        "parameters": [
+          {
+            "name": "X-MVN-Storefront-Host",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Mvn-Storefront-Host"
+            }
+          },
+          {
+            "name": "X-MVN-Storefront-Timestamp",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Mvn-Storefront-Timestamp"
+            }
+          },
+          {
+            "name": "X-MVN-Storefront-Signature",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Mvn-Storefront-Signature"
+            }
+          }
+        ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/OrderPayload"
               }
             }
-          },
-          "required": true
+          }
         },
         "responses": {
           "200": {
@@ -3740,6 +3988,88 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/PublicProductCollectionPlacementResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/storefront/context": {
+      "get": {
+        "tags": [
+          "api",
+          "api"
+        ],
+        "summary": "Get Public Storefront Context",
+        "operationId": "get_public_storefront_context",
+        "parameters": [
+          {
+            "name": "X-MVN-Storefront-Host",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Mvn-Storefront-Host"
+            }
+          },
+          {
+            "name": "X-MVN-Storefront-Timestamp",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Mvn-Storefront-Timestamp"
+            }
+          },
+          {
+            "name": "X-MVN-Storefront-Signature",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Mvn-Storefront-Signature"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicStorefrontContextResponse"
                 }
               }
             }
@@ -51036,6 +51366,60 @@
           "series"
         ],
         "title": "PublicSeriesPageResponse"
+      },
+      "PublicStorefrontContextResponse": {
+        "properties": {
+          "tenant_slug": {
+            "type": "string",
+            "title": "Tenant Slug"
+          },
+          "tenant_kind": {
+            "type": "string",
+            "title": "Tenant Kind"
+          },
+          "storefront_slug": {
+            "type": "string",
+            "title": "Storefront Slug"
+          },
+          "display_name": {
+            "type": "string",
+            "title": "Display Name"
+          },
+          "hostname": {
+            "type": "string",
+            "title": "Hostname"
+          },
+          "city": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "City"
+          },
+          "default_locale": {
+            "type": "string",
+            "title": "Default Locale"
+          },
+          "currency": {
+            "type": "string",
+            "title": "Currency"
+          }
+        },
+        "type": "object",
+        "required": [
+          "tenant_slug",
+          "tenant_kind",
+          "storefront_slug",
+          "display_name",
+          "hostname",
+          "default_locale",
+          "currency"
+        ],
+        "title": "PublicStorefrontContextResponse"
       },
       "RepairDiagnosticLeadResponse": {
         "properties": {

--- a/routers/api.py
+++ b/routers/api.py
@@ -9,6 +9,7 @@ from routers.api_leads import router as leads_router
 from routers.api_orders import router as orders_router
 from routers.api_products import router as products_router
 from routers.api_proxy import router as proxy_router
+from routers.api_storefront import router as storefront_router
 from routers.api_yandex_business import router as yandex_business_router
 
 router = APIRouter(prefix="/api", tags=["api"])
@@ -20,4 +21,5 @@ router.include_router(orders_router)
 router.include_router(products_router)
 router.include_router(proxy_router)
 router.include_router(product_collections_router)
+router.include_router(storefront_router)
 router.include_router(yandex_business_router)

--- a/routers/api_leads.py
+++ b/routers/api_leads.py
@@ -9,7 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from core.config import settings
 from core.database import get_session
-from core.tenant_scope import get_system_tenant_scope
+from core.tenant_scope import get_public_tenant_scope
 from schemas_installation_estimate import (
     InstallationEstimateLeadPayload,
     InstallationEstimateLeadResponse,
@@ -71,7 +71,7 @@ async def installation_estimate_form_payload(
 async def create_public_contact_lead(
     payload: PublicContactLeadPayload,
     session: AsyncSession = Depends(get_session),
-    tenant_scope: TenantScope = Depends(get_system_tenant_scope),
+    tenant_scope: TenantScope = Depends(get_public_tenant_scope),
 ):
     return await WebsiteLeadService.create_contact_lead(
         session,
@@ -110,7 +110,7 @@ async def create_installation_estimate_lead(
     facade: Optional[List[UploadFile]] = File(default=None),
     power_supply: Optional[List[UploadFile]] = File(default=None),
     session: AsyncSession = Depends(get_session),
-    tenant_scope: TenantScope = Depends(get_system_tenant_scope),
+    tenant_scope: TenantScope = Depends(get_public_tenant_scope),
 ):
     try:
         uploads = await InstallationEstimateLeadService.collect_uploads(
@@ -149,7 +149,7 @@ async def create_installation_estimate_lead(
 async def create_product_availability_lead(
     payload: ProductAvailabilityLeadPayload,
     session: AsyncSession = Depends(get_session),
-    tenant_scope: TenantScope = Depends(get_system_tenant_scope),
+    tenant_scope: TenantScope = Depends(get_public_tenant_scope),
 ):
     try:
         return await WebsiteLeadService.create_product_availability_lead(
@@ -175,7 +175,7 @@ async def create_repair_diagnostic_lead(
     error_display: Optional[List[UploadFile]] = File(default=None),
     leak_place: Optional[List[UploadFile]] = File(default=None),
     session: AsyncSession = Depends(get_session),
-    tenant_scope: TenantScope = Depends(get_system_tenant_scope),
+    tenant_scope: TenantScope = Depends(get_public_tenant_scope),
 ):
     try:
         parsed_payload = RepairDiagnosticService.parse_payload(payload)

--- a/routers/api_orders.py
+++ b/routers/api_orders.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from core.database import get_session
-from core.tenant_scope import get_system_tenant_scope
+from core.tenant_scope import get_public_tenant_scope
 from schemas import OrderPayload, OrderResponse, PublicOrderPricingErrorResponse
 from services.installation_pricing_service import InstallationPricingError
 from services.website_order_service import WebsiteOrderService
@@ -27,7 +27,7 @@ router = APIRouter(tags=["api"])
 async def create_order(
     payload: OrderPayload,
     session: AsyncSession = Depends(get_session),
-    tenant_scope: TenantScope = Depends(get_system_tenant_scope),
+    tenant_scope: TenantScope = Depends(get_public_tenant_scope),
 ):
     """
     Create a new order from website.

--- a/routers/api_storefront.py
+++ b/routers/api_storefront.py
@@ -1,0 +1,42 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from core.database import get_session
+from core.tenant_scope import get_public_tenant_scope
+from models.tenancy import TenantScope
+from schemas_tenancy import PublicStorefrontContextResponse
+from services.storefront_context_service import StorefrontContextService
+
+
+router = APIRouter(tags=["api"])
+
+
+@router.get(
+    "/v1/storefront/context",
+    response_model=PublicStorefrontContextResponse,
+    operation_id="get_public_storefront_context",
+)
+async def get_public_storefront_context(
+    session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_public_tenant_scope),
+) -> PublicStorefrontContextResponse:
+    context = await StorefrontContextService.resolve_by_scope(
+        session,
+        tenant_id=tenant_scope.tenant_id,
+        storefront_id=tenant_scope.storefront_id,
+    )
+    if context is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Storefront is unavailable",
+        )
+    return PublicStorefrontContextResponse(
+        tenant_slug=context.tenant_slug,
+        tenant_kind=context.tenant_kind,
+        storefront_slug=context.storefront_slug,
+        display_name=context.storefront_name,
+        hostname=context.hostname,
+        city=context.city,
+        default_locale=context.default_locale,
+        currency=context.currency,
+    )

--- a/schemas_tenancy.py
+++ b/schemas_tenancy.py
@@ -1,0 +1,12 @@
+from pydantic import BaseModel
+
+
+class PublicStorefrontContextResponse(BaseModel):
+    tenant_slug: str
+    tenant_kind: str
+    storefront_slug: str
+    display_name: str
+    hostname: str
+    city: str | None = None
+    default_locale: str
+    currency: str

--- a/services/storefront_context_service.py
+++ b/services/storefront_context_service.py
@@ -28,6 +28,7 @@ class StorefrontContext:
     city: str | None
     default_locale: str
     currency: str
+    tenant_is_system: bool = False
 
 
 class StorefrontContextService:
@@ -73,6 +74,23 @@ class StorefrontContextService:
     ) -> StorefrontContext | None:
         hostname = cls.normalize_hostname(raw_host)
         row = await TenancyDAO.get_active_storefront_by_hostname(session, hostname)
+        if row is None:
+            return None
+        return StorefrontContext(**asdict(row))
+
+    @classmethod
+    async def resolve_by_scope(
+        cls,
+        session: AsyncSession,
+        *,
+        tenant_id: int,
+        storefront_id: int,
+    ) -> StorefrontContext | None:
+        row = await TenancyDAO.get_active_storefront_by_scope(
+            session,
+            tenant_id=tenant_id,
+            storefront_id=storefront_id,
+        )
         if row is None:
             return None
         return StorefrontContext(**asdict(row))

--- a/services/storefront_context_signature_service.py
+++ b/services/storefront_context_signature_service.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import hmac
+import time
+from hashlib import sha256
+from typing import Iterable
+
+from services.storefront_context_service import StorefrontContextService
+
+
+class InvalidStorefrontContextSignature(ValueError):
+    pass
+
+
+class StorefrontContextSignatureService:
+    """Sign the storefront hostname selected by a trusted website runtime."""
+
+    VERSION = "v1"
+
+    @classmethod
+    def canonical_message(
+        cls,
+        *,
+        timestamp: int,
+        method: str,
+        path: str,
+        hostname: str,
+    ) -> bytes:
+        normalized_hostname = StorefrontContextService.normalize_hostname(hostname)
+        normalized_method = str(method or "").strip().upper()
+        normalized_path = str(path or "").strip()
+        if not normalized_method or not normalized_path.startswith("/"):
+            raise InvalidStorefrontContextSignature(
+                "Storefront context request target is invalid"
+            )
+        return (
+            f"{cls.VERSION}\n{int(timestamp)}\n{normalized_method}\n"
+            f"{normalized_path}\n{normalized_hostname}"
+        ).encode("utf-8")
+
+    @classmethod
+    def sign(
+        cls,
+        *,
+        secret: str,
+        timestamp: int,
+        method: str,
+        path: str,
+        hostname: str,
+    ) -> str:
+        normalized_secret = str(secret or "")
+        if len(normalized_secret.encode("utf-8")) < 32:
+            raise InvalidStorefrontContextSignature(
+                "Storefront context signing secret is not configured securely"
+            )
+        digest = hmac.new(
+            normalized_secret.encode("utf-8"),
+            cls.canonical_message(
+                timestamp=timestamp,
+                method=method,
+                path=path,
+                hostname=hostname,
+            ),
+            sha256,
+        ).hexdigest()
+        return f"{cls.VERSION}={digest}"
+
+    @classmethod
+    def verify(
+        cls,
+        *,
+        secret: str,
+        timestamp: int,
+        method: str,
+        path: str,
+        hostname: str,
+        signature: str,
+        max_age_seconds: int,
+        now: int | None = None,
+    ) -> str:
+        normalized_secret = str(secret or "")
+        if len(normalized_secret.encode("utf-8")) < 32:
+            raise InvalidStorefrontContextSignature(
+                "Storefront context signing secret is not configured securely"
+            )
+
+        max_age = int(max_age_seconds)
+        if max_age <= 0:
+            raise InvalidStorefrontContextSignature(
+                "Storefront context signature lifetime is invalid"
+            )
+        current_timestamp = int(time.time()) if now is None else int(now)
+        signed_timestamp = int(timestamp)
+        if abs(current_timestamp - signed_timestamp) > max_age:
+            raise InvalidStorefrontContextSignature(
+                "Storefront context signature has expired"
+            )
+
+        normalized_hostname = StorefrontContextService.normalize_hostname(hostname)
+        expected = cls.sign(
+            secret=normalized_secret,
+            timestamp=signed_timestamp,
+            method=method,
+            path=path,
+            hostname=normalized_hostname,
+        )
+        if not hmac.compare_digest(expected, str(signature or "")):
+            raise InvalidStorefrontContextSignature(
+                "Storefront context signature is invalid"
+            )
+        return normalized_hostname
+
+    @classmethod
+    def verify_any(
+        cls,
+        *,
+        secrets: Iterable[str],
+        timestamp: int,
+        method: str,
+        path: str,
+        hostname: str,
+        signature: str,
+        max_age_seconds: int,
+        now: int | None = None,
+    ) -> str:
+        configured = [str(secret or "") for secret in secrets if str(secret or "")]
+        if not configured:
+            raise InvalidStorefrontContextSignature(
+                "Storefront context signing secret is not configured securely"
+            )
+
+        for secret in configured:
+            try:
+                return cls.verify(
+                    secret=secret,
+                    timestamp=timestamp,
+                    method=method,
+                    path=path,
+                    hostname=hostname,
+                    signature=signature,
+                    max_age_seconds=max_age_seconds,
+                    now=now,
+                )
+            except InvalidStorefrontContextSignature:
+                continue
+        raise InvalidStorefrontContextSignature(
+            "Storefront context signature is invalid"
+        )

--- a/tests/integration/test_public_storefront_context.py
+++ b/tests/integration/test_public_storefront_context.py
@@ -1,0 +1,255 @@
+import time
+
+import pytest
+from sqlmodel import select
+
+from core.config import settings
+from models import Lead, Order, Product
+from models.tenancy import Storefront, StorefrontDomain
+from services.storefront_context_signature_service import (
+    StorefrontContextSignatureService,
+)
+
+
+_PATH = "/api/v1/leads/contact"
+_SECRET = "test-storefront-secret-at-least-32-bytes"
+
+
+async def _seed_secondary_storefront(db) -> Storefront:
+    storefront = Storefront(
+        id=2,
+        tenant_id=1,
+        slug="orsha",
+        display_name="MVN Орша",
+        status="active",
+        city="Орша",
+        is_default=False,
+    )
+    db.add(storefront)
+    await db.flush()
+    db.add(
+        StorefrontDomain(
+            storefront_id=int(storefront.id),
+            hostname="orsha.internal.mvn.by",
+            status="active",
+            is_primary=True,
+        )
+    )
+    await db.commit()
+    return storefront
+
+
+def _headers(
+    *,
+    path: str = _PATH,
+    method: str = "POST",
+    signature: str | None = None,
+) -> dict[str, str]:
+    timestamp = int(time.time())
+    return {
+        "X-MVN-Storefront-Host": "orsha.internal.mvn.by",
+        "X-MVN-Storefront-Timestamp": str(timestamp),
+        "X-MVN-Storefront-Signature": signature
+        or StorefrontContextSignatureService.sign(
+            secret=_SECRET,
+            timestamp=timestamp,
+            method=method,
+            path=path,
+            hostname="orsha.internal.mvn.by",
+        ),
+    }
+
+
+def _payload() -> dict[str, str]:
+    return {
+        "name": "Пилот Орша",
+        "phone": "+375 (29) 111-22-33",
+        "address": "Орша",
+        "message": "Проверка второй витрины",
+    }
+
+
+@pytest.mark.asyncio
+async def test_signed_context_routes_public_lead_to_secondary_storefront(
+    async_client,
+    db,
+    monkeypatch,
+):
+    storefront = await _seed_secondary_storefront(db)
+    monkeypatch.setattr(settings, "STOREFRONT_CONTEXT_SIGNING_SECRET", _SECRET)
+
+    response = await async_client.post(_PATH, json=_payload(), headers=_headers())
+
+    assert response.status_code == 200
+    lead = await db.get(Lead, response.json()["lead_id"])
+    assert lead is not None
+    assert (lead.tenant_id, lead.storefront_id) == (1, storefront.id)
+
+
+@pytest.mark.asyncio
+async def test_signed_context_routes_public_order_to_secondary_storefront(
+    async_client,
+    db,
+    monkeypatch,
+):
+    storefront = await _seed_secondary_storefront(db)
+    product = Product(
+        title="Storefront context product",
+        slug="storefront-context-product",
+        price=2100,
+        is_published=True,
+    )
+    db.add(product)
+    await db.commit()
+    await db.refresh(product)
+    monkeypatch.setattr(settings, "STOREFRONT_CONTEXT_SIGNING_SECRET", _SECRET)
+
+    response = await async_client.post(
+        "/api/v1/orders",
+        json={
+            "customer": {
+                "name": "Покупатель Орша",
+                "phone": "+375291112234",
+                "email": "orsha@example.test",
+                "address": "Орша",
+                "type": "individual",
+            },
+            "items": [
+                {
+                    "product_id": product.id,
+                    "quantity": 1,
+                    "with_installation": False,
+                    "installation_options": [],
+                }
+            ],
+            "comment": "Проверка provenance заказа",
+        },
+        headers=_headers(path="/api/v1/orders"),
+    )
+
+    assert response.status_code == 200
+    order = await db.get(Order, response.json()["id"])
+    assert order is not None
+    assert (order.tenant_id, order.storefront_id) == (1, storefront.id)
+
+
+@pytest.mark.asyncio
+async def test_signed_context_exposes_public_storefront_dto_without_ids(
+    async_client,
+    db,
+    monkeypatch,
+):
+    await _seed_secondary_storefront(db)
+    monkeypatch.setattr(settings, "STOREFRONT_CONTEXT_SIGNING_SECRET", _SECRET)
+    path = "/api/v1/storefront/context"
+
+    response = await async_client.get(
+        path,
+        headers=_headers(path=path, method="GET"),
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "tenant_slug": "mvn",
+        "tenant_kind": "operator",
+        "storefront_slug": "orsha",
+        "display_name": "MVN Орша",
+        "hostname": "orsha.internal.mvn.by",
+        "city": "Орша",
+        "default_locale": "ru-BY",
+        "currency": "BYN",
+    }
+    assert "tenant_id" not in response.json()
+    assert "storefront_id" not in response.json()
+    assert response.headers["cache-control"] == "private, no-store"
+    assert response.headers["cdn-cache-control"] == "no-store"
+    assert response.headers["vary"] == "X-MVN-Storefront-Host"
+
+
+@pytest.mark.asyncio
+async def test_unsigned_host_header_cannot_select_secondary_storefront(
+    async_client,
+    db,
+):
+    await _seed_secondary_storefront(db)
+
+    response = await async_client.post(
+        _PATH,
+        json=_payload(),
+        headers={"Host": "orsha.internal.mvn.by"},
+    )
+
+    assert response.status_code == 200
+    lead = await db.get(Lead, response.json()["lead_id"])
+    assert lead is not None
+    assert (lead.tenant_id, lead.storefront_id) == (1, 1)
+
+
+@pytest.mark.asyncio
+async def test_unsigned_context_endpoint_keeps_canonical_mvn_projection(
+    async_client,
+    db,
+):
+    db.add(
+        StorefrontDomain(
+            storefront_id=1,
+            hostname="mvn.by",
+            status="active",
+            is_primary=True,
+        )
+    )
+    await db.commit()
+
+    response = await async_client.get("/api/v1/storefront/context")
+
+    assert response.status_code == 200
+    assert response.json()["tenant_slug"] == "mvn"
+    assert response.json()["storefront_slug"] == "main"
+    assert response.json()["hostname"] == "mvn.by"
+
+
+@pytest.mark.asyncio
+async def test_partial_or_tampered_context_fails_closed(
+    async_client,
+    db,
+    monkeypatch,
+):
+    await _seed_secondary_storefront(db)
+    monkeypatch.setattr(settings, "STOREFRONT_CONTEXT_SIGNING_SECRET", _SECRET)
+
+    partial = await async_client.post(
+        _PATH,
+        json=_payload(),
+        headers={"X-MVN-Storefront-Host": "orsha.internal.mvn.by"},
+    )
+    wrong_path = await async_client.post(
+        _PATH,
+        json=_payload(),
+        headers=_headers(path="/api/v1/orders"),
+    )
+
+    assert partial.status_code == 401
+    assert wrong_path.status_code == 401
+    leads = (await db.execute(select(Lead))).scalars().all()
+    assert leads == []
+
+
+@pytest.mark.asyncio
+async def test_context_selection_is_disabled_without_server_secret(
+    async_client,
+    db,
+    monkeypatch,
+):
+    await _seed_secondary_storefront(db)
+    monkeypatch.setattr(settings, "STOREFRONT_CONTEXT_SIGNING_SECRET", "")
+    monkeypatch.setattr(
+        settings,
+        "STOREFRONT_CONTEXT_PREVIOUS_SIGNING_SECRET",
+        _SECRET,
+    )
+
+    response = await async_client.post(_PATH, json=_payload(), headers=_headers())
+
+    assert response.status_code == 401
+    leads = (await db.execute(select(Lead))).scalars().all()
+    assert leads == []

--- a/tests/unit/test_public_checkout_validation.py
+++ b/tests/unit/test_public_checkout_validation.py
@@ -5,7 +5,7 @@ from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
 from core.database import get_session
-from core.tenant_scope import get_system_tenant_scope
+from core.tenant_scope import get_public_tenant_scope
 from routers.api_orders import router
 from services.installation_pricing_service import InstallationPricingError
 from services.website_order_service import WebsiteOrderService
@@ -40,7 +40,7 @@ def checkout_app(monkeypatch):
     create_order = AsyncMock()
     monkeypatch.setattr(WebsiteOrderService, "create_order", create_order)
     app.dependency_overrides[get_session] = override_session
-    app.dependency_overrides[get_system_tenant_scope] = override_tenant_scope
+    app.dependency_overrides[get_public_tenant_scope] = override_tenant_scope
     return app, create_order
 
 

--- a/tests/unit/test_storefront_context_service.py
+++ b/tests/unit/test_storefront_context_service.py
@@ -82,3 +82,41 @@ async def test_resolve_by_host_returns_none_for_unknown_domain(monkeypatch):
     )
 
     assert await StorefrontContextService.resolve_by_host(object(), "unknown.example") is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_by_scope_returns_public_context(monkeypatch):
+    session = object()
+    row = StorefrontContextRow(
+        tenant_id=1,
+        tenant_slug="mvn",
+        tenant_kind="operator",
+        storefront_id=2,
+        storefront_slug="orsha",
+        storefront_name="MVN Орша",
+        hostname="orsha.mvn.by",
+        city="Орша",
+        default_locale="ru-BY",
+        currency="BYN",
+        tenant_is_system=True,
+    )
+    resolver = AsyncMock(return_value=row)
+    monkeypatch.setattr(
+        "services.storefront_context_service.TenancyDAO.get_active_storefront_by_scope",
+        resolver,
+    )
+
+    context = await StorefrontContextService.resolve_by_scope(
+        session,
+        tenant_id=1,
+        storefront_id=2,
+    )
+
+    assert context is not None
+    assert context.storefront_name == "MVN Орша"
+    assert context.tenant_is_system is True
+    resolver.assert_awaited_once_with(
+        session,
+        tenant_id=1,
+        storefront_id=2,
+    )

--- a/tests/unit/test_storefront_context_signature_service.py
+++ b/tests/unit/test_storefront_context_signature_service.py
@@ -1,0 +1,120 @@
+import pytest
+
+from services.storefront_context_signature_service import (
+    InvalidStorefrontContextSignature,
+    StorefrontContextSignatureService,
+)
+
+
+_SECRET = "test-storefront-secret-at-least-32-bytes"
+
+
+def _signature(*, timestamp: int = 1_700_000_000) -> str:
+    return StorefrontContextSignatureService.sign(
+        secret=_SECRET,
+        timestamp=timestamp,
+        method="POST",
+        path="/api/v1/leads/contact",
+        hostname="CITY.MVN.BY:443",
+    )
+
+
+def test_signature_round_trip_returns_normalized_hostname():
+    signature = _signature()
+
+    hostname = StorefrontContextSignatureService.verify(
+        secret=_SECRET,
+        timestamp=1_700_000_000,
+        method="post",
+        path="/api/v1/leads/contact",
+        hostname="city.mvn.by",
+        signature=signature,
+        max_age_seconds=300,
+        now=1_700_000_100,
+    )
+
+    assert hostname == "city.mvn.by"
+    assert signature.startswith("v1=")
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("method", "GET"),
+        ("path", "/api/v1/orders"),
+        ("hostname", "other.mvn.by"),
+        ("signature", "v1=" + "0" * 64),
+    ],
+)
+def test_signature_rejects_tampered_request_target(field, value):
+    kwargs = {
+        "secret": _SECRET,
+        "timestamp": 1_700_000_000,
+        "method": "POST",
+        "path": "/api/v1/leads/contact",
+        "hostname": "city.mvn.by",
+        "signature": _signature(),
+        "max_age_seconds": 300,
+        "now": 1_700_000_100,
+    }
+    kwargs[field] = value
+
+    with pytest.raises(
+        InvalidStorefrontContextSignature,
+        match="signature is invalid",
+    ):
+        StorefrontContextSignatureService.verify(**kwargs)
+
+
+def test_signature_rejects_expired_timestamp():
+    with pytest.raises(
+        InvalidStorefrontContextSignature,
+        match="has expired",
+    ):
+        StorefrontContextSignatureService.verify(
+            secret=_SECRET,
+            timestamp=1_700_000_000,
+            method="POST",
+            path="/api/v1/leads/contact",
+            hostname="city.mvn.by",
+            signature=_signature(),
+            max_age_seconds=300,
+            now=1_700_000_301,
+        )
+
+
+def test_signature_rejects_missing_secret():
+    with pytest.raises(
+        InvalidStorefrontContextSignature,
+        match="not configured securely",
+    ):
+        StorefrontContextSignatureService.sign(
+            secret="",
+            timestamp=1_700_000_000,
+            method="POST",
+            path="/api/v1/leads/contact",
+            hostname="city.mvn.by",
+        )
+
+
+def test_verify_any_accepts_previous_secret_during_rotation():
+    signature = StorefrontContextSignatureService.sign(
+        secret=_SECRET,
+        timestamp=1_700_000_000,
+        method="POST",
+        path="/api/v1/leads/contact",
+        hostname="city.mvn.by",
+    )
+
+    hostname = StorefrontContextSignatureService.verify_any(
+        secrets=("new-storefront-secret-at-least-32-bytes", _SECRET),
+        timestamp=1_700_000_000,
+        method="POST",
+        path="/api/v1/leads/contact",
+        hostname="city.mvn.by",
+        signature=signature,
+        max_age_seconds=300,
+        now=1_700_000_100,
+    )
+
+    assert hostname == "city.mvn.by"

--- a/tests/unit/test_website_lead_service.py
+++ b/tests/unit/test_website_lead_service.py
@@ -6,7 +6,7 @@ import pytest
 
 from core.config import settings
 from core.database import get_session
-from core.tenant_scope import get_system_tenant_scope
+from core.tenant_scope import get_public_tenant_scope
 from crud.product import ProductDAO
 from main import app
 from models import Customer, Lead, LeadSource, Order, OrderStatus, Product
@@ -356,7 +356,7 @@ async def test_public_product_availability_lead_endpoint_returns_response(
         fake_create,
     )
     app.dependency_overrides[get_session] = override_get_session
-    app.dependency_overrides[get_system_tenant_scope] = override_tenant_scope
+    app.dependency_overrides[get_public_tenant_scope] = override_tenant_scope
 
     transport = ASGITransport(app=app)
     try:
@@ -381,7 +381,7 @@ async def test_public_product_availability_lead_endpoint_validates_phone(tenant_
     async def override_tenant_scope():
         return tenant_scope
 
-    app.dependency_overrides[get_system_tenant_scope] = override_tenant_scope
+    app.dependency_overrides[get_public_tenant_scope] = override_tenant_scope
     transport = ASGITransport(app=app)
     try:
         async with AsyncClient(transport=transport, base_url="http://test") as client:


### PR DESCRIPTION
## Summary
- resolve canonical or signed tenant/storefront context on public API requests
- reject forged, expired, partial, unknown, or disabled storefront envelopes
- persist trusted storefront provenance on public Leads and Orders without exposing internal IDs
- document the signing contract and keep canonical MVN behavior as the safe fallback

## Validation
- 55 focused unit/integration tests passed
- Manager OpenAPI client regeneration is clean
- Manager production build passed
- full CI remains the merge gate

## Rollout
The signing secret stays disabled during this release. Existing mvn/main traffic continues through the canonical fallback; activation is deferred to the isolated second-storefront canary.