### PR TITLE
Scope warranty coverage access to tenant

### DIFF
--- a/routers/manager_warranties.py
+++ b/routers/manager_warranties.py
@@ -2,7 +2,8 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from core.database import get_session
-from core.security import get_current_username
+from core.security import get_current_manager_tenant_scope, get_current_username
+from models.tenancy import TenantScope
 from routers.manager_operation_ids import (
     CREATE_MANAGER_WARRANTY_POLICY,
     DECIDE_MANAGER_WARRANTY_COVERAGE,
@@ -100,8 +101,16 @@ async def list_manager_equipment_warranty_coverages(
     equipment_id: int,
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
-    return await WarrantyService.list_coverages(session, equipment_id=equipment_id)
+    coverages = await WarrantyService.list_coverages(
+        session,
+        equipment_id=equipment_id,
+        tenant_scope=tenant_scope,
+    )
+    if coverages is None:
+        raise HTTPException(status_code=404, detail="Equipment not found")
+    return coverages
 
 
 @router.post(
@@ -114,6 +123,7 @@ async def decide_manager_warranty_coverage(
     payload: ManagerWarrantyDecisionPayload,
     username: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     try:
         data = await WarrantyService.record_decision(
@@ -122,6 +132,7 @@ async def decide_manager_warranty_coverage(
             action=payload.action,
             reason=payload.reason,
             decided_by=username,
+            tenant_scope=tenant_scope,
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/routers/manager_warranties.py
+++ b/routers/manager_warranties.py
@@ -19,6 +19,7 @@ from schemas import (
     ManagerWarrantyPolicyPayload,
     ManagerWarrantyPolicyResponse,
 )
+from services.warranty_coverage_service import WarrantyCoverageService
 from services.warranty_service import WarrantyService
 
 
@@ -103,7 +104,7 @@ async def list_manager_equipment_warranty_coverages(
     session: AsyncSession = Depends(get_session),
     tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
-    coverages = await WarrantyService.list_coverages(
+    coverages = await WarrantyCoverageService.list_coverages(
         session,
         equipment_id=equipment_id,
         tenant_scope=tenant_scope,
@@ -126,7 +127,7 @@ async def decide_manager_warranty_coverage(
     tenant_scope: TenantScope = Depends(get_current_manager_tenant_scope),
 ):
     try:
-        data = await WarrantyService.record_decision(
+        data = await WarrantyCoverageService.record_decision(
             session,
             coverage_id=coverage_id,
             action=payload.action,

--- a/services/tenant_entity_access_service.py
+++ b/services/tenant_entity_access_service.py
@@ -18,6 +18,7 @@ from sqlmodel import select
 from models import (
     Customer,
     CustomerEquipment,
+    EquipmentWarrantyCoverage,
     Lead,
     Order,
     OrderDocument,
@@ -159,6 +160,32 @@ class TenantEntityAccessService:
         if for_update:
             statement = statement.with_for_update(
                 of=(CustomerEquipment, Customer)
+            )
+        return (await session.execute(statement)).scalars().first()
+
+    @staticmethod
+    async def get_warranty_coverage(
+        session: AsyncSession,
+        coverage_id: int,
+        *,
+        tenant_scope: TenantScope,
+        for_update: bool = False,
+    ) -> EquipmentWarrantyCoverage | None:
+        statement = (
+            select(EquipmentWarrantyCoverage)
+            .join(
+                CustomerEquipment,
+                CustomerEquipment.id == EquipmentWarrantyCoverage.equipment_id,
+            )
+            .join(Customer, Customer.id == CustomerEquipment.customer_id)
+            .where(
+                EquipmentWarrantyCoverage.id == int(coverage_id),
+                tenant_scope_clause(Customer, tenant_scope),
+            )
+        )
+        if for_update:
+            statement = statement.with_for_update(
+                of=(EquipmentWarrantyCoverage, CustomerEquipment, Customer)
             )
         return (await session.execute(statement)).scalars().first()
 

--- a/services/warranty_coverage_service.py
+++ b/services/warranty_coverage_service.py
@@ -1,0 +1,184 @@
+"""Tenant-scoped warranty coverage reads and manager decisions."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from models import EquipmentWarrantyCoverage, EquipmentWarrantyDecision
+from models.tenancy import TenantScope
+from services.tenant_entity_access_service import TenantEntityAccessService
+
+
+class WarrantyCoverageService:
+    DECISIONS = {"voided", "restored"}
+
+    @staticmethod
+    def _naive(value: datetime | None) -> datetime | None:
+        if value is not None and value.tzinfo is not None:
+            return value.replace(tzinfo=None)
+        return value
+
+    @classmethod
+    def coverage_status(
+        cls,
+        coverage: EquipmentWarrantyCoverage,
+        *,
+        now: datetime | None = None,
+    ) -> dict[str, Any]:
+        moment = cls._naive(now) or datetime.now()
+        starts_at = cls._naive(coverage.starts_at)
+        expires_at = cls._naive(coverage.expires_at)
+        if coverage.decision_status == "voided":
+            time_status = "voided"
+        elif starts_at and starts_at > moment:
+            time_status = "scheduled"
+        elif expires_at is None:
+            time_status = "unknown"
+        else:
+            time_status = "active" if expires_at >= moment else "expired"
+
+        if not coverage.maintenance_required:
+            maintenance_status = "not_required"
+        elif coverage.next_maintenance_due_at is None:
+            maintenance_status = "unknown"
+        else:
+            due_at = cls._naive(coverage.next_maintenance_due_at)
+            grace_until = due_at + timedelta(days=int(coverage.grace_period_days or 0))
+            if moment > grace_until:
+                maintenance_status = "overdue"
+            elif moment >= due_at - timedelta(days=30):
+                maintenance_status = "due_soon"
+            else:
+                maintenance_status = "current"
+        return {
+            "time_status": time_status,
+            "maintenance_status": maintenance_status,
+            "requires_manager_decision": maintenance_status == "overdue"
+            and coverage.decision_status == "none",
+        }
+
+    @classmethod
+    def to_item(cls, coverage: EquipmentWarrantyCoverage) -> dict[str, Any]:
+        return {
+            "id": int(coverage.id or 0),
+            "equipment_id": int(coverage.equipment_id),
+            "component_id": coverage.component_id,
+            "policy_id": coverage.policy_id,
+            "coverage_type": coverage.coverage_type,
+            "source": coverage.source,
+            "starts_at": coverage.starts_at,
+            "expires_at": coverage.expires_at,
+            "maintenance_required": bool(coverage.maintenance_required),
+            "maintenance_interval_months": coverage.maintenance_interval_months,
+            "grace_period_days": int(coverage.grace_period_days or 0),
+            "allowed_maintenance_provider": coverage.allowed_maintenance_provider,
+            "next_maintenance_due_at": coverage.next_maintenance_due_at,
+            "terms_snapshot": coverage.terms_snapshot,
+            "policy_snapshot": coverage.policy_snapshot,
+            "decision_status": coverage.decision_status,
+            "decision_reason": coverage.decision_reason,
+            "decided_at": coverage.decided_at,
+            "decided_by": coverage.decided_by,
+            **cls.coverage_status(coverage),
+            "created_at": coverage.created_at,
+            "updated_at": coverage.updated_at,
+        }
+
+    @classmethod
+    async def list_coverages(
+        cls,
+        session: AsyncSession,
+        *,
+        equipment_id: int,
+        tenant_scope: TenantScope,
+    ) -> list[dict[str, Any]] | None:
+        equipment = await TenantEntityAccessService.get_equipment(
+            session,
+            equipment_id,
+            tenant_scope=tenant_scope,
+        )
+        if equipment is None:
+            return None
+        result = await session.execute(
+            select(EquipmentWarrantyCoverage)
+            .where(EquipmentWarrantyCoverage.equipment_id == equipment_id)
+            .order_by(
+                EquipmentWarrantyCoverage.coverage_type,
+                EquipmentWarrantyCoverage.id,
+            )
+        )
+        return [cls.to_item(item) for item in result.scalars().all()]
+
+    @classmethod
+    async def record_decision(
+        cls,
+        session: AsyncSession,
+        *,
+        coverage_id: int,
+        action: str,
+        reason: str,
+        decided_by: str,
+        tenant_scope: TenantScope,
+    ) -> dict[str, Any] | None:
+        coverage = await TenantEntityAccessService.get_warranty_coverage(
+            session,
+            coverage_id,
+            tenant_scope=tenant_scope,
+            for_update=True,
+        )
+        if coverage is None:
+            return None
+        return await cls._record_decision(
+            session,
+            coverage=coverage,
+            action=action,
+            reason=reason,
+            decided_by=decided_by,
+        )
+
+    @classmethod
+    async def _record_decision(
+        cls,
+        session: AsyncSession,
+        *,
+        coverage: EquipmentWarrantyCoverage,
+        action: str,
+        reason: str,
+        decided_by: str,
+    ) -> dict[str, Any]:
+        normalized_action = str(action or "").strip().lower()
+        if normalized_action not in cls.DECISIONS:
+            raise ValueError("Warranty decision must be voided or restored")
+        cleaned_reason = " ".join(str(reason or "").split())
+        if not cleaned_reason:
+            raise ValueError("Warranty decision reason is required")
+
+        coverage.decision_status = normalized_action
+        coverage.decision_reason = cleaned_reason
+        coverage.decided_at = datetime.now()
+        coverage.decided_by = decided_by
+        coverage.updated_at = datetime.now()
+        session.add(coverage)
+        session.add(
+            EquipmentWarrantyDecision(
+                coverage_id=int(coverage.id or 0),
+                action=normalized_action,
+                reason=cleaned_reason,
+                decided_by=decided_by,
+            )
+        )
+        if normalized_action == "restored":
+            from services.warranty_maintenance_service import WarrantyMaintenanceService
+
+            await session.flush()
+            await WarrantyMaintenanceService.restore_from_latest_maintenance(
+                session,
+                coverage=coverage,
+            )
+        await session.commit()
+        await session.refresh(coverage)
+        return cls.to_item(coverage)

--- a/services/warranty_service.py
+++ b/services/warranty_service.py
@@ -20,6 +20,8 @@ from models import (
     Supplier,
     WarrantyPolicy,
 )
+from models.tenancy import TenantScope
+from services.tenant_entity_access_service import TenantEntityAccessService
 
 
 class WarrantyService:
@@ -608,7 +610,20 @@ class WarrantyService:
         }
 
     @classmethod
-    async def list_coverages(cls, session: AsyncSession, *, equipment_id: int) -> list[dict[str, Any]]:
+    async def list_coverages(
+        cls,
+        session: AsyncSession,
+        *,
+        equipment_id: int,
+        tenant_scope: TenantScope,
+    ) -> list[dict[str, Any]] | None:
+        equipment = await TenantEntityAccessService.get_equipment(
+            session,
+            equipment_id,
+            tenant_scope=tenant_scope,
+        )
+        if equipment is None:
+            return None
         result = await session.execute(
             select(EquipmentWarrantyCoverage)
             .where(EquipmentWarrantyCoverage.equipment_id == equipment_id)
@@ -636,16 +651,40 @@ class WarrantyService:
         action: str,
         reason: str,
         decided_by: str,
+        tenant_scope: TenantScope,
     ) -> dict[str, Any] | None:
+        coverage = await TenantEntityAccessService.get_warranty_coverage(
+            session,
+            coverage_id,
+            tenant_scope=tenant_scope,
+            for_update=True,
+        )
+        if coverage is None:
+            return None
+        return await cls._record_decision(
+            session,
+            coverage=coverage,
+            action=action,
+            reason=reason,
+            decided_by=decided_by,
+        )
+
+    @classmethod
+    async def _record_decision(
+        cls,
+        session: AsyncSession,
+        *,
+        coverage: EquipmentWarrantyCoverage,
+        action: str,
+        reason: str,
+        decided_by: str,
+    ) -> dict[str, Any]:
         normalized_action = str(action or "").strip().lower()
         if normalized_action not in cls.DECISIONS:
             raise ValueError("Warranty decision must be voided or restored")
         cleaned_reason = " ".join(str(reason or "").split())
         if not cleaned_reason:
             raise ValueError("Warranty decision reason is required")
-        coverage = await session.get(EquipmentWarrantyCoverage, coverage_id)
-        if not coverage:
-            return None
         coverage.decision_status = normalized_action
         coverage.decision_reason = cleaned_reason
         coverage.decided_at = datetime.now()
@@ -654,7 +693,7 @@ class WarrantyService:
         session.add(coverage)
         session.add(
             EquipmentWarrantyDecision(
-                coverage_id=coverage_id,
+                coverage_id=int(coverage.id or 0),
                 action=normalized_action,
                 reason=cleaned_reason,
                 decided_by=decided_by,

--- a/services/warranty_service.py
+++ b/services/warranty_service.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import re
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -14,19 +14,18 @@ from models import (
     CustomerEquipment,
     EquipmentServiceEventType,
     EquipmentWarrantyCoverage,
-    EquipmentWarrantyDecision,
     Product,
     ProductSeries,
     Supplier,
     WarrantyPolicy,
 )
 from models.tenancy import TenantScope
-from services.tenant_entity_access_service import TenantEntityAccessService
+from services.warranty_coverage_service import WarrantyCoverageService
 
 
 class WarrantyService:
     COVERAGE_TYPES = {"supplier", "mvn_work", "legacy"}
-    DECISIONS = {"voided", "restored"}
+    DECISIONS = WarrantyCoverageService.DECISIONS
 
     @staticmethod
     def policy_to_item(
@@ -551,63 +550,11 @@ class WarrantyService:
 
     @classmethod
     def coverage_status(cls, coverage: EquipmentWarrantyCoverage, *, now: datetime | None = None) -> dict[str, Any]:
-        moment = cls._naive(now) or datetime.now()
-        starts_at = cls._naive(coverage.starts_at)
-        expires_at = cls._naive(coverage.expires_at)
-        if coverage.decision_status == "voided":
-            time_status = "voided"
-        elif starts_at and starts_at > moment:
-            time_status = "scheduled"
-        elif expires_at is None:
-            time_status = "unknown"
-        else:
-            time_status = "active" if expires_at >= moment else "expired"
-
-        if not coverage.maintenance_required:
-            maintenance_status = "not_required"
-        elif coverage.next_maintenance_due_at is None:
-            maintenance_status = "unknown"
-        else:
-            due_at = cls._naive(coverage.next_maintenance_due_at)
-            grace_until = due_at + timedelta(days=int(coverage.grace_period_days or 0))
-            if moment > grace_until:
-                maintenance_status = "overdue"
-            elif moment >= due_at - timedelta(days=30):
-                maintenance_status = "due_soon"
-            else:
-                maintenance_status = "current"
-        return {
-            "time_status": time_status,
-            "maintenance_status": maintenance_status,
-            "requires_manager_decision": maintenance_status == "overdue" and coverage.decision_status == "none",
-        }
+        return WarrantyCoverageService.coverage_status(coverage, now=now)
 
     @classmethod
     def to_item(cls, coverage: EquipmentWarrantyCoverage) -> dict[str, Any]:
-        return {
-            "id": int(coverage.id or 0),
-            "equipment_id": int(coverage.equipment_id),
-            "component_id": coverage.component_id,
-            "policy_id": coverage.policy_id,
-            "coverage_type": coverage.coverage_type,
-            "source": coverage.source,
-            "starts_at": coverage.starts_at,
-            "expires_at": coverage.expires_at,
-            "maintenance_required": bool(coverage.maintenance_required),
-            "maintenance_interval_months": coverage.maintenance_interval_months,
-            "grace_period_days": int(coverage.grace_period_days or 0),
-            "allowed_maintenance_provider": coverage.allowed_maintenance_provider,
-            "next_maintenance_due_at": coverage.next_maintenance_due_at,
-            "terms_snapshot": coverage.terms_snapshot,
-            "policy_snapshot": coverage.policy_snapshot,
-            "decision_status": coverage.decision_status,
-            "decision_reason": coverage.decision_reason,
-            "decided_at": coverage.decided_at,
-            "decided_by": coverage.decided_by,
-            **cls.coverage_status(coverage),
-            "created_at": coverage.created_at,
-            "updated_at": coverage.updated_at,
-        }
+        return WarrantyCoverageService.to_item(coverage)
 
     @classmethod
     async def list_coverages(
@@ -617,19 +564,11 @@ class WarrantyService:
         equipment_id: int,
         tenant_scope: TenantScope,
     ) -> list[dict[str, Any]] | None:
-        equipment = await TenantEntityAccessService.get_equipment(
+        return await WarrantyCoverageService.list_coverages(
             session,
-            equipment_id,
+            equipment_id=equipment_id,
             tenant_scope=tenant_scope,
         )
-        if equipment is None:
-            return None
-        result = await session.execute(
-            select(EquipmentWarrantyCoverage)
-            .where(EquipmentWarrantyCoverage.equipment_id == equipment_id)
-            .order_by(EquipmentWarrantyCoverage.coverage_type, EquipmentWarrantyCoverage.id)
-        )
-        return [cls.to_item(item) for item in result.scalars().all()]
 
     @classmethod
     async def generate_maintenance_reminders(
@@ -653,60 +592,14 @@ class WarrantyService:
         decided_by: str,
         tenant_scope: TenantScope,
     ) -> dict[str, Any] | None:
-        coverage = await TenantEntityAccessService.get_warranty_coverage(
+        return await WarrantyCoverageService.record_decision(
             session,
-            coverage_id,
-            tenant_scope=tenant_scope,
-            for_update=True,
-        )
-        if coverage is None:
-            return None
-        return await cls._record_decision(
-            session,
-            coverage=coverage,
+            coverage_id=coverage_id,
             action=action,
             reason=reason,
             decided_by=decided_by,
+            tenant_scope=tenant_scope,
         )
-
-    @classmethod
-    async def _record_decision(
-        cls,
-        session: AsyncSession,
-        *,
-        coverage: EquipmentWarrantyCoverage,
-        action: str,
-        reason: str,
-        decided_by: str,
-    ) -> dict[str, Any]:
-        normalized_action = str(action or "").strip().lower()
-        if normalized_action not in cls.DECISIONS:
-            raise ValueError("Warranty decision must be voided or restored")
-        cleaned_reason = " ".join(str(reason or "").split())
-        if not cleaned_reason:
-            raise ValueError("Warranty decision reason is required")
-        coverage.decision_status = normalized_action
-        coverage.decision_reason = cleaned_reason
-        coverage.decided_at = datetime.now()
-        coverage.decided_by = decided_by
-        coverage.updated_at = datetime.now()
-        session.add(coverage)
-        session.add(
-            EquipmentWarrantyDecision(
-                coverage_id=int(coverage.id or 0),
-                action=normalized_action,
-                reason=cleaned_reason,
-                decided_by=decided_by,
-            )
-        )
-        if normalized_action == "restored":
-            from services.warranty_maintenance_service import WarrantyMaintenanceService
-
-            await session.flush()
-            await WarrantyMaintenanceService.restore_from_latest_maintenance(session, coverage=coverage)
-        await session.commit()
-        await session.refresh(coverage)
-        return cls.to_item(coverage)
 
     @classmethod
     async def recalculate_after_maintenance(

--- a/tests/integration/test_manager_warranty_coverage_scope.py
+++ b/tests/integration/test_manager_warranty_coverage_scope.py
@@ -1,0 +1,209 @@
+from datetime import timedelta
+
+import pytest
+from httpx import AsyncClient
+from sqlmodel import select
+
+from core.security import create_access_token
+from models import (
+    Customer,
+    CustomerEquipment,
+    EquipmentWarrantyCoverage,
+    EquipmentWarrantyDecision,
+    StaffUser,
+    Storefront,
+    Tenant,
+    TenantMembership,
+)
+from models.common import CustomerType
+
+
+async def _create_owner(
+    db,
+    *,
+    tenant_id: int,
+    username: str,
+) -> StaffUser:
+    owner = StaffUser(
+        display_name=username,
+        status="active",
+        roles=["owner"],
+        primary_role="owner",
+        username=username,
+    )
+    db.add(owner)
+    await db.flush()
+    db.add(
+        TenantMembership(
+            tenant_id=tenant_id,
+            staff_user_id=int(owner.id),
+            role="owner",
+            status="active",
+        )
+    )
+    await db.flush()
+    return owner
+
+
+def _headers(owner: StaffUser) -> dict[str, str]:
+    token = create_access_token(
+        {
+            "sub": owner.username,
+            "staff_user_id": owner.id,
+            "auth_source": "warranty-coverage-scope-test",
+        },
+        expires_delta=timedelta(minutes=10),
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.mark.asyncio
+async def test_warranty_coverage_read_and_decision_are_tenant_scoped_and_atomic(
+    async_client: AsyncClient,
+    db,
+):
+    tenant_b = Tenant(
+        id=2,
+        slug="warranty-tenant-b",
+        display_name="Warranty Tenant B",
+        status="active",
+        is_system=False,
+    )
+    db.add(tenant_b)
+    await db.flush()
+    storefront_b = Storefront(
+        id=2,
+        tenant_id=int(tenant_b.id),
+        slug="main",
+        display_name="Warranty Tenant B Main",
+        status="active",
+        is_default=True,
+    )
+    db.add(storefront_b)
+    await db.flush()
+
+    owner_a = await _create_owner(
+        db,
+        tenant_id=1,
+        username="warranty-owner-a",
+    )
+    owner_b = await _create_owner(
+        db,
+        tenant_id=int(tenant_b.id),
+        username="warranty-owner-b",
+    )
+    customer_a = Customer(
+        tenant_id=1,
+        name="Warranty customer A",
+        phone="+375290000081",
+        type=CustomerType.individual,
+    )
+    customer_b = Customer(
+        tenant_id=int(tenant_b.id),
+        name="Warranty customer B",
+        phone="+375290000082",
+        type=CustomerType.individual,
+    )
+    db.add_all([customer_a, customer_b])
+    await db.flush()
+    equipment_a = CustomerEquipment(
+        customer_id=int(customer_a.id),
+        display_name="Tenant A equipment",
+    )
+    equipment_b = CustomerEquipment(
+        customer_id=int(customer_b.id),
+        display_name="Tenant B equipment",
+    )
+    db.add_all([equipment_a, equipment_b])
+    await db.flush()
+    coverage_a = EquipmentWarrantyCoverage(
+        equipment_id=int(equipment_a.id),
+        coverage_type="supplier",
+        terms_snapshot="Tenant A private warranty terms",
+        policy_snapshot={"owner": "tenant-a"},
+    )
+    coverage_b = EquipmentWarrantyCoverage(
+        equipment_id=int(equipment_b.id),
+        coverage_type="supplier",
+        terms_snapshot="Tenant B private warranty terms",
+        policy_snapshot={"owner": "tenant-b"},
+    )
+    db.add_all([coverage_a, coverage_b])
+    await db.commit()
+
+    headers_b = _headers(owner_b)
+    owned_list = await async_client.get(
+        f"/api/manager/equipment/{equipment_b.id}/warranty-coverages",
+        headers=headers_b,
+    )
+    foreign_list = await async_client.get(
+        f"/api/manager/equipment/{equipment_a.id}/warranty-coverages",
+        headers=headers_b,
+    )
+    missing_list = await async_client.get(
+        "/api/manager/equipment/999999/warranty-coverages",
+        headers=headers_b,
+    )
+    assert owned_list.status_code == 200
+    assert [item["id"] for item in owned_list.json()] == [coverage_b.id]
+    assert foreign_list.status_code == 404
+    assert missing_list.status_code == 404
+
+    foreign_before = {
+        "decision_status": coverage_a.decision_status,
+        "decision_reason": coverage_a.decision_reason,
+        "decided_at": coverage_a.decided_at,
+        "decided_by": coverage_a.decided_by,
+        "updated_at": coverage_a.updated_at,
+    }
+    foreign_decision = await async_client.post(
+        f"/api/manager/warranty-coverages/{coverage_a.id}/decision",
+        headers=headers_b,
+        json={"action": "voided", "reason": "Cross-tenant mutation"},
+    )
+    missing_decision = await async_client.post(
+        "/api/manager/warranty-coverages/999999/decision",
+        headers=headers_b,
+        json={"action": "voided", "reason": "Missing coverage"},
+    )
+    assert foreign_decision.status_code == 404
+    assert missing_decision.status_code == 404
+
+    await db.refresh(coverage_a)
+    assert {
+        "decision_status": coverage_a.decision_status,
+        "decision_reason": coverage_a.decision_reason,
+        "decided_at": coverage_a.decided_at,
+        "decided_by": coverage_a.decided_by,
+        "updated_at": coverage_a.updated_at,
+    } == foreign_before
+    decisions_before_positive = list(
+        (await db.execute(select(EquipmentWarrantyDecision))).scalars()
+    )
+    assert decisions_before_positive == []
+
+    owned_decision = await async_client.post(
+        f"/api/manager/warranty-coverages/{coverage_b.id}/decision",
+        headers=headers_b,
+        json={"action": "voided", "reason": "Owned warranty decision"},
+    )
+    assert owned_decision.status_code == 200, owned_decision.text
+    assert owned_decision.json()["decision_status"] == "voided"
+    assert owned_decision.json()["decision_reason"] == "Owned warranty decision"
+
+    await db.refresh(coverage_b)
+    decisions = list(
+        (await db.execute(select(EquipmentWarrantyDecision))).scalars()
+    )
+    assert coverage_b.decision_status == "voided"
+    assert coverage_b.decision_reason == "Owned warranty decision"
+    assert len(decisions) == 1
+    assert decisions[0].coverage_id == coverage_b.id
+    assert decisions[0].decided_by == owner_b.username
+
+    # The system tenant remains unable to cross the same tenant boundary.
+    system_foreign = await async_client.get(
+        f"/api/manager/equipment/{equipment_b.id}/warranty-coverages",
+        headers=_headers(owner_a),
+    )
+    assert system_foreign.status_code == 404

--- a/tests/unit/test_warranty_service.py
+++ b/tests/unit/test_warranty_service.py
@@ -8,6 +8,7 @@ from sqlmodel import SQLModel, select
 
 from models import (
     Brand,
+    Customer,
     CustomerEquipment,
     EquipmentMaintenanceReminder,
     EquipmentServiceEventType,
@@ -19,9 +20,34 @@ from models import (
     Supplier,
     WarrantyPolicy,
 )
+from models.tenancy import TenantScope
 from services.warranty_service import WarrantyService
 from services.warranty_maintenance_service import WarrantyMaintenanceService
 from services.equipment_warranty_bridge_service import EquipmentWarrantyBridgeService
+
+
+TEST_TENANT_SCOPE = TenantScope(tenant_id=1, storefront_id=1, is_system=True)
+
+
+async def _create_scoped_equipment(
+    session: AsyncSession,
+    *,
+    equipment_id: int,
+) -> CustomerEquipment:
+    customer = Customer(
+        tenant_id=TEST_TENANT_SCOPE.tenant_id,
+        name=f"Warranty customer {equipment_id}",
+        phone=f"+37529{equipment_id:07d}",
+    )
+    session.add(customer)
+    await session.flush()
+    equipment = CustomerEquipment(
+        id=equipment_id,
+        customer_id=int(customer.id),
+    )
+    session.add(equipment)
+    await session.flush()
+    return equipment
 
 
 @pytest.fixture
@@ -287,6 +313,7 @@ async def test_maintenance_advances_only_for_allowed_provider_and_within_grace(w
 @pytest.mark.asyncio
 async def test_manager_restore_uses_latest_verified_late_maintenance(warranty_session):
     due_at = datetime(2026, 5, 1, 9, 0)
+    await _create_scoped_equipment(warranty_session, equipment_id=51)
     coverage = EquipmentWarrantyCoverage(
         equipment_id=51,
         coverage_type="supplier",
@@ -313,6 +340,7 @@ async def test_manager_restore_uses_latest_verified_late_maintenance(warranty_se
         action="restored",
         reason="Late service accepted after inspection",
         decided_by="manager@example.test",
+        tenant_scope=TEST_TENANT_SCOPE,
     )
 
     assert restored is not None
@@ -401,6 +429,7 @@ async def test_policy_coverage_rejects_legacy_field_edit(warranty_session):
 @pytest.mark.asyncio
 async def test_overdue_reminders_are_idempotent_and_manual_decision_is_audited(warranty_session):
     due_at = datetime(2026, 6, 1, 9, 0, 0)
+    await _create_scoped_equipment(warranty_session, equipment_id=42)
     coverage = EquipmentWarrantyCoverage(
         equipment_id=42,
         coverage_type="supplier",
@@ -435,6 +464,7 @@ async def test_overdue_reminders_are_idempotent_and_manual_decision_is_audited(w
         action="voided",
         reason="  Maintenance was completed outside the allowed provider.  ",
         decided_by="manager@example.test",
+        tenant_scope=TEST_TENANT_SCOPE,
     )
     decisions = list(
         (await warranty_session.execute(select(EquipmentWarrantyDecision))).scalars().all()

--- a/tests/unit/test_warranty_service.py
+++ b/tests/unit/test_warranty_service.py
@@ -21,6 +21,7 @@ from models import (
     WarrantyPolicy,
 )
 from models.tenancy import TenantScope
+from services.warranty_coverage_service import WarrantyCoverageService
 from services.warranty_service import WarrantyService
 from services.warranty_maintenance_service import WarrantyMaintenanceService
 from services.equipment_warranty_bridge_service import EquipmentWarrantyBridgeService
@@ -334,7 +335,7 @@ async def test_manager_restore_uses_latest_verified_late_maintenance(warranty_se
     warranty_session.add_all([coverage, event])
     await warranty_session.flush()
 
-    restored = await WarrantyService.record_decision(
+    restored = await WarrantyCoverageService.record_decision(
         warranty_session,
         coverage_id=int(coverage.id),
         action="restored",


### PR DESCRIPTION
## What changed

- makes trusted Manager tenant scope mandatory in the core warranty coverage list/decision service methods
- validates equipment ownership through `CustomerEquipment -> Customer`
- loads decision targets through `Coverage -> CustomerEquipment -> Customer` under a row lock
- removes the remaining unscoped public service entry points
- returns the existing not-found contract for foreign and nonexistent identifiers
- keeps warranty coverage tenant-wide because Customer ownership is tenant-wide

## Why

Both endpoints previously accepted opaque equipment/coverage IDs without tenant ownership checks. That allowed cross-tenant warranty terms to be read and warranty decisions/audit rows to be mutated.

## Safety

- ownership is checked before validation, mutation or audit insertion
- the system tenant receives no cross-tenant bypass
- non-system tenants keep access to their own coverages; this is not converted into a platform-only feature
- global WarrantyPolicy permissions remain a separate concern in the platform-permissions PR

## Validation

- 34 focused tenant, warranty and equipment regression tests passed on PostgreSQL after hardening
- foreign and missing reads return 404
- foreign and missing decisions leave coverage timestamps/fields unchanged and create no audit rows
- owned decision creates exactly one audit row