### PR TITLE
Restrict platform-wide Manager operations

### DIFF
--- a/core/security.py
+++ b/core/security.py
@@ -187,6 +187,18 @@ async def require_owner_access(
     return auth
 
 
+async def require_system_owner_access(
+    auth: AuthenticatedUser = Depends(require_owner_access),
+) -> AuthenticatedUser:
+    """Restrict platform infrastructure to system-tenant owners/admins."""
+    if not auth.is_system_tenant:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="System tenant owner access required",
+        )
+    return auth
+
+
 async def get_current_user(
     auth: AuthenticatedUser = Depends(require_manager_access),
 ) -> str:

--- a/routers/manager_backups.py
+++ b/routers/manager_backups.py
@@ -13,6 +13,7 @@ from routers.manager_operation_ids import (
     START_MANAGER_BACKUP_RUN,
     START_MANAGER_BACKUP_RESTORE,
 )
+from routers.manager_permission_policy import ManagerPermissionRoute
 from schemas import (
     ManagerBackupListResponse,
     ManagerBackupRunStartResponse,
@@ -39,6 +40,7 @@ router = APIRouter(
     prefix="/api/manager/backups",
     tags=["manager/backups"],
     dependencies=[Depends(get_current_owner_username)],
+    route_class=ManagerPermissionRoute,
 )
 BACKUP_LIST_UNAVAILABLE = "backup_list_unavailable"
 BACKUP_LIST_UNAVAILABLE_MESSAGE = "Список резервных копий временно недоступен"

--- a/routers/manager_brands.py
+++ b/routers/manager_brands.py
@@ -18,6 +18,7 @@ from routers.manager_operation_ids import (
     APPLY_MANAGER_SERIES_GALLERY_TO_PRODUCTS,
     UPDATE_MANAGER_BRAND,
 )
+from routers.manager_permission_policy import ManagerPermissionRoute
 from schemas import (
     ManagerActionMessageResponse,
     ManagerBrandCreatePayload,
@@ -42,6 +43,7 @@ router = APIRouter(
     prefix="/api/manager/brands",
     tags=["manager brands"],
     dependencies=[Depends(get_current_username)],
+    route_class=ManagerPermissionRoute,
 )
 
 

--- a/routers/manager_catalog.py
+++ b/routers/manager_catalog.py
@@ -25,6 +25,7 @@ from routers.manager_operation_ids import (
     IMPORT_ONLINER,
     START_CATALOG_IMPORT_JOB,
 )
+from routers.manager_permission_policy import ManagerPermissionRoute
 from schemas import (
     BulkRoundRequest,
     BulkProductIdsRequest,
@@ -53,7 +54,11 @@ from routers import manager_customers
 _importer = ImporterService()
 
 
-router = APIRouter(prefix="/api/manager", tags=["manager"])
+router = APIRouter(
+    prefix="/api/manager",
+    tags=["manager"],
+    route_class=ManagerPermissionRoute,
+)
 
 
 @router.get(

--- a/routers/manager_catalog_quality.py
+++ b/routers/manager_catalog_quality.py
@@ -6,11 +6,16 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from core.database import get_session
 from core.security import get_current_username
 from routers.manager_operation_ids import GET_MANAGER_CATALOG_QUALITY_REPORT
+from routers.manager_permission_policy import ManagerPermissionRoute
 from schemas import ManagerCatalogQualityReportResponse
 from services.catalog_quality_service import CatalogQualityService
 
 
-router = APIRouter(prefix="/api/manager/catalog-quality", tags=["manager catalog quality"])
+router = APIRouter(
+    prefix="/api/manager/catalog-quality",
+    tags=["manager catalog quality"],
+    route_class=ManagerPermissionRoute,
+)
 
 
 @router.get(

--- a/routers/manager_crm.py
+++ b/routers/manager_crm.py
@@ -3,10 +3,15 @@ from fastapi import APIRouter, Depends, Query
 from core.manager_telemetry import ManagerTelemetryService
 from core.security import get_current_username
 from routers.manager_operation_ids import GET_MANAGER_CRM_HEALTH_REPORT
+from routers.manager_permission_policy import ManagerPermissionRoute
 from schemas import ManagerCrmHealthReportResponse
 
 
-router = APIRouter(prefix="/api/manager/crm", tags=["manager-crm"])
+router = APIRouter(
+    prefix="/api/manager/crm",
+    tags=["manager-crm"],
+    route_class=ManagerPermissionRoute,
+)
 
 
 @router.get(
@@ -19,4 +24,3 @@ async def get_manager_crm_health_report(
     _user: str = Depends(get_current_username),
 ):
     return ManagerTelemetryService.get_report(hours=hours)
-

--- a/routers/manager_features.py
+++ b/routers/manager_features.py
@@ -32,9 +32,14 @@ from routers.manager_operation_ids import (
     UPDATE_MANAGER_PRODUCT_FEATURES,
     UPSERT_MANAGER_FEATURE_TARGET_LINK,
 )
+from routers.manager_permission_policy import ManagerPermissionRoute
 
 
-router = APIRouter(prefix="/api/manager", tags=["manager-features"])
+router = APIRouter(
+    prefix="/api/manager",
+    tags=["manager-features"],
+    route_class=ManagerPermissionRoute,
+)
 
 
 @router.get(

--- a/routers/manager_google_auth.py
+++ b/routers/manager_google_auth.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.concurrency import run_in_threadpool
 from fastapi.responses import HTMLResponse
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
 
 from core.config import settings
 from core.database import get_session
@@ -16,10 +17,12 @@ from core.security import (
     get_current_owner_username,
     require_owner_access,
 )
+from models import Tenant, TenantMembership
 from routers.manager_operation_ids import (
     GET_MANAGER_GOOGLE_AUTH_STATUS,
     GET_MANAGER_GOOGLE_AUTH_URL,
 )
+from routers.manager_permission_policy import ManagerPermissionRoute
 from schemas import ManagerGoogleAuthStatusResponse, ManagerGoogleAuthUrlResponse
 from services.google_service import get_google_service
 from services.staff_user_service import StaffUserService
@@ -40,6 +43,7 @@ class GoogleOAuthConfigurationError(RuntimeError):
 router = APIRouter(
     prefix="/api/manager/google-auth",
     tags=["manager/google-auth"],
+    route_class=ManagerPermissionRoute,
 )
 
 
@@ -134,7 +138,36 @@ async def _oauth_owner_binding_is_active(
         return False
     if staff_user is None or not StaffUserService.is_active(staff_user):
         return False
-    return StaffUserService.primary_role(staff_user).strip().lower() in OWNER_ACCESS_ROLES
+    if StaffUserService.primary_role(staff_user).strip().lower() not in OWNER_ACCESS_ROLES:
+        return False
+
+    try:
+        membership_id = int(pending.get("tenant_membership_id"))
+        tenant_id = int(pending.get("tenant_id"))
+    except (TypeError, ValueError):
+        return False
+    if membership_id <= 0 or tenant_id <= 0:
+        return False
+
+    statement = (
+        select(TenantMembership, Tenant)
+        .join(Tenant, Tenant.id == TenantMembership.tenant_id)
+        .where(
+            TenantMembership.id == membership_id,
+            TenantMembership.staff_user_id == int(staff_user_id),
+            TenantMembership.tenant_id == tenant_id,
+        )
+    )
+    row = (await session.execute(statement)).first()
+    if row is None:
+        return False
+    membership, tenant = row
+    return (
+        str(membership.status or "").strip().lower() == "active"
+        and str(membership.role or "").strip().lower() in OWNER_ACCESS_ROLES
+        and str(tenant.status or "").strip().lower() == "active"
+        and bool(tenant.is_system)
+    )
 
 
 @router.get("/status", response_model=ManagerGoogleAuthStatusResponse, operation_id=GET_MANAGER_GOOGLE_AUTH_STATUS)
@@ -165,6 +198,8 @@ async def get_manager_google_auth_url(
             "auth_source": auth.auth_source,
             "staff_user_id": auth.staff_user_id,
             "username": auth.username,
+            "tenant_membership_id": auth.tenant_membership_id,
+            "tenant_id": auth.tenant_id,
         }
         url = await run_in_threadpool(
             lambda: get_google_service().get_auth_url(redirect_uri, state=state)

--- a/routers/manager_mdv_catalog.py
+++ b/routers/manager_mdv_catalog.py
@@ -8,6 +8,7 @@ from routers.manager_operation_ids import (
     PREVIEW_MDV_CATALOG_IMPORT,
     START_MDV_CATALOG_IMPORT_JOB,
 )
+from routers.manager_permission_policy import ManagerPermissionRoute
 from schemas import (
     CatalogImportJobStartResponse,
     MdvCatalogImportPayload,
@@ -19,7 +20,11 @@ from services.mdv_catalog_preview_service import MdvCatalogPreviewService
 from services.mdv_legacy_replace_service import MdvLegacyReplaceService
 
 
-router = APIRouter(prefix="/api/manager", tags=["manager"])
+router = APIRouter(
+    prefix="/api/manager",
+    tags=["manager"],
+    route_class=ManagerPermissionRoute,
+)
 
 
 @router.post(

--- a/routers/manager_media_cleanup.py
+++ b/routers/manager_media_cleanup.py
@@ -12,6 +12,7 @@ from routers.manager_operation_ids import (
     REJECT_MAIN_IMAGE_CLEANUP_ITEMS,
     SKIP_MAIN_IMAGE_CLEANUP_ITEMS,
 )
+from routers.manager_permission_policy import ManagerPermissionRoute
 from schemas import (
     ProductMainImageCleanupApprovePayload,
     ProductMainImageCleanupBatchCreatePayload,
@@ -26,7 +27,11 @@ from schemas import (
 from services.product_main_image_cleanup_service import ProductMainImageCleanupService
 
 
-router = APIRouter(prefix="/api/manager/main-image-cleanup", tags=["manager"])
+router = APIRouter(
+    prefix="/api/manager/main-image-cleanup",
+    tags=["manager"],
+    route_class=ManagerPermissionRoute,
+)
 
 
 @router.post(

--- a/routers/manager_media_gallery_read.py
+++ b/routers/manager_media_gallery_read.py
@@ -10,6 +10,7 @@ from routers.manager_operation_ids import (
     GET_IMAGE_VARIANT_CANDIDATES,
     REUSE_SEARCH,
 )
+from routers.manager_permission_policy import ManagerPermissionRoute
 from schemas import (
     CommonGalleryImageResponse,
     ManagerMediaReuseSearchItemResponse,
@@ -19,7 +20,11 @@ from services.manager_media_service import ManagerMediaService
 from services.product_image_variant_service import ProductImageVariantService
 
 
-router = APIRouter(prefix="/api/manager", tags=["manager"])
+router = APIRouter(
+    prefix="/api/manager",
+    tags=["manager"],
+    route_class=ManagerPermissionRoute,
+)
 
 
 @router.get(

--- a/routers/manager_media_gallery_write.py
+++ b/routers/manager_media_gallery_write.py
@@ -21,6 +21,7 @@ from routers.manager_operation_ids import (
     REPROCESS_IMAGE_VARIANT,
     SET_MAIN_IMAGE,
 )
+from routers.manager_permission_policy import ManagerPermissionRoute
 from schemas import (
     BulkGalleryAddRequest,
     BulkGalleryDeleteRequest,
@@ -42,7 +43,11 @@ from services.manager_media_service import ManagerMediaService
 from services.product_image_variant_service import ProductImageVariantService
 
 
-router = APIRouter(prefix="/api/manager", tags=["manager"])
+router = APIRouter(
+    prefix="/api/manager",
+    tags=["manager"],
+    route_class=ManagerPermissionRoute,
+)
 
 
 @router.post(

--- a/routers/manager_media_ingest_write.py
+++ b/routers/manager_media_ingest_write.py
@@ -7,11 +7,16 @@ from core.database import get_session
 from core.logger import logger
 from core.security import get_current_username
 from routers.manager_operation_ids import UPLOAD_IMAGE, UPLOAD_LOCAL_IMAGES
+from routers.manager_permission_policy import ManagerPermissionRoute
 from schemas import ManagerMediaImageLinkResponse, ManagerMediaUploadLocalImagesResponse
 from services.manager_media_orchestrator_service import ManagerMediaOrchestratorService
 
 
-router = APIRouter(prefix="/api/manager", tags=["manager"])
+router = APIRouter(
+    prefix="/api/manager",
+    tags=["manager"],
+    route_class=ManagerPermissionRoute,
+)
 
 
 @router.post(

--- a/routers/manager_media_library.py
+++ b/routers/manager_media_library.py
@@ -17,6 +17,7 @@ from routers.manager_operation_ids import (
     UPLOAD_MEDIA_ASSET_FROM_URL,
     UPLOAD_MEDIA_ASSETS,
 )
+from routers.manager_permission_policy import ManagerPermissionRoute
 from schemas import (
     ManagerActionMessageResponse,
     ManagerBackgroundRemovalConfigResponse,
@@ -39,7 +40,11 @@ from services.product_image_processing_provider import (
 )
 
 
-router = APIRouter(prefix="/api/manager/media/assets", tags=["manager media"])
+router = APIRouter(
+    prefix="/api/manager/media/assets",
+    tags=["manager media"],
+    route_class=ManagerPermissionRoute,
+)
 MAX_UPLOAD_IMAGE_BYTES = 20 * 1024 * 1024
 
 

--- a/routers/manager_media_processing.py
+++ b/routers/manager_media_processing.py
@@ -7,6 +7,7 @@ from routers.manager_operation_ids import (
     CREATE_MEDIA_PROCESSING_JOB,
     LIST_MEDIA_PROCESSING_JOBS,
 )
+from routers.manager_permission_policy import ManagerPermissionRoute
 from schemas import (
     ManagerMediaProcessingJobCreatePayload,
     ManagerMediaProcessingJobListResponse,
@@ -15,7 +16,11 @@ from schemas import (
 from services.media_processing_job_service import MediaProcessingJobService
 
 
-router = APIRouter(prefix="/api/manager/media/processing-jobs", tags=["manager media"])
+router = APIRouter(
+    prefix="/api/manager/media/processing-jobs",
+    tags=["manager media"],
+    route_class=ManagerPermissionRoute,
+)
 
 
 @router.get(

--- a/routers/manager_permission_policy.py
+++ b/routers/manager_permission_policy.py
@@ -1,0 +1,217 @@
+"""Central route policy for platform-global Manager operations.
+
+Tenant-scoped CRM and commerce routes intentionally do not use this route
+class. The policy is keyed by stable operation IDs so adding a new global
+mutation requires an explicit permission decision that is covered by tests.
+"""
+
+from collections.abc import Sequence
+from typing import Any
+
+from fastapi import Depends
+from fastapi.params import Depends as DependsParam
+from fastapi.routing import APIRoute
+
+from core.security import (
+    require_system_manager_tenant_scope,
+    require_system_owner_access,
+)
+from routers import manager_operation_ids as operation_ids
+
+
+PLATFORM_MANAGER_OPERATION_IDS = frozenset(
+    {
+        # Catalog products and imports.
+        operation_ids.CREATE_MANAGER_PRODUCT,
+        operation_ids.DUPLICATE_MANAGER_PRODUCT,
+        operation_ids.UPDATE_PRODUCT,
+        operation_ids.DELETE_MANAGER_PRODUCT,
+        operation_ids.BULK_ROUND_PRICE,
+        operation_ids.BULK_SET_RRC_PRICE,
+        operation_ids.BULK_DELETE_MANAGER_PRODUCTS,
+        operation_ids.IMPORT_ONLINER,
+        operation_ids.CATALOG_IMPORT,
+        operation_ids.START_CATALOG_IMPORT_JOB,
+        operation_ids.GET_CURRENT_CATALOG_IMPORT_JOB_STATUS,
+        operation_ids.GET_CATALOG_IMPORT_JOB_STATUS,
+        operation_ids.PREVIEW_MDV_CATALOG_IMPORT,
+        operation_ids.START_MDV_CATALOG_IMPORT_JOB,
+        operation_ids.GET_MANAGER_CATALOG_QUALITY_REPORT,
+        operation_ids.GET_MANAGER_YANDEX_BUSINESS_QUALITY_REPORT,
+        # Catalog dictionaries and projections.
+        operation_ids.CREATE_MANAGER_BRAND,
+        operation_ids.UPDATE_MANAGER_BRAND,
+        operation_ids.DELETE_MANAGER_BRAND,
+        operation_ids.CREATE_MANAGER_BRAND_FEATURE,
+        operation_ids.UPDATE_MANAGER_BRAND_FEATURE,
+        operation_ids.DELETE_MANAGER_BRAND_FEATURE,
+        operation_ids.CREATE_MANAGER_BRAND_SERIES,
+        operation_ids.UPDATE_MANAGER_BRAND_SERIES,
+        operation_ids.APPLY_MANAGER_SERIES_GALLERY_TO_PRODUCTS,
+        operation_ids.DELETE_MANAGER_BRAND_SERIES,
+        operation_ids.CREATE_MANAGER_TAG_GROUP,
+        operation_ids.UPDATE_MANAGER_TAG_GROUP,
+        operation_ids.DELETE_MANAGER_TAG_GROUP,
+        operation_ids.CREATE_MANAGER_TAG,
+        operation_ids.UPDATE_MANAGER_TAG,
+        operation_ids.DELETE_MANAGER_TAG,
+        operation_ids.CREATE_MANAGER_FEATURE,
+        operation_ids.UPDATE_MANAGER_FEATURE,
+        operation_ids.ARCHIVE_MANAGER_FEATURE,
+        operation_ids.UPSERT_MANAGER_FEATURE_TARGET_LINK,
+        operation_ids.DELETE_MANAGER_FEATURE_TARGET_LINK,
+        operation_ids.UPDATE_MANAGER_PRODUCT_FEATURES,
+        operation_ids.DELETE_MANAGER_PRODUCT_FEATURE,
+        operation_ids.APPLY_MANAGER_PRODUCT_FEATURE_SUGGESTIONS,
+        operation_ids.BULK_UPDATE_SPECS,
+        operation_ids.NORMALIZE_LEGACY_SPECS,
+        operation_ids.CREATE_MANAGER_PRODUCT_COLLECTION,
+        operation_ids.UPDATE_MANAGER_PRODUCT_COLLECTION,
+        operation_ids.DUPLICATE_MANAGER_PRODUCT_COLLECTION,
+        operation_ids.ARCHIVE_MANAGER_PRODUCT_COLLECTION,
+        operation_ids.REPLACE_MANAGER_PRODUCT_COLLECTION_ITEMS,
+        operation_ids.REPLACE_MANAGER_PRODUCT_COLLECTION_PLACEMENTS,
+        # Platform-owned service dictionaries.
+        operation_ids.CREATE_MANAGER_TARIFF,
+        operation_ids.UPDATE_MANAGER_TARIFF,
+        operation_ids.DELETE_MANAGER_TARIFF,
+        operation_ids.CREATE_MANAGER_TARIFF_RULE,
+        operation_ids.UPDATE_MANAGER_TARIFF_RULE,
+        operation_ids.DELETE_MANAGER_TARIFF_RULE,
+        operation_ids.CREATE_MANAGER_REPAIR_COMPLAINT_PRESET,
+        operation_ids.UPDATE_MANAGER_REPAIR_COMPLAINT_PRESET,
+        operation_ids.DELETE_MANAGER_REPAIR_COMPLAINT_PRESET,
+        # Saved shared estimates and platform warranty definitions.
+        operation_ids.CREATE_MANAGER_SERVICE_ESTIMATE,
+        operation_ids.LIST_MANAGER_SERVICE_ESTIMATES,
+        operation_ids.GET_MANAGER_SERVICE_ESTIMATE,
+        operation_ids.GET_MANAGER_SERVICE_ESTIMATE_ORDER_LINES,
+        operation_ids.DELETE_MANAGER_SERVICE_ESTIMATE,
+        operation_ids.CREATE_MANAGER_WARRANTY_POLICY,
+        operation_ids.PATCH_MANAGER_WARRANTY_POLICY,
+        # Supplier data and supply workflows are platform-global today.
+        operation_ids.CREATE_SUPPLIER,
+        operation_ids.PATCH_SUPPLIER,
+        operation_ids.DELETE_SUPPLIER,
+        operation_ids.LIST_SUPPLIERS,
+        operation_ids.LIST_SUPPLIER_CONTACTS,
+        operation_ids.CREATE_SUPPLIER_CONTACT,
+        operation_ids.PATCH_SUPPLIER_CONTACT,
+        operation_ids.DELETE_SUPPLIER_CONTACT,
+        operation_ids.LIST_SUPPLIER_WAREHOUSES,
+        operation_ids.CREATE_SUPPLIER_WAREHOUSE,
+        operation_ids.PATCH_SUPPLIER_WAREHOUSE,
+        operation_ids.DELETE_SUPPLIER_WAREHOUSE,
+        operation_ids.LIST_SUPPLIER_SHEETS,
+        operation_ids.LIST_SUPPLIER_SOURCES,
+        operation_ids.CREATE_SUPPLIER_SOURCE,
+        operation_ids.PATCH_SUPPLIER_SOURCE,
+        operation_ids.DELETE_SUPPLIER_SOURCE,
+        operation_ids.ANALYZE_SUPPLIER_SOURCE,
+        operation_ids.SYNC_SUPPLIER_SOURCE,
+        operation_ids.SYNC_ALL_SUPPLIER_SOURCES,
+        operation_ids.LIST_UNMAPPED_SUPPLIER_OFFERS,
+        operation_ids.LIST_SUPPLIER_SOURCE_URL_IMPORT_CANDIDATES,
+        operation_ids.START_SUPPLIER_SOURCE_URL_IMPORT,
+        operation_ids.SUGGEST_SUPPLIER_OFFERS,
+        operation_ids.CREATE_SUPPLIER_MAPPING,
+        operation_ids.BULK_CREATE_SUPPLIER_MAPPINGS,
+        operation_ids.DELETE_SUPPLIER_MAPPING,
+        operation_ids.GET_PRODUCT_SUPPLIER_OFFERS,
+        operation_ids.UPSERT_PRODUCT_LOCAL_STOCK,
+        operation_ids.LIST_SUPPLY_REQUESTS,
+        operation_ids.CREATE_SUPPLY_REQUEST,
+        operation_ids.CREATE_SUPPLY_REQUEST_FROM_ORDER_LINES,
+        operation_ids.CREATE_STOCK_SUPPLY_REQUEST,
+        operation_ids.PATCH_SUPPLY_REQUEST,
+        operation_ids.PATCH_SUPPLY_REQUEST_LINE,
+        operation_ids.GENERATE_SUPPLY_REQUEST_SUPPLIER_MESSAGE,
+        operation_ids.GENERATE_SUPPLY_LOGISTICS_MESSAGE,
+        # Product gallery, reusable media and cleanup workflows.
+        operation_ids.UPLOAD_IMAGE,
+        operation_ids.UPLOAD_LOCAL_IMAGES,
+        operation_ids.LINK_SEARCH_RESULT,
+        operation_ids.SET_MAIN_IMAGE,
+        operation_ids.DELETE_IMAGE,
+        operation_ids.CROP_PRODUCT_IMAGE,
+        operation_ids.REMOVE_PRODUCT_IMAGE_BACKGROUND,
+        operation_ids.REUSE_IMAGE,
+        operation_ids.BULK_ADD_GALLERY_IMAGES,
+        operation_ids.BULK_UPLOAD_LOCAL_IMAGES,
+        operation_ids.BULK_DELETE_COMMON_GALLERY_IMAGES,
+        operation_ids.APPLY_GALLERY_TO_SERIES,
+        operation_ids.PROCESS_MISSING_IMAGE_VARIANTS,
+        operation_ids.REPROCESS_IMAGE_VARIANT,
+        operation_ids.GET_IMAGE_VARIANT_CANDIDATES,
+        operation_ids.CLEANUP_MEDIA,
+        operation_ids.LIST_MEDIA_ASSETS,
+        operation_ids.GET_MEDIA_BACKGROUND_REMOVAL_CONFIG,
+        operation_ids.UPLOAD_MEDIA_ASSETS,
+        operation_ids.UPLOAD_MEDIA_ASSET_FROM_URL,
+        operation_ids.BACKFILL_REFERENCED_MEDIA_ASSETS,
+        operation_ids.UPDATE_MEDIA_ASSET,
+        operation_ids.CROP_MEDIA_ASSET,
+        operation_ids.REMOVE_MEDIA_ASSET_BACKGROUND,
+        operation_ids.DELETE_MEDIA_ASSET,
+        operation_ids.LIST_MEDIA_PROCESSING_JOBS,
+        operation_ids.CREATE_MEDIA_PROCESSING_JOB,
+        operation_ids.CREATE_MAIN_IMAGE_CLEANUP_BATCH,
+        operation_ids.LIST_MAIN_IMAGE_CLEANUP_BATCHES,
+        operation_ids.LIST_MAIN_IMAGE_CLEANUP_ITEMS,
+        operation_ids.APPROVE_MAIN_IMAGE_CLEANUP_ITEMS,
+        operation_ids.REJECT_MAIN_IMAGE_CLEANUP_ITEMS,
+        operation_ids.SKIP_MAIN_IMAGE_CLEANUP_ITEMS,
+        operation_ids.LIST_MAIN_IMAGE_CLEANUP_SKIP_REASONS,
+        # Platform-wide telemetry, not tenant CRM data.
+        operation_ids.GET_MANAGER_CRM_HEALTH_REPORT,
+    }
+)
+
+
+SYSTEM_OWNER_OPERATION_IDS = frozenset(
+    {
+        operation_ids.LIST_MANAGER_SETTINGS,
+        operation_ids.UPDATE_MANAGER_SETTING,
+        operation_ids.CREATE_MANAGER_SETTING,
+        operation_ids.GET_MANAGER_GOOGLE_AUTH_STATUS,
+        operation_ids.GET_MANAGER_GOOGLE_AUTH_URL,
+        operation_ids.LIST_MANAGER_BACKUPS,
+        operation_ids.START_MANAGER_BACKUP_RUN,
+        operation_ids.GET_MANAGER_BACKUP_RUN_STATUS,
+        operation_ids.START_MANAGER_BACKUP_RESTORE,
+        operation_ids.GET_MANAGER_BACKUP_RESTORE_STATUS,
+    }
+)
+
+
+def required_permission_dependency(operation_id: str | None):
+    if operation_id in PLATFORM_MANAGER_OPERATION_IDS:
+        return require_system_manager_tenant_scope
+    if operation_id in SYSTEM_OWNER_OPERATION_IDS:
+        return require_system_owner_access
+    return None
+
+
+class ManagerPermissionRoute(APIRoute):
+    """Attach the centralized Manager permission selected by operation ID."""
+
+    def __init__(
+        self,
+        *args: Any,
+        operation_id: str | None = None,
+        dependencies: Sequence[DependsParam] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        permission_dependency = required_permission_dependency(operation_id)
+        route_dependencies = list(dependencies or ())
+        if permission_dependency is not None and not any(
+            dependency.dependency is permission_dependency
+            for dependency in route_dependencies
+        ):
+            route_dependencies.insert(0, Depends(permission_dependency))
+        super().__init__(
+            *args,
+            operation_id=operation_id,
+            dependencies=route_dependencies,
+            **kwargs,
+        )

--- a/routers/manager_product_collections.py
+++ b/routers/manager_product_collections.py
@@ -25,12 +25,14 @@ from routers.manager_operation_ids import (
     REPLACE_MANAGER_PRODUCT_COLLECTION_PLACEMENTS,
     UPDATE_MANAGER_PRODUCT_COLLECTION,
 )
+from routers.manager_permission_policy import ManagerPermissionRoute
 from services.manager_product_collection_service import ManagerProductCollectionService
 
 
 router = APIRouter(
     prefix="/api/manager/product-collections",
     tags=["manager product collections"],
+    route_class=ManagerPermissionRoute,
 )
 
 

--- a/routers/manager_repair_complaints.py
+++ b/routers/manager_repair_complaints.py
@@ -11,6 +11,7 @@ from routers.manager_operation_ids import (
     LIST_MANAGER_REPAIR_COMPLAINT_PRESETS,
     UPDATE_MANAGER_REPAIR_COMPLAINT_PRESET,
 )
+from routers.manager_permission_policy import ManagerPermissionRoute
 from schemas import (
     ManagerActionMessageResponse,
     ManagerRepairActAiDraftPayload,
@@ -31,6 +32,7 @@ router = APIRouter(
     prefix="/api/manager/repair-complaints",
     tags=["manager/repair-complaints"],
     dependencies=[Depends(get_current_username)],
+    route_class=ManagerPermissionRoute,
 )
 
 

--- a/routers/manager_service_estimates.py
+++ b/routers/manager_service_estimates.py
@@ -11,6 +11,7 @@ from routers.manager_operation_ids import (
     GET_MANAGER_SERVICE_ESTIMATE_ORDER_LINES,
     LIST_MANAGER_SERVICE_ESTIMATES,
 )
+from routers.manager_permission_policy import ManagerPermissionRoute
 from schemas import (
     ManagerActionMessageResponse,
     ManagerInstallEstimateCalculatePayload,
@@ -29,6 +30,7 @@ router = APIRouter(
     prefix="/api/manager/service-estimates",
     tags=["manager/service-estimates"],
     dependencies=[Depends(get_current_username)],
+    route_class=ManagerPermissionRoute,
 )
 
 

--- a/routers/manager_settings.py
+++ b/routers/manager_settings.py
@@ -13,6 +13,7 @@ from routers.manager_operation_ids import (
     SUGGEST_ADDRESS,
     UPDATE_MANAGER_SETTING,
 )
+from routers.manager_permission_policy import ManagerPermissionRoute
 from schemas import (
     AddressSuggestResponse,
     FxRateResponse,
@@ -31,6 +32,7 @@ router = APIRouter(
     prefix="/api/manager/settings",
     tags=["manager/settings"],
     dependencies=[Depends(get_current_username)],
+    route_class=ManagerPermissionRoute,
 )
 
 

--- a/routers/manager_specs.py
+++ b/routers/manager_specs.py
@@ -5,6 +5,7 @@ from core.database import get_session
 from core.logger import logger
 from core.security import get_current_username
 from routers.manager_operation_ids import BULK_UPDATE_SPECS, NORMALIZE_LEGACY_SPECS
+from routers.manager_permission_policy import ManagerPermissionRoute
 from schemas import (
     BulkSpecUpdate,
     ManagerBulkSpecsResponse,
@@ -14,7 +15,11 @@ from services.manager_legacy_specs_service import ManagerLegacySpecsService
 from services.manager_specs_service import ManagerSpecsService
 
 
-router = APIRouter(prefix="/api/manager", tags=["manager"])
+router = APIRouter(
+    prefix="/api/manager",
+    tags=["manager"],
+    route_class=ManagerPermissionRoute,
+)
 
 
 @router.post(

--- a/routers/manager_supply.py
+++ b/routers/manager_supply.py
@@ -46,6 +46,7 @@ from routers.manager_operation_ids import (
     SYNC_SUPPLIER_SOURCE,
     UPSERT_PRODUCT_LOCAL_STOCK,
 )
+from routers.manager_permission_policy import ManagerPermissionRoute
 from schemas import (
     ManagerActionMessageResponse,
     CatalogImportJobStartResponse,
@@ -97,7 +98,11 @@ from services.supplier_sync_service import SupplierSyncService
 from services.supply_request_service import SupplierProfileService, SupplyRequestService
 
 
-router = APIRouter(prefix="/api/manager", tags=["manager"])
+router = APIRouter(
+    prefix="/api/manager",
+    tags=["manager"],
+    route_class=ManagerPermissionRoute,
+)
 
 
 @router.get("/suppliers", response_model=SupplierListResponse, operation_id=LIST_SUPPLIERS)

--- a/routers/manager_tags.py
+++ b/routers/manager_tags.py
@@ -23,8 +23,13 @@ from routers.manager_operation_ids import (
     UPDATE_MANAGER_TAG,
     DELETE_MANAGER_TAG,
 )
+from routers.manager_permission_policy import ManagerPermissionRoute
 
-router = APIRouter(prefix="/api/manager/tags", tags=["manager tags"])
+router = APIRouter(
+    prefix="/api/manager/tags",
+    tags=["manager tags"],
+    route_class=ManagerPermissionRoute,
+)
 
 @router.get(
     "/groups",

--- a/routers/manager_tariffs.py
+++ b/routers/manager_tariffs.py
@@ -15,6 +15,7 @@ from routers.manager_operation_ids import (
     UPDATE_MANAGER_TARIFF,
     UPDATE_MANAGER_TARIFF_RULE,
 )
+from routers.manager_permission_policy import ManagerPermissionRoute
 from schemas import (
     ManagerActionMessageResponse,
     ManagerQuickTariffListResponse,
@@ -34,6 +35,7 @@ router = APIRouter(
     prefix="/api/manager/tariffs",
     tags=["manager/tariffs"],
     dependencies=[Depends(get_current_username)],
+    route_class=ManagerPermissionRoute,
 )
 
 

--- a/routers/manager_warranties.py
+++ b/routers/manager_warranties.py
@@ -10,6 +10,7 @@ from routers.manager_operation_ids import (
     LIST_MANAGER_WARRANTY_POLICIES,
     PATCH_MANAGER_WARRANTY_POLICY,
 )
+from routers.manager_permission_policy import ManagerPermissionRoute
 from schemas import (
     ManagerEquipmentWarrantyCoverageResponse,
     ManagerWarrantyDecisionPayload,
@@ -20,7 +21,11 @@ from schemas import (
 from services.warranty_service import WarrantyService
 
 
-router = APIRouter(prefix="/api/manager", tags=["manager-warranties"])
+router = APIRouter(
+    prefix="/api/manager",
+    tags=["manager-warranties"],
+    route_class=ManagerPermissionRoute,
+)
 
 
 @router.get("/warranty-policies", response_model=ManagerWarrantyPolicyListResponse, operation_id=LIST_MANAGER_WARRANTY_POLICIES)

--- a/routers/manager_yandex_business.py
+++ b/routers/manager_yandex_business.py
@@ -10,6 +10,7 @@ from routers.manager_operation_ids import (
     GET_MANAGER_YANDEX_BUSINESS_PRICE_LIST,
     GET_MANAGER_YANDEX_BUSINESS_QUALITY_REPORT,
 )
+from routers.manager_permission_policy import ManagerPermissionRoute
 from services.yandex_business_price_list_service import YandexBusinessPriceListService
 
 
@@ -17,6 +18,7 @@ router = APIRouter(
     prefix="/api/manager/yandex-business",
     tags=["manager/yandex-business"],
     dependencies=[Depends(get_current_username)],
+    route_class=ManagerPermissionRoute,
 )
 
 

--- a/tests/unit/test_manager_backups_api_unit.py
+++ b/tests/unit/test_manager_backups_api_unit.py
@@ -2,7 +2,11 @@ import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
-from core.security import get_current_owner_username
+from core.security import (
+    AuthenticatedUser,
+    get_current_owner_username,
+    require_system_owner_access,
+)
 from routers.manager_backups import router as manager_backups_router
 from services.backup_service import BackupConfigurationError
 from services.google_oauth_credentials import GoogleTokenRefreshError
@@ -13,6 +17,14 @@ async def backups_client():
     app = FastAPI()
     app.include_router(manager_backups_router)
     app.dependency_overrides[get_current_owner_username] = lambda: "admin"
+    app.dependency_overrides[require_system_owner_access] = lambda: AuthenticatedUser(
+        username="admin",
+        auth_source="legacy",
+        role="owner",
+        tenant_id=1,
+        storefront_id=1,
+        is_system_tenant=True,
+    )
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:

--- a/tests/unit/test_manager_google_auth_api.py
+++ b/tests/unit/test_manager_google_auth_api.py
@@ -63,6 +63,9 @@ async def google_auth_client(monkeypatch):
         username=settings.ADMIN_USERNAME,
         auth_source="legacy",
         role="owner",
+        tenant_id=1,
+        storefront_id=1,
+        is_system_tenant=True,
     )
 
     async def _override_session():
@@ -305,3 +308,47 @@ async def test_google_auth_owner_binding_rejects_demoted_staff(monkeypatch):
             "username": "manager",
         },
     ) is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("tenant_is_system", "expected"),
+    [(True, True), (False, False)],
+)
+async def test_google_auth_owner_binding_requires_active_system_membership(
+    monkeypatch,
+    tenant_is_system,
+    expected,
+):
+    async def fake_get_by_id(_session, staff_user_id):
+        assert staff_user_id == 42
+        return SimpleNamespace(status="active", primary_role="owner", roles=["owner"])
+
+    class _Result:
+        @staticmethod
+        def first():
+            return (
+                SimpleNamespace(status="active", role="owner"),
+                SimpleNamespace(status="active", is_system=tenant_is_system),
+            )
+
+    class _Session:
+        @staticmethod
+        async def execute(_statement):
+            return _Result()
+
+    monkeypatch.setattr(
+        "routers.manager_google_auth.StaffUserService.get_by_id",
+        fake_get_by_id,
+    )
+
+    assert await _oauth_owner_binding_is_active(
+        _Session(),
+        {
+            "auth_source": "staff_password",
+            "staff_user_id": 42,
+            "username": "owner",
+            "tenant_membership_id": 7,
+            "tenant_id": 3,
+        },
+    ) is expected

--- a/tests/unit/test_manager_platform_permissions.py
+++ b/tests/unit/test_manager_platform_permissions.py
@@ -1,0 +1,464 @@
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.routing import APIRoute
+from httpx import ASGITransport, AsyncClient
+
+from core.database import get_session
+from core.security import (
+    AuthenticatedUser,
+    get_current_auth_context,
+    require_system_manager_tenant_scope,
+    require_system_owner_access,
+)
+from models.tenancy import TenantScope
+from routers import (
+    api_yandex_business,
+    manager_backups,
+    manager_brands,
+    manager_catalog,
+    manager_catalog_quality,
+    manager_crm,
+    manager_features,
+    manager_google_auth,
+    manager_leads,
+    manager_mdv_catalog,
+    manager_media_cleanup,
+    manager_media_gallery_read,
+    manager_media_gallery_write,
+    manager_media_ingest_write,
+    manager_media_library,
+    manager_media_processing,
+    manager_media_worker,
+    manager_orders,
+    manager_product_collections,
+    manager_repair_complaints,
+    manager_service_estimates,
+    manager_settings,
+    manager_specs,
+    manager_supply,
+    manager_tags,
+    manager_tariffs,
+    manager_warranties,
+    manager_yandex_business,
+)
+from routers.manager_permission_policy import (
+    PLATFORM_MANAGER_OPERATION_IDS,
+    SYSTEM_OWNER_OPERATION_IDS,
+)
+from services.settings_service import SettingsService
+from services.supplier_mapping_service import SupplierCatalogService
+from services.tag_service import TagService
+
+
+PLATFORM_ROUTERS = (
+    manager_catalog.router,
+    manager_brands.router,
+    manager_tags.router,
+    manager_features.router,
+    manager_specs.router,
+    manager_product_collections.router,
+    manager_mdv_catalog.router,
+    manager_supply.router,
+    manager_media_gallery_write.router,
+    manager_media_ingest_write.router,
+    manager_media_library.router,
+    manager_media_processing.router,
+    manager_media_cleanup.router,
+    manager_tariffs.router,
+    manager_repair_complaints.router,
+    manager_catalog_quality.router,
+    manager_service_estimates.router,
+    manager_warranties.router,
+    manager_media_gallery_read.router,
+    manager_crm.router,
+    manager_yandex_business.router,
+)
+
+PURE_GLOBAL_MUTATION_ROUTERS = (
+    manager_brands.router,
+    manager_tags.router,
+    manager_features.router,
+    manager_specs.router,
+    manager_product_collections.router,
+    manager_mdv_catalog.router,
+    manager_supply.router,
+    manager_media_gallery_write.router,
+    manager_media_ingest_write.router,
+    manager_media_library.router,
+    manager_media_processing.router,
+    manager_media_cleanup.router,
+)
+FULLY_SYSTEM_SCOPED_ROUTERS = (
+    manager_supply.router,
+    manager_media_library.router,
+    manager_media_processing.router,
+    manager_media_cleanup.router,
+)
+SERVICE_DICTIONARY_MUTATION_OPERATION_IDS = frozenset(
+    {
+        "create_manager_tariff",
+        "update_manager_tariff",
+        "delete_manager_tariff",
+        "create_manager_tariff_rule",
+        "update_manager_tariff_rule",
+        "delete_manager_tariff_rule",
+        "create_manager_repair_complaint_preset",
+        "update_manager_repair_complaint_preset",
+        "delete_manager_repair_complaint_preset",
+    }
+)
+SERVICE_DICTIONARY_TENANT_READ_OPERATION_IDS = frozenset(
+    {
+        "list_manager_tariffs",
+        "list_manager_quick_tariffs",
+        "list_manager_tariff_rules",
+        "list_manager_favorite_tariff_rules",
+        "list_manager_repair_complaint_presets",
+        "generate_manager_repair_act_ai_draft",
+    }
+)
+ADDITIONAL_PLATFORM_OPERATION_IDS = frozenset(
+    {
+        "get_manager_catalog_quality_report",
+        "create_manager_service_estimate",
+        "list_manager_service_estimates",
+        "get_manager_service_estimate",
+        "get_manager_service_estimate_order_lines",
+        "delete_manager_service_estimate",
+        "create_manager_warranty_policy",
+        "patch_manager_warranty_policy",
+        "get_image_variant_candidates",
+        "get_manager_crm_health_report",
+        "get_manager_yandex_business_quality_report",
+    }
+)
+ADDITIONAL_TENANT_OPERATION_IDS = frozenset(
+    {
+        "calculate_manager_install_estimate",
+        "list_manager_warranty_policies",
+        "list_manager_equipment_warranty_coverages",
+        "decide_manager_warranty_coverage",
+        "reuse_search",
+        "get_common_gallery_images",
+        "get_manager_yandex_business_price_list",
+    }
+)
+INFRASTRUCTURE_ROUTERS = (
+    manager_settings.router,
+    manager_backups.router,
+    manager_google_auth.router,
+)
+UNSAFE_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
+
+
+def _api_routes(*routers):
+    return [
+        route
+        for router in routers
+        for route in router.routes
+        if isinstance(route, APIRoute)
+    ]
+
+
+def _has_direct_dependency(route: APIRoute, dependency) -> bool:
+    return any(item.call is dependency for item in route.dependant.dependencies)
+
+
+def test_platform_policy_is_attached_to_every_registered_operation():
+    routes = _api_routes(*PLATFORM_ROUTERS, *INFRASTRUCTURE_ROUTERS)
+    by_operation_id = {route.operation_id: route for route in routes}
+
+    missing_platform = PLATFORM_MANAGER_OPERATION_IDS - by_operation_id.keys()
+    missing_infrastructure = SYSTEM_OWNER_OPERATION_IDS - by_operation_id.keys()
+    assert not missing_platform
+    assert not missing_infrastructure
+
+    for operation_id in PLATFORM_MANAGER_OPERATION_IDS:
+        assert _has_direct_dependency(
+            by_operation_id[operation_id],
+            require_system_manager_tenant_scope,
+        ), operation_id
+    for operation_id in SYSTEM_OWNER_OPERATION_IDS:
+        assert _has_direct_dependency(
+            by_operation_id[operation_id],
+            require_system_owner_access,
+        ), operation_id
+
+
+def test_every_global_mutation_in_policy_routers_requires_system_manager():
+    for route in _api_routes(*PURE_GLOBAL_MUTATION_ROUTERS):
+        if route.methods.intersection(UNSAFE_METHODS):
+            assert route.operation_id in PLATFORM_MANAGER_OPERATION_IDS, route.operation_id
+            assert _has_direct_dependency(route, require_system_manager_tenant_scope)
+
+    for route in _api_routes(manager_catalog.router):
+        is_catalog_operation = route.path.startswith("/api/manager/products") or route.path.startswith(
+            "/api/manager/catalog"
+        )
+        if is_catalog_operation and (
+            route.methods.intersection(UNSAFE_METHODS)
+            or route.path.startswith("/api/manager/catalog/import/jobs")
+        ):
+            assert route.operation_id in PLATFORM_MANAGER_OPERATION_IDS, route.operation_id
+            assert _has_direct_dependency(route, require_system_manager_tenant_scope)
+
+
+def test_sensitive_supply_and_reusable_media_routers_are_fully_system_scoped():
+    for route in _api_routes(*FULLY_SYSTEM_SCOPED_ROUTERS):
+        assert route.operation_id in PLATFORM_MANAGER_OPERATION_IDS, route.operation_id
+        assert _has_direct_dependency(route, require_system_manager_tenant_scope)
+
+
+def test_service_dictionary_policy_gates_mutations_but_preserves_tenant_reads():
+    routes = _api_routes(
+        manager_tariffs.router,
+        manager_repair_complaints.router,
+    )
+    by_operation_id = {route.operation_id: route for route in routes}
+
+    assert SERVICE_DICTIONARY_MUTATION_OPERATION_IDS <= by_operation_id.keys()
+    assert SERVICE_DICTIONARY_TENANT_READ_OPERATION_IDS <= by_operation_id.keys()
+    for operation_id in SERVICE_DICTIONARY_MUTATION_OPERATION_IDS:
+        assert operation_id in PLATFORM_MANAGER_OPERATION_IDS
+        assert _has_direct_dependency(
+            by_operation_id[operation_id],
+            require_system_manager_tenant_scope,
+        )
+    for operation_id in SERVICE_DICTIONARY_TENANT_READ_OPERATION_IDS:
+        assert operation_id not in PLATFORM_MANAGER_OPERATION_IDS
+        assert not _has_direct_dependency(
+            by_operation_id[operation_id],
+            require_system_manager_tenant_scope,
+        )
+
+
+def test_additional_global_surfaces_are_gated_without_widening_exceptions():
+    routers = (
+        manager_catalog_quality.router,
+        manager_service_estimates.router,
+        manager_warranties.router,
+        manager_media_gallery_read.router,
+        manager_crm.router,
+        manager_yandex_business.router,
+    )
+    routes = _api_routes(*routers)
+    by_operation_id = {route.operation_id: route for route in routes}
+
+    assert ADDITIONAL_PLATFORM_OPERATION_IDS <= by_operation_id.keys()
+    assert ADDITIONAL_TENANT_OPERATION_IDS <= by_operation_id.keys()
+    for operation_id in ADDITIONAL_PLATFORM_OPERATION_IDS:
+        assert operation_id in PLATFORM_MANAGER_OPERATION_IDS
+        assert _has_direct_dependency(
+            by_operation_id[operation_id],
+            require_system_manager_tenant_scope,
+        )
+    for operation_id in ADDITIONAL_TENANT_OPERATION_IDS:
+        assert operation_id not in PLATFORM_MANAGER_OPERATION_IDS
+        assert not _has_direct_dependency(
+            by_operation_id[operation_id],
+            require_system_manager_tenant_scope,
+        )
+
+    for route in _api_routes(api_yandex_business.router):
+        assert not _has_direct_dependency(route, require_system_manager_tenant_scope)
+
+
+def test_tenant_crm_routes_and_media_worker_do_not_gain_platform_gate():
+    tenant_routes = _api_routes(
+        manager_leads.router,
+        manager_orders.router,
+        manager_catalog.router,
+    )
+    tenant_routes = [
+        route
+        for route in tenant_routes
+        if "/customers" in route.path
+        or "/leads" in route.path
+        or "/orders" in route.path
+    ]
+    assert tenant_routes
+    for route in tenant_routes:
+        assert not _has_direct_dependency(route, require_system_manager_tenant_scope)
+        assert not _has_direct_dependency(route, require_system_owner_access)
+
+    worker_routes = _api_routes(manager_media_worker.router)
+    assert worker_routes
+    for route in worker_routes:
+        assert route.operation_id not in PLATFORM_MANAGER_OPERATION_IDS
+        assert not _has_direct_dependency(route, require_system_manager_tenant_scope)
+
+
+@pytest.mark.asyncio
+async def test_system_scope_dependencies_reject_non_system_tenants():
+    with pytest.raises(HTTPException) as manager_error:
+        await require_system_manager_tenant_scope(
+            TenantScope(tenant_id=2, storefront_id=20, is_system=False)
+        )
+    assert manager_error.value.status_code == 403
+
+    with pytest.raises(HTTPException) as owner_error:
+        await require_system_owner_access(
+            AuthenticatedUser(
+                username="tenant-owner",
+                auth_source="staff_password",
+                role="owner",
+                tenant_id=2,
+                storefront_id=20,
+                is_system_tenant=False,
+            )
+        )
+    assert owner_error.value.status_code == 403
+
+
+def _auth_context(*, role: str, is_system: bool) -> AuthenticatedUser:
+    return AuthenticatedUser(
+        username=f"{role}-user",
+        auth_source="staff_password",
+        staff_user_id=42,
+        role=role,
+        tenant_id=1 if is_system else 2,
+        storefront_id=10 if is_system else 20,
+        tenant_membership_id=100 if is_system else 200,
+        is_system_tenant=is_system,
+    )
+
+
+@pytest.mark.asyncio
+async def test_catalog_dictionary_mutation_is_denied_before_service_for_tenant_manager(
+    monkeypatch,
+):
+    app = FastAPI()
+    app.include_router(manager_tags.router)
+    app.dependency_overrides[get_current_auth_context] = lambda: _auth_context(
+        role="manager",
+        is_system=False,
+    )
+
+    async def _session():
+        yield object()
+
+    app.dependency_overrides[get_session] = _session
+    create_group = AsyncMock()
+    monkeypatch.setattr(TagService, "create_tag_group", create_group)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        response = await client.post(
+            "/api/manager/tags/groups",
+            json={"title": "Restricted"},
+        )
+
+    assert response.status_code == 403
+    create_group.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_sensitive_supplier_read_is_denied_before_service_for_tenant_manager(
+    monkeypatch,
+):
+    app = FastAPI()
+    app.include_router(manager_supply.router)
+    app.dependency_overrides[get_current_auth_context] = lambda: _auth_context(
+        role="manager",
+        is_system=False,
+    )
+
+    async def _session():
+        yield object()
+
+    app.dependency_overrides[get_session] = _session
+    list_suppliers = AsyncMock()
+    monkeypatch.setattr(SupplierCatalogService, "list_suppliers", list_suppliers)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        response = await client.get("/api/manager/suppliers")
+
+    assert response.status_code == 403
+    list_suppliers.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_system_manager_can_run_registered_catalog_mutation(monkeypatch):
+    app = FastAPI()
+    app.include_router(manager_tags.router)
+    app.dependency_overrides[get_current_auth_context] = lambda: _auth_context(
+        role="manager",
+        is_system=True,
+    )
+
+    async def _session():
+        yield object()
+
+    app.dependency_overrides[get_session] = _session
+    create_group = AsyncMock(
+        return_value={
+            "id": 1,
+            "title": "Allowed",
+            "slug": "allowed",
+            "color": "secondary",
+            "is_public": True,
+            "allow_multiple": False,
+            "tags": [],
+        }
+    )
+    monkeypatch.setattr(TagService, "create_tag_group", create_group)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        response = await client.post(
+            "/api/manager/tags/groups",
+            json={"title": "Allowed"},
+        )
+
+    assert response.status_code == 200
+    create_group.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_infrastructure_mutation_requires_system_owner(monkeypatch):
+    app = FastAPI()
+    app.include_router(manager_settings.router)
+    current_auth = {"value": _auth_context(role="owner", is_system=False)}
+    app.dependency_overrides[get_current_auth_context] = lambda: current_auth["value"]
+
+    async def _session():
+        yield object()
+
+    app.dependency_overrides[get_session] = _session
+    create_setting = AsyncMock(
+        return_value={
+            "key": "allowed",
+            "value": "yes",
+            "description": None,
+            "updated_at": datetime.now(timezone.utc),
+        }
+    )
+    monkeypatch.setattr(SettingsService, "create_setting", create_setting)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        denied = await client.post(
+            "/api/manager/settings",
+            json={"key": "allowed", "value": "yes"},
+        )
+        current_auth["value"] = _auth_context(role="owner", is_system=True)
+        allowed = await client.post(
+            "/api/manager/settings",
+            json={"key": "allowed", "value": "yes"},
+        )
+
+    assert denied.status_code == 403
+    assert allowed.status_code == 200
+    create_setting.assert_awaited_once()


### PR DESCRIPTION
## What changed

- adds one operation-ID based permission policy for platform-global Manager routes
- restricts 136 catalog, import, supplier, supply, media, saved-estimate, warranty-definition and operational-report operations to the active system tenant
- restricts 10 settings, backup and Google OAuth operations to system owners/admins
- revalidates active system-tenant membership in the Google OAuth callback before token exchange
- keeps tenant CRM, TenantOffer, public catalog references and the media worker outside the platform gate

## Why

Several entities are still intentionally shared at platform level and do not yet carry tenant ownership. A non-system tenant must not be able to read procurement data or mutate shared catalog, supplier, media and infrastructure state.

## Safety

- supplier/supply and internal reusable-media/job/cleanup routers are fully system-only, including sensitive reads
- Product/reference reads required to configure TenantOffer remain available
- stateless installation calculation, warranty reference list and public Yandex XML remain available
- route-policy tests fail when a covered operation is missing its required dependency
- the media worker keeps its separate service-token boundary

## Validation

- 44 focused RBAC, route-policy, operation-ID and router-boundary tests passed
- 19 representative PostgreSQL integration tests passed before the final additive route-policy expansion
- application introspection confirms 136 platform + 10 infrastructure operations, with each gate attached exactly once
- OpenAPI and generated Manager client were synchronized by the commit hook