### PR TITLE
Scope public order idempotency to storefront

### DIFF
--- a/alembic/versions/d0f1a2b3c4d5_scope_order_fingerprint_to_storefront.py
+++ b/alembic/versions/d0f1a2b3c4d5_scope_order_fingerprint_to_storefront.py
@@ -1,0 +1,96 @@
+"""scope order source fingerprint uniqueness to the exact storefront
+
+Revision ID: d0f1a2b3c4d5
+Revises: c9e0f1a2b3d4
+Create Date: 2026-08-01
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "d0f1a2b3c4d5"
+down_revision = "c9e0f1a2b3d4"
+branch_labels = None
+depends_on = None
+
+
+ORDER_FINGERPRINT_INDEX = "uq_order_source_fingerprint"
+
+
+def _assert_no_null_provenance() -> None:
+    count = int(
+        op.get_bind()
+        .execute(
+            sa.text(
+                'SELECT COUNT(*) FROM "order" '
+                "WHERE source_fingerprint IS NOT NULL "
+                "AND (tenant_id IS NULL OR storefront_id IS NULL)"
+            )
+        )
+        .scalar_one()
+        or 0
+    )
+    if count:
+        raise RuntimeError(
+            "Refusing storefront idempotency upgrade: "
+            f"order_fingerprint_null_scope={count}"
+        )
+
+
+def _assert_downgrade_is_lossless() -> None:
+    count = int(
+        op.get_bind()
+        .execute(
+            sa.text(
+                "SELECT COUNT(*) FROM ("
+                'SELECT tenant_id, source_fingerprint FROM "order" '
+                "WHERE source_fingerprint IS NOT NULL "
+                "GROUP BY tenant_id, source_fingerprint HAVING COUNT(*) > 1"
+                ") AS duplicates"
+            )
+        )
+        .scalar_one()
+        or 0
+    )
+    if count:
+        raise RuntimeError(
+            "Refusing storefront idempotency downgrade: "
+            f"duplicate_tenant_order_fingerprint={count}"
+        )
+
+
+def _create_storefront_scoped_index() -> None:
+    op.create_index(
+        ORDER_FINGERPRINT_INDEX,
+        "order",
+        ["tenant_id", "storefront_id", "source_fingerprint"],
+        unique=True,
+        postgresql_where=sa.text("source_fingerprint IS NOT NULL"),
+        sqlite_where=sa.text("source_fingerprint IS NOT NULL"),
+    )
+
+
+def _create_tenant_scoped_index() -> None:
+    op.create_index(
+        ORDER_FINGERPRINT_INDEX,
+        "order",
+        ["tenant_id", "source_fingerprint"],
+        unique=True,
+        postgresql_where=sa.text("source_fingerprint IS NOT NULL"),
+        sqlite_where=sa.text("source_fingerprint IS NOT NULL"),
+    )
+
+
+def upgrade() -> None:
+    _assert_no_null_provenance()
+    op.drop_index(ORDER_FINGERPRINT_INDEX, table_name="order")
+    _create_storefront_scoped_index()
+
+
+def downgrade() -> None:
+    _assert_downgrade_is_lossless()
+    op.drop_index(ORDER_FINGERPRINT_INDEX, table_name="order")
+    _create_tenant_scoped_index()

--- a/models/order.py
+++ b/models/order.py
@@ -406,6 +406,7 @@ class Order(SQLModel, table=True):
         Index(
             "uq_order_source_fingerprint",
             "tenant_id",
+            "storefront_id",
             "source_fingerprint",
             unique=True,
             postgresql_where=text("source_fingerprint IS NOT NULL"),

--- a/services/installation_estimate_lead_service.py
+++ b/services/installation_estimate_lead_service.py
@@ -35,7 +35,7 @@ from services.communications.template_registry import (
 )
 from services.tenant_entity_access_service import TenantEntityAccessService
 from services.order_service import OrderService
-from services.tenant_scope_service import TenantScope
+from services.tenant_scope_service import TenantScope, storefront_scope_clause
 from services.private_attachment_storage_service import (
     PrivateAttachmentStorage,
     get_private_attachment_storage,
@@ -338,7 +338,7 @@ class InstallationEstimateLeadService:
             .outerjoin(Customer, Customer.id == Order.customer_id)
             .where(
                 Order.source_fingerprint == fingerprint,
-                TenantEntityAccessService.order_clause(tenant_scope),
+                storefront_scope_clause(Order, tenant_scope),
                 TenantEntityAccessService.order_customer_clause(tenant_scope),
             )
             .limit(1)

--- a/tests/unit/test_communication_installation_watermark_migration.py
+++ b/tests/unit/test_communication_installation_watermark_migration.py
@@ -32,7 +32,7 @@ def test_installation_watermark_precedes_the_single_provider_boundary_head():
     script = ScriptDirectory.from_config(Config("alembic.ini"))
     revision = script.get_revision(REVISION)
 
-    assert script.get_heads() == ["c9e0f1a2b3d4"]
+    assert script.get_heads() == ["d0f1a2b3c4d5"]
     assert revision is not None
     assert revision.down_revision == "f4d5e6f7a8b9"
 

--- a/tests/unit/test_customer_manager_tenant_scope_migration.py
+++ b/tests/unit/test_customer_manager_tenant_scope_migration.py
@@ -10,7 +10,8 @@ from alembic.script import ScriptDirectory
 
 
 REVISION = "b8d9e0f1a2c3"
-HEAD_REVISION = "c9e0f1a2b3d4"
+CONTRACT_REVISION = "c9e0f1a2b3d4"
+HEAD_REVISION = "d0f1a2b3c4d5"
 MIGRATION_PATH = Path(
     "alembic/versions/b8d9e0f1a2c3_add_customer_manager_tenant_scope.py"
 )
@@ -88,7 +89,8 @@ def _create_legacy_schema(connection) -> None:
 def test_customer_manager_tenant_scope_is_single_alembic_head():
     script = ScriptDirectory.from_config(Config("alembic.ini"))
     assert script.get_current_head() == HEAD_REVISION
-    assert script.get_revision(HEAD_REVISION).down_revision == REVISION
+    assert script.get_revision(CONTRACT_REVISION).down_revision == REVISION
+    assert script.get_revision(HEAD_REVISION).down_revision == CONTRACT_REVISION
 
 
 def test_customer_manager_tenant_scope_migration_is_additive_and_guarded():

--- a/tests/unit/test_installation_estimate_lead_service.py
+++ b/tests/unit/test_installation_estimate_lead_service.py
@@ -219,6 +219,110 @@ async def test_installation_estimate_rejects_reused_key_with_different_request(
 
 
 @pytest.mark.asyncio
+async def test_installation_estimate_idempotency_is_isolated_by_storefront(
+    installation_estimate_session,
+):
+    storage = FakePrivateStorage()
+    first_storefront = TenantScope(
+        tenant_id=1,
+        storefront_id=1,
+        is_system=True,
+    )
+    second_storefront = TenantScope(
+        tenant_id=1,
+        storefront_id=2,
+        is_system=True,
+    )
+    payload = _payload()
+    uploads = [_upload()]
+    shared_key = "estimate-shared-across-storefronts"
+
+    first = await InstallationEstimateLeadService.create_lead(
+        installation_estimate_session,
+        tenant_scope=first_storefront,
+        payload=payload,
+        uploads=uploads,
+        idempotency_key=shared_key,
+        storage=storage,
+    )
+    second = await InstallationEstimateLeadService.create_lead(
+        installation_estimate_session,
+        tenant_scope=second_storefront,
+        payload=payload,
+        uploads=uploads,
+        idempotency_key=shared_key,
+        storage=storage,
+    )
+    first_replay = await InstallationEstimateLeadService.create_lead(
+        installation_estimate_session,
+        tenant_scope=first_storefront,
+        payload=payload,
+        uploads=uploads,
+        idempotency_key=shared_key,
+        storage=storage,
+    )
+    second_replay = await InstallationEstimateLeadService.create_lead(
+        installation_estimate_session,
+        tenant_scope=second_storefront,
+        payload=payload,
+        uploads=uploads,
+        idempotency_key=shared_key,
+        storage=storage,
+    )
+
+    assert first.replayed is False
+    assert second.replayed is False
+    assert first.order_id != second.order_id
+    assert first_replay.replayed is True
+    assert second_replay.replayed is True
+    assert first_replay.order_id == first.order_id
+    assert second_replay.order_id == second.order_id
+
+    orders = list(
+        (
+            await installation_estimate_session.execute(
+                select(Order).order_by(Order.storefront_id)
+            )
+        ).scalars()
+    )
+    assert [(order.tenant_id, order.storefront_id) for order in orders] == [
+        (1, 1),
+        (1, 2),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_installation_estimate_same_storefront_still_rejects_key_reuse(
+    installation_estimate_session,
+):
+    storage = FakePrivateStorage()
+    scope = TenantScope(tenant_id=1, storefront_id=2, is_system=True)
+    shared_key = "estimate-conflict-inside-storefront"
+
+    await InstallationEstimateLeadService.create_lead(
+        installation_estimate_session,
+        tenant_scope=scope,
+        payload=_payload(),
+        uploads=[_upload()],
+        idempotency_key=shared_key,
+        storage=storage,
+    )
+
+    with pytest.raises(
+        InstallationEstimateIdempotencyConflict,
+        match="другой заявки",
+    ):
+        await InstallationEstimateLeadService.create_lead(
+            installation_estimate_session,
+            tenant_scope=scope,
+            payload=_payload(description="Другая заявка второго storefront"),
+            uploads=[_upload()],
+            idempotency_key=shared_key,
+            storage=storage,
+        )
+
+
+@pytest.mark.asyncio
 async def test_installation_estimate_rolls_back_db_and_private_objects(
     installation_estimate_session,
     monkeypatch,

--- a/tests/unit/test_lead_order_tenant_provenance_expand.py
+++ b/tests/unit/test_lead_order_tenant_provenance_expand.py
@@ -16,7 +16,8 @@ import models  # noqa: F401 - registers SQLModel tables for metadata assertions
 REVISION = "f6b2a4d8e1c3"
 PROVENANCE_BOUNDARY_REVISION = "a7c8d9e0f1b2"
 CUSTOMER_SCOPE_REVISION = "b8d9e0f1a2c3"
-HEAD_REVISION = "c9e0f1a2b3d4"
+PROVENANCE_CONTRACT_REVISION = "c9e0f1a2b3d4"
+HEAD_REVISION = "d0f1a2b3c4d5"
 MIGRATION_PATH = Path("alembic/versions/f6b2a4d8e1c3_add_lead_order_tenant_provenance_expand.py")
 
 
@@ -79,6 +80,10 @@ def test_lead_order_tenant_provenance_expand_is_in_single_head_chain():
     assert revision.down_revision == "e9a1b2c3d4e5"
     assert (
         script.get_revision(HEAD_REVISION).down_revision
+        == PROVENANCE_CONTRACT_REVISION
+    )
+    assert (
+        script.get_revision(PROVENANCE_CONTRACT_REVISION).down_revision
         == CUSTOMER_SCOPE_REVISION
     )
     assert (

--- a/tests/unit/test_order_source_fingerprint_migration.py
+++ b/tests/unit/test_order_source_fingerprint_migration.py
@@ -30,7 +30,7 @@ def test_order_source_fingerprint_remains_in_the_single_alembic_chain():
     script = ScriptDirectory.from_config(Config("alembic.ini"))
     revision = script.get_revision(REVISION)
 
-    assert script.get_heads() == ["c9e0f1a2b3d4"]
+    assert script.get_heads() == ["d0f1a2b3c4d5"]
     assert revision is not None
     assert revision.down_revision == "f3c4d5e6f7a8"
     assert set(revision.nextrev) == {"d8e7f6a5b4c3"}

--- a/tests/unit/test_storefront_order_idempotency_migration.py
+++ b/tests/unit/test_storefront_order_idempotency_migration.py
@@ -1,0 +1,158 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from alembic.config import Config
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from alembic.script import ScriptDirectory
+from sqlalchemy import inspect, text
+
+
+REVISION = "d0f1a2b3c4d5"
+MIGRATION_PATH = Path(
+    "alembic/versions/d0f1a2b3c4d5_scope_order_fingerprint_to_storefront.py"
+)
+
+
+def _load_migration_module():
+    spec = importlib.util.spec_from_file_location(
+        "storefront_order_idempotency_migration",
+        MIGRATION_PATH,
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _engine(*, nullable_scope: bool = False):
+    engine = sa.create_engine("sqlite://")
+    metadata = sa.MetaData()
+    order = sa.Table(
+        "order",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("tenant_id", sa.Integer, nullable=nullable_scope),
+        sa.Column("storefront_id", sa.Integer, nullable=nullable_scope),
+        sa.Column("source_fingerprint", sa.String(64), nullable=True),
+    )
+    sa.Index(
+        "uq_order_source_fingerprint",
+        order.c.tenant_id,
+        order.c.source_fingerprint,
+        unique=True,
+        sqlite_where=text("source_fingerprint IS NOT NULL"),
+    )
+    metadata.create_all(engine)
+    return engine
+
+
+def _run(engine, action: str) -> None:
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        migration.op = Operations(MigrationContext.configure(connection))
+        getattr(migration, action)()
+
+
+def test_storefront_idempotency_migration_is_the_single_head():
+    script = ScriptDirectory.from_config(Config("alembic.ini"))
+    revision = script.get_revision(REVISION)
+
+    assert script.get_heads() == [REVISION]
+    assert revision is not None
+    assert revision.down_revision == "c9e0f1a2b3d4"
+
+
+def test_upgrade_allows_same_key_across_storefronts_but_not_inside_one():
+    engine = _engine()
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                'INSERT INTO "order" '
+                "(id, tenant_id, storefront_id, source_fingerprint) "
+                "VALUES (1, 1, 1, 'shared-key')"
+            )
+        )
+
+    _run(engine, "upgrade")
+
+    indexes = {
+        index["name"]: index
+        for index in inspect(engine).get_indexes("order")
+    }
+    assert indexes["uq_order_source_fingerprint"]["column_names"] == [
+        "tenant_id",
+        "storefront_id",
+        "source_fingerprint",
+    ]
+    assert indexes["uq_order_source_fingerprint"]["unique"] == 1
+
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                'INSERT INTO "order" '
+                "(id, tenant_id, storefront_id, source_fingerprint) "
+                "VALUES (2, 1, 2, 'shared-key')"
+            )
+        )
+
+    with pytest.raises(sa.exc.IntegrityError):
+        with engine.begin() as connection:
+            connection.execute(
+                text(
+                    'INSERT INTO "order" '
+                    "(id, tenant_id, storefront_id, source_fingerprint) "
+                    "VALUES (3, 1, 2, 'shared-key')"
+                )
+            )
+
+    with pytest.raises(
+        RuntimeError,
+        match="duplicate_tenant_order_fingerprint=1",
+    ):
+        _run(engine, "downgrade")
+
+
+def test_upgrade_rejects_fingerprint_without_complete_provenance():
+    engine = _engine(nullable_scope=True)
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                'INSERT INTO "order" '
+                "(id, tenant_id, storefront_id, source_fingerprint) "
+                "VALUES (1, 1, NULL, 'unsafe-key')"
+            )
+        )
+
+    with pytest.raises(
+        RuntimeError,
+        match="order_fingerprint_null_scope=1",
+    ):
+        _run(engine, "upgrade")
+
+
+def test_downgrade_restores_tenant_scoped_index_when_lossless():
+    engine = _engine()
+    _run(engine, "upgrade")
+
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                'INSERT INTO "order" '
+                "(id, tenant_id, storefront_id, source_fingerprint) "
+                "VALUES (1, 1, 1, 'one-key'), (2, 1, 2, 'another-key')"
+            )
+        )
+
+    _run(engine, "downgrade")
+
+    indexes = {
+        index["name"]: index
+        for index in inspect(engine).get_indexes("order")
+    }
+    assert indexes["uq_order_source_fingerprint"]["column_names"] == [
+        "tenant_id",
+        "source_fingerprint",
+    ]

--- a/tests/unit/test_tenant_provenance_contract_migration.py
+++ b/tests/unit/test_tenant_provenance_contract_migration.py
@@ -204,7 +204,7 @@ def test_tenant_provenance_contract_is_the_single_alembic_head():
     script = ScriptDirectory.from_config(Config("alembic.ini"))
     revision = script.get_revision(REVISION)
 
-    assert script.get_heads() == [REVISION]
+    assert script.get_heads() == ["d0f1a2b3c4d5"]
     assert revision is not None
     assert revision.down_revision == "b8d9e0f1a2c3"
 
@@ -340,6 +340,7 @@ def test_contract_model_metadata_matches_database_boundary():
     }
     assert order_indexes["uq_order_source_fingerprint"] == (
         "tenant_id",
+        "storefront_id",
         "source_fingerprint",
     )
     assert lead_indexes["uq_lead_bot_source_fingerprint"] == (


### PR DESCRIPTION
## Summary
- namespace installation-estimate idempotency by exact tenant and storefront
- replace the live partial unique index with `(tenant_id, storefront_id, source_fingerprint)`
- keep replays and conflicts inside the originating storefront
- add guarded upgrade/downgrade migration checks and cross-storefront tests

## Validation
- 18 focused service/migration tests passed
- 3 API integration tests passed on isolated PostgreSQL
- empty-database Alembic upgrade reached the new head
- diff check passed

## Release order
This PR is stacked on the trusted storefront-context PR. It will be rebased/retargeted to `main` after that release; only then will full CI be treated as the merge gate.