### PR TITLE
Scope supply requests to storefront orders

### DIFF
--- a/crud/supply_request.py
+++ b/crud/supply_request.py
@@ -1,0 +1,41 @@
+"""Persistence helpers for supply-request source ownership checks."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+from sqlmodel import select
+
+from models.order import Order, OrderProductLink
+from models.tenancy import TenantScope
+from services.tenant_scope_service import storefront_scope_clause
+
+
+class SupplyRequestDAO:
+    @staticmethod
+    async def get_order_product_links_for_storefront(
+        session: AsyncSession,
+        *,
+        order_product_link_ids: Iterable[int],
+        tenant_scope: TenantScope,
+    ) -> list[OrderProductLink]:
+        normalized_ids = tuple(
+            dict.fromkeys(int(value) for value in order_product_link_ids)
+        )
+        if not normalized_ids:
+            return []
+
+        statement = (
+            select(OrderProductLink)
+            .join(Order, Order.id == OrderProductLink.order_id)
+            .where(
+                OrderProductLink.id.in_(normalized_ids),
+                storefront_scope_clause(Order, tenant_scope),
+            )
+            .options(selectinload(OrderProductLink.product))
+            .order_by(OrderProductLink.id.asc())
+        )
+        result = await session.execute(statement)
+        return list(result.scalars().all())

--- a/routers/manager_supply.py
+++ b/routers/manager_supply.py
@@ -6,7 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from core.database import get_session
 from core.manager_api_errors import manager_http_error
 from core.manager_error_codes import BAD_REQUEST, PRODUCT_NOT_FOUND
-from core.security import get_current_username
+from core.security import AuthenticatedUser, get_current_username, require_manager_access
 from routers.manager_operation_ids import (
     ANALYZE_SUPPLIER_SOURCE,
     BULK_CREATE_SUPPLIER_MAPPINGS,
@@ -811,10 +811,15 @@ async def create_supply_request(
 async def create_supply_request_from_order_lines(
     payload: SupplyRequestFromOrderLinesPayload,
     session: AsyncSession = Depends(get_session),
-    user: str = Depends(get_current_username),
+    auth: AuthenticatedUser = Depends(require_manager_access),
 ):
     try:
-        return await SupplyRequestService.create_from_order_lines(session, payload.model_dump(), created_by=user)
+        return await SupplyRequestService.create_from_order_lines(
+            session,
+            payload.model_dump(),
+            tenant_scope=auth.tenant_scope(),
+            created_by=auth.username,
+        )
     except ValueError as exc:
         raise manager_http_error(
             status_code=400,

--- a/services/supply_request_service.py
+++ b/services/supply_request_service.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 from sqlmodel import select
 
+from crud.supply_request import SupplyRequestDAO
 from models.order import OrderProductLink
 from models.product import Product
 from models.supplier import (
@@ -21,6 +22,7 @@ from models.supplier import (
     SupplyRequest,
     SupplyRequestLine,
 )
+from models.tenancy import TenantScope
 from services.fx_rate_service import FxRateService
 from services.product_supply_metrics_service import ProductSupplyMetricsService
 
@@ -413,16 +415,21 @@ class SupplyRequestService:
         return {"items": [await SupplyRequestService.get_request(session, request.id)]}
 
     @staticmethod
-    async def create_from_order_lines(session: AsyncSession, payload: dict, *, created_by: str | None = None) -> dict:
+    async def create_from_order_lines(
+        session: AsyncSession,
+        payload: dict,
+        *,
+        tenant_scope: TenantScope,
+        created_by: str | None = None,
+    ) -> dict:
         line_ids = [int(value) for value in payload.get("order_product_link_ids") or []]
         if not line_ids:
             raise ValueError("Order product lines are required")
-        result = await session.execute(
-            select(OrderProductLink)
-            .where(OrderProductLink.id.in_(line_ids))
-            .options(selectinload(OrderProductLink.product))
+        links = await SupplyRequestDAO.get_order_product_links_for_storefront(
+            session,
+            order_product_link_ids=line_ids,
+            tenant_scope=tenant_scope,
         )
-        links = list(result.scalars().all())
         if len(links) != len(set(line_ids)):
             raise ValueError("Some order product lines were not found")
 

--- a/tests/integration/test_manager_supply_order_line_scope.py
+++ b/tests/integration/test_manager_supply_order_line_scope.py
@@ -1,0 +1,160 @@
+import pytest
+from sqlalchemy import func
+from sqlmodel import select
+
+from core.config import settings
+from models import Order, OrderProductLink, OrderStatus, Product, Storefront, Tenant
+from models.supplier import Supplier, SupplyRequest, SupplyRequestLine
+
+
+async def _auth_headers(async_client) -> dict[str, str]:
+    response = await async_client.post(
+        "/login/access-token",
+        data={
+            "username": settings.ADMIN_USERNAME,
+            "password": settings.ADMIN_PASSWORD,
+        },
+    )
+    assert response.status_code == 200, response.text
+    return {"Authorization": f"Bearer {response.json()['access_token']}"}
+
+
+async def _seed_scoped_order_lines(db):
+    secondary_storefront = Storefront(
+        id=2,
+        tenant_id=1,
+        slug="secondary",
+        display_name="MVN Secondary",
+        status="active",
+        is_default=False,
+    )
+    foreign_tenant = Tenant(
+        id=2,
+        slug="foreign-supply",
+        display_name="Foreign Supply",
+        kind="independent_seller",
+        status="active",
+        is_system=False,
+    )
+    foreign_storefront = Storefront(
+        id=3,
+        tenant_id=2,
+        slug="main",
+        display_name="Foreign Supply Main",
+        status="active",
+        is_default=True,
+    )
+    product = Product(
+        title="Scoped supply product",
+        slug="scoped-supply-product",
+        price=2000,
+        specs={"area_m2": 25},
+        is_published=True,
+    )
+    supplier = Supplier(
+        name="Scoped supply supplier",
+        code="scoped-supply-supplier",
+        default_payment_method="bank",
+    )
+    db.add(foreign_tenant)
+    await db.flush()
+    db.add_all(
+        [
+            secondary_storefront,
+            foreign_storefront,
+            product,
+            supplier,
+        ]
+    )
+    await db.flush()
+
+    orders = [
+        Order(
+            tenant_id=1,
+            storefront_id=1,
+            status=OrderStatus.NEGOTIATION,
+            title="Owned order",
+        ),
+        Order(
+            tenant_id=1,
+            storefront_id=2,
+            status=OrderStatus.NEGOTIATION,
+            title="Foreign storefront order",
+        ),
+        Order(
+            tenant_id=2,
+            storefront_id=3,
+            status=OrderStatus.NEGOTIATION,
+            title="Foreign tenant order",
+        ),
+    ]
+    db.add_all(orders)
+    await db.flush()
+    lines = [
+        OrderProductLink(
+            order_id=order.id,
+            product_id=product.id,
+            quantity=1,
+            price=2000,
+            cost=1200,
+        )
+        for order in orders
+    ]
+    db.add_all(lines)
+    await db.commit()
+    return supplier, lines
+
+
+async def _supply_counts(db) -> tuple[int, int]:
+    request_count = int(
+        (await db.execute(select(func.count()).select_from(SupplyRequest))).scalar_one()
+    )
+    line_count = int(
+        (await db.execute(select(func.count()).select_from(SupplyRequestLine))).scalar_one()
+    )
+    return request_count, line_count
+
+
+@pytest.mark.asyncio
+async def test_manager_creates_supply_request_from_owned_canonical_order_line(
+    async_client,
+    db,
+):
+    supplier, lines = await _seed_scoped_order_lines(db)
+
+    response = await async_client.post(
+        "/api/manager/supply-requests/from-order-lines",
+        headers=await _auth_headers(async_client),
+        json={
+            "order_product_link_ids": [lines[0].id],
+            "supplier_id": supplier.id,
+            "intent": "order",
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["items"][0]["lines"][0]["order_product_link_id"] == lines[0].id
+    assert await _supply_counts(db) == (1, 1)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("foreign_line_index", [1, 2])
+async def test_manager_mixed_owned_and_foreign_order_lines_fail_atomically(
+    async_client,
+    db,
+    foreign_line_index,
+):
+    supplier, lines = await _seed_scoped_order_lines(db)
+
+    response = await async_client.post(
+        "/api/manager/supply-requests/from-order-lines",
+        headers=await _auth_headers(async_client),
+        json={
+            "order_product_link_ids": [lines[0].id, lines[foreign_line_index].id],
+            "supplier_id": supplier.id,
+            "intent": "order",
+        },
+    )
+
+    assert response.status_code == 400, response.text
+    assert await _supply_counts(db) == (0, 0)

--- a/tests/unit/test_supply_request_service.py
+++ b/tests/unit/test_supply_request_service.py
@@ -123,7 +123,10 @@ async def test_supplier_contacts_and_warehouses_crud_defaults(db):
 
 
 @pytest.mark.asyncio
-async def test_create_supply_request_from_order_lines_selects_available_min_cost_offer(db):
+async def test_create_supply_request_from_order_lines_selects_available_min_cost_offer(
+    db,
+    tenant_scope,
+):
     _product, supplier_a, _supplier_b, order, order_line = await _seed_supplier_product(db)
     await SupplierProfileService.create_warehouse(
         db,
@@ -139,6 +142,7 @@ async def test_create_supply_request_from_order_lines_selects_available_min_cost
     result = await SupplyRequestService.create_from_order_lines(
         db,
         {"order_product_link_ids": [order_line.id], "intent": "order"},
+        tenant_scope=tenant_scope,
         created_by="pytest",
     )
 
@@ -206,11 +210,12 @@ async def test_create_stock_request_and_generate_messages(db):
 
 
 @pytest.mark.asyncio
-async def test_supply_status_transitions_and_partial_receipt(db):
+async def test_supply_status_transitions_and_partial_receipt(db, tenant_scope):
     _product, supplier_a, _supplier_b, _order, order_line = await _seed_supplier_product(db)
     result = await SupplyRequestService.create_from_order_lines(
         db,
         {"order_product_link_ids": [order_line.id], "intent": "order"},
+        tenant_scope=tenant_scope,
     )
     request = result["items"][0]
     line = request["lines"][0]


### PR DESCRIPTION
## What changed

- passes the authenticated Manager tenant/storefront scope into supply request creation
- reads source order lines through a dedicated DAO joining `OrderProductLink -> Order`
- applies the shared exact storefront scope before returning any line
- rejects mixed owned/foreign line IDs before supplier lookup or inserts

## Why

The endpoint previously trusted opaque order-line IDs. A Manager could submit a line belonging to another storefront or tenant and create a platform-global supply request from it.

## Safety

- the full unique input set must belong to the selected storefront
- mixed inputs fail atomically with the existing bad-request contract
- canonical system storefront behavior remains compatible
- this PR does not introduce incomplete `SupplyRequest` provenance; that remains a later model phase
- platform-wide supplier permissions are handled in a separate security PR

## Validation

- 7 focused unit/integration tests passed on PostgreSQL
- foreign storefront and foreign tenant cases are covered
- mixed owned/foreign requests create zero rows
- Python compilation and diff checks passed