### PR TITLE
Harden trusted storefront request gateway

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,12 +11,21 @@ CORS_ORIGINS=["https://mvn.by","https://dev.mvn.by","http://localhost:4321"]
 WEBSITE_URL=http://localhost:4321
 # Public storefront base URL used by backend catalog freshness purges.
 PUBLIC_SITE_URL=https://mvn.by
-# Optional rollout gate for a second storefront. Keep blank while only the
-# canonical MVN storefront is active. The same 32+ byte random secret is held
-# only by air-api and the trusted mvn-web server/edge runtime.
+# Optional rollout gate for a second storefront. Keep both primary fields blank
+# while only the canonical MVN storefront is active. The key ID is public; the
+# 32+ byte random secret is held only by air-api and the trusted storefront
+# server/edge runtime.
+STOREFRONT_CONTEXT_SIGNING_KEY_ID=
 STOREFRONT_CONTEXT_SIGNING_SECRET=
+STOREFRONT_CONTEXT_PREVIOUS_SIGNING_KEY_ID=
 STOREFRONT_CONTEXT_PREVIOUS_SIGNING_SECRET=
 STOREFRONT_CONTEXT_MAX_AGE_SECONDS=300
+# Bounds early buffering used to hash and replay signed multipart bodies.
+STOREFRONT_CONTEXT_MAX_BODY_BYTES=20971520
+# Comma-separated upstream air-api hosts. Blank uses safe environment defaults.
+STOREFRONT_CONTEXT_API_HOSTS=
+# Keep false until canonical MVN traffic is also server-signed.
+STOREFRONT_CONTEXT_REQUIRE_SIGNED_REQUESTS=false
 
 # --- Standalone storefront catalog synchronization ---
 # Use a narrowly scoped token with Actions access to the private mvn-web repo.

--- a/core/app_http.py
+++ b/core/app_http.py
@@ -13,6 +13,11 @@ from core.logger import logger
 from core.manager_error_codes import INTERNAL_ERROR, VALIDATION_ERROR, resolve_manager_error_message
 from core.manager_telemetry import ManagerTelemetryService
 from core.request_context import RequestContextMiddleware
+from core.storefront_request_gateway import StorefrontRequestGatewayMiddleware
+from core.storefront_request_envelope import (
+    private_storefront_response_headers,
+    storefront_signing_header_state,
+)
 
 
 def _is_manager_api_path(path: str) -> bool:
@@ -24,6 +29,18 @@ def _public_error_response() -> JSONResponse:
         status_code=500,
         content={"message": INTERNAL_SERVER_ERROR_MESSAGE},
     )
+
+
+def _apply_storefront_private_headers(
+    request: Request,
+    response: JSONResponse,
+) -> JSONResponse:
+    has_storefront_headers, _ = storefront_signing_header_state(
+        request.scope.get("headers", ())
+    )
+    if has_storefront_headers:
+        response.headers.update(private_storefront_response_headers())
+    return response
 
 
 def _manager_error_response(*, status_code: int, message: str, error_code: str, field_errors: dict[str, str] | None = None) -> JSONResponse:
@@ -101,13 +118,19 @@ async def global_exception_handler(request: Request, exc: Exception):
             status_code=500,
             error_code=INTERNAL_ERROR,
         )
-        return _manager_error_response(
-            status_code=500,
-            message=resolve_manager_error_message(INTERNAL_ERROR, INTERNAL_SERVER_ERROR_MESSAGE),
-            error_code=INTERNAL_ERROR,
+        return _apply_storefront_private_headers(
+            request,
+            _manager_error_response(
+                status_code=500,
+                message=resolve_manager_error_message(
+                    INTERNAL_ERROR,
+                    INTERNAL_SERVER_ERROR_MESSAGE,
+                ),
+                error_code=INTERNAL_ERROR,
+            ),
         )
 
-    return _public_error_response()
+    return _apply_storefront_private_headers(request, _public_error_response())
 
 
 def configure_http(app: FastAPI) -> None:
@@ -127,6 +150,10 @@ def configure_http(app: FastAPI) -> None:
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],
+    )
+    app.add_middleware(
+        StorefrontRequestGatewayMiddleware,
+        max_body_bytes=settings.STOREFRONT_CONTEXT_MAX_BODY_BYTES,
     )
     # Added last so it is the outermost user middleware and also covers CORS
     # preflight/short-circuit responses.

--- a/core/config.py
+++ b/core/config.py
@@ -1,3 +1,4 @@
+import re
 from urllib.parse import urlsplit
 
 from dotenv import load_dotenv
@@ -10,6 +11,11 @@ from core.runtime_controls import (
 )
 
 load_dotenv()
+
+
+_STOREFRONT_SIGNING_KEY_ID_PATTERN = re.compile(
+    r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$"
+)
 
 
 def _redact_settings_validation_error(error: ValidationError) -> ValidationError:
@@ -115,12 +121,54 @@ class Settings(BaseSettings):
     STATIC_DIR: str = "static"
     UPLOAD_DIR: str = "static/uploads"
     PUBLIC_SITE_URL: str = "https://mvn.by"
-    # Optional shared secret for a trusted storefront SSR/proxy. When unset,
-    # public writes keep using the canonical MVN storefront; a request that
+    # Optional runtime keyring for a trusted storefront SSR/proxy. When unset,
+    # public requests keep using the canonical MVN storefront; a request that
     # tries to select another storefront still fails closed.
+    STOREFRONT_CONTEXT_SIGNING_KEY_ID: str = ""
     STOREFRONT_CONTEXT_SIGNING_SECRET: str = ""
+    STOREFRONT_CONTEXT_PREVIOUS_SIGNING_KEY_ID: str = ""
     STOREFRONT_CONTEXT_PREVIOUS_SIGNING_SECRET: str = ""
     STOREFRONT_CONTEXT_MAX_AGE_SECONDS: int = 300
+    STOREFRONT_CONTEXT_MAX_BODY_BYTES: int = 20 * 1024 * 1024
+    STOREFRONT_CONTEXT_REQUIRE_SIGNED_REQUESTS: bool = False
+    # Comma-separated upstream API host allowlist. Blank keeps the safe
+    # environment-specific defaults used by production and local smoke tests.
+    STOREFRONT_CONTEXT_API_HOSTS: str = ""
+
+    @property
+    def storefront_context_api_hosts(self) -> tuple[str, ...]:
+        configured = tuple(
+            item.strip()
+            for item in self.STOREFRONT_CONTEXT_API_HOSTS.split(",")
+            if item.strip()
+        )
+        if configured:
+            return configured
+        if self.ENVIRONMENT == "production":
+            return ("api.mvn.by", "localhost", "127.0.0.1")
+        return (
+            "api.mvn.by",
+            "localhost",
+            "127.0.0.1",
+            "testserver",
+            "test",
+            "app",
+        )
+
+    @field_validator(
+        "STOREFRONT_CONTEXT_SIGNING_KEY_ID",
+        "STOREFRONT_CONTEXT_PREVIOUS_SIGNING_KEY_ID",
+    )
+    @classmethod
+    def _validate_storefront_context_key_id(cls, value: str) -> str:
+        normalized = str(value or "").strip()
+        if normalized and not _STOREFRONT_SIGNING_KEY_ID_PATTERN.fullmatch(
+            normalized
+        ):
+            raise ValueError(
+                "Storefront context signing key ID must use 1-64 ASCII letters, digits, dot, underscore or dash"
+            )
+        return normalized
 
     @field_validator(
         "STOREFRONT_CONTEXT_SIGNING_SECRET",
@@ -144,6 +192,50 @@ class Settings(BaseSettings):
                 "STOREFRONT_CONTEXT_MAX_AGE_SECONDS must be between 30 and 900"
             )
         return normalized
+
+    @field_validator("STOREFRONT_CONTEXT_MAX_BODY_BYTES")
+    @classmethod
+    def _validate_storefront_context_max_body_bytes(cls, value: int) -> int:
+        normalized = int(value)
+        if normalized < 1024 or normalized > 64 * 1024 * 1024:
+            raise ValueError(
+                "STOREFRONT_CONTEXT_MAX_BODY_BYTES must be between 1 KiB and 64 MiB"
+            )
+        return normalized
+
+    @model_validator(mode="after")
+    def _validate_storefront_context_keyring(self):
+        primary_id = bool(self.STOREFRONT_CONTEXT_SIGNING_KEY_ID)
+        primary_secret = bool(self.STOREFRONT_CONTEXT_SIGNING_SECRET)
+        previous_id = bool(self.STOREFRONT_CONTEXT_PREVIOUS_SIGNING_KEY_ID)
+        previous_secret = bool(self.STOREFRONT_CONTEXT_PREVIOUS_SIGNING_SECRET)
+
+        if primary_id != primary_secret:
+            raise ValueError(
+                "STOREFRONT_CONTEXT_SIGNING_KEY_ID and STOREFRONT_CONTEXT_SIGNING_SECRET must be configured together"
+            )
+        if previous_id != previous_secret:
+            raise ValueError(
+                "STOREFRONT_CONTEXT_PREVIOUS_SIGNING_KEY_ID and "
+                "STOREFRONT_CONTEXT_PREVIOUS_SIGNING_SECRET must be configured together"
+            )
+        if previous_id and not primary_id:
+            raise ValueError(
+                "Previous storefront signing key requires a configured primary key"
+            )
+        if (
+            previous_id
+            and self.STOREFRONT_CONTEXT_PREVIOUS_SIGNING_KEY_ID
+            == self.STOREFRONT_CONTEXT_SIGNING_KEY_ID
+        ):
+            raise ValueError(
+                "Primary and previous storefront signing key IDs must differ"
+            )
+        if self.STOREFRONT_CONTEXT_REQUIRE_SIGNED_REQUESTS and not primary_id:
+            raise ValueError(
+                "Signed storefront requests cannot be required without a primary signing key"
+            )
+        return self
 
     # Product media storage. Default stays local so CI/deploy do not require
     # R2/S3 secrets unless PRODUCT_MEDIA_STORAGE_PROVIDER is changed.

--- a/core/storefront_public_routes.py
+++ b/core/storefront_public_routes.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+
+# These endpoints have independent trust contracts and intentionally do not
+# select a tenant/storefront. Any expansion requires an explicit security review.
+INTENTIONALLY_OPEN_PUBLIC_V1_REQUESTS = frozenset(
+    {
+        ("GET", "/api/v1/address-suggest"),
+        ("GET", "/api/v1/feeds/yandex-business.yml"),
+        ("GET", "/api/v1/proxy/bank"),
+        ("GET", "/api/v1/proxy/egr"),
+    }
+)
+
+
+def requires_storefront_gateway(*, method: str, path: str) -> bool:
+    normalized_path = str(path or "")
+    if not normalized_path.startswith("/api/v1/"):
+        return False
+    return (str(method or "").upper(), normalized_path) not in (
+        INTENTIONALLY_OPEN_PUBLIC_V1_REQUESTS
+    )

--- a/core/storefront_request_auth.py
+++ b/core/storefront_request_auth.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import hmac
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+
+from core.storefront_request_envelope import storefront_signing_header_state
+from services.storefront_context_service import StorefrontContextService
+from services.storefront_context_signature_service import (
+    InvalidStorefrontContextSignature,
+    StorefrontContextSignatureService,
+)
+
+
+STOREFRONT_VERIFIED_ENVELOPE_SCOPE_KEY = "mvn.storefront_verified_envelope"
+
+
+@dataclass(frozen=True, slots=True)
+class StorefrontEnvelopeAuthConfig:
+    primary_key_id: str
+    primary_secret: str = field(repr=False)
+    previous_key_id: str = ""
+    previous_secret: str = field(default="", repr=False)
+    allowed_api_hosts: tuple[str, ...] = ()
+    max_age_seconds: int = 300
+
+
+@dataclass(frozen=True, slots=True)
+class VerifiedStorefrontEnvelope:
+    hostname: str
+
+
+def _decode_ascii_header(value: bytes, *, label: str) -> str:
+    try:
+        return value.decode("ascii")
+    except UnicodeDecodeError as exc:
+        raise InvalidStorefrontContextSignature(
+            f"Storefront context {label} is invalid"
+        ) from exc
+
+
+def _complete_signing_headers(
+    raw_headers: tuple[tuple[bytes, bytes], ...],
+) -> dict[bytes, bytes]:
+    has_storefront_headers, complete = storefront_signing_header_state(raw_headers)
+    if not has_storefront_headers or not complete:
+        raise InvalidStorefrontContextSignature(
+            "Storefront context signing headers are incomplete"
+        )
+    return {
+        name.lower(): value
+        for name, value in raw_headers
+        if name.lower().startswith(b"x-mvn-storefront-")
+    }
+
+
+def _select_signing_secret(
+    *,
+    supplied_key_id: str,
+    config: StorefrontEnvelopeAuthConfig,
+) -> str:
+    if not config.primary_key_id or not config.primary_secret:
+        raise InvalidStorefrontContextSignature(
+            "Storefront context signing is disabled"
+        )
+    if bool(config.previous_key_id) != bool(config.previous_secret):
+        raise InvalidStorefrontContextSignature(
+            "Storefront context signing keyring is invalid"
+        )
+
+    candidates = [(config.primary_key_id, config.primary_secret)]
+    if config.previous_key_id and config.previous_secret:
+        if config.previous_key_id == config.primary_key_id:
+            raise InvalidStorefrontContextSignature(
+                "Storefront context signing keyring is invalid"
+            )
+        candidates.append((config.previous_key_id, config.previous_secret))
+
+    selected = ""
+    supplied = supplied_key_id.encode("utf-8")
+    for candidate_id, candidate_secret in candidates:
+        if hmac.compare_digest(candidate_id.encode("utf-8"), supplied):
+            selected = candidate_secret
+    if not selected:
+        raise InvalidStorefrontContextSignature(
+            "Storefront context signing key is not allowed"
+        )
+    return selected
+
+
+def resolve_allowed_api_hostname(
+    *,
+    raw_headers: Iterable[tuple[bytes, bytes]],
+    allowed_api_hosts: Iterable[str],
+) -> str:
+    headers = tuple(raw_headers)
+    host_values = [value for name, value in headers if name.lower() == b"host"]
+    if len(host_values) != 1:
+        raise InvalidStorefrontContextSignature(
+            "Storefront context API host is invalid"
+        )
+    raw_hostname = _decode_ascii_header(host_values[0], label="API host")
+    try:
+        hostname = StorefrontContextService.normalize_hostname(raw_hostname)
+        allowed = {
+            StorefrontContextService.normalize_hostname(item)
+            for item in allowed_api_hosts
+        }
+    except (TypeError, ValueError) as exc:
+        raise InvalidStorefrontContextSignature(
+            "Storefront context API host allowlist is invalid"
+        ) from exc
+    if hostname not in allowed:
+        raise InvalidStorefrontContextSignature(
+            "Storefront context API host is not allowed"
+        )
+    return hostname
+
+
+def authenticate_storefront_envelope(
+    *,
+    raw_headers: Iterable[tuple[bytes, bytes]],
+    method: str,
+    raw_path: bytes,
+    query_string: bytes,
+    body_sha256: str,
+    config: StorefrontEnvelopeAuthConfig,
+) -> VerifiedStorefrontEnvelope:
+    """Verify one complete request envelope without parsing its body."""
+
+    headers = tuple(raw_headers)
+    signing_headers = _complete_signing_headers(headers)
+    key_id = _decode_ascii_header(
+        signing_headers[b"x-mvn-storefront-key-id"],
+        label="key ID",
+    )
+    storefront_hostname = _decode_ascii_header(
+        signing_headers[b"x-mvn-storefront-host"],
+        label="storefront host",
+    )
+    raw_timestamp = _decode_ascii_header(
+        signing_headers[b"x-mvn-storefront-timestamp"],
+        label="timestamp",
+    )
+    signature = _decode_ascii_header(
+        signing_headers[b"x-mvn-storefront-signature"],
+        label="signature",
+    )
+    if not raw_timestamp.isdigit() or (
+        raw_timestamp != "0" and raw_timestamp.startswith("0")
+    ):
+        raise InvalidStorefrontContextSignature(
+            "Storefront context timestamp is not canonical"
+        )
+
+    api_hostname = resolve_allowed_api_hostname(
+        raw_headers=headers,
+        allowed_api_hosts=config.allowed_api_hosts,
+    )
+    secret = _select_signing_secret(
+        supplied_key_id=key_id,
+        config=config,
+    )
+    target = StorefrontContextSignatureService.request_target(
+        raw_path=raw_path,
+        query_string=query_string,
+    )
+    hostname = StorefrontContextSignatureService.verify(
+        secret=secret,
+        timestamp=int(raw_timestamp),
+        method=method,
+        path_and_query=target,
+        api_hostname=api_hostname,
+        storefront_hostname=storefront_hostname,
+        body_sha256=body_sha256,
+        signature=signature,
+        max_age_seconds=config.max_age_seconds,
+    )
+    return VerifiedStorefrontEnvelope(hostname=hostname)

--- a/core/storefront_request_envelope.py
+++ b/core/storefront_request_envelope.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+
+STOREFRONT_HEADER_PREFIX = b"x-mvn-storefront-"
+STOREFRONT_SIGNING_HEADERS = frozenset(
+    {
+        b"x-mvn-storefront-key-id",
+        b"x-mvn-storefront-host",
+        b"x-mvn-storefront-timestamp",
+        b"x-mvn-storefront-signature",
+    }
+)
+PRIVATE_CACHE_CONTROL = "private, no-store"
+PRIVATE_CDN_CACHE_CONTROL = "no-store"
+STOREFRONT_VARY = "X-MVN-Storefront-Host"
+
+
+def storefront_signing_header_state(
+    raw_headers: Iterable[tuple[bytes, bytes]],
+) -> tuple[bool, bool]:
+    counts: dict[bytes, int] = {}
+    for raw_name, _ in raw_headers:
+        name = raw_name.lower()
+        if not name.startswith(STOREFRONT_HEADER_PREFIX):
+            continue
+        counts[name] = counts.get(name, 0) + 1
+
+    present = frozenset(counts)
+    if not present:
+        return False, False
+    complete = (
+        present == STOREFRONT_SIGNING_HEADERS
+        and all(counts[name] == 1 for name in STOREFRONT_SIGNING_HEADERS)
+    )
+    return True, complete
+
+
+def private_storefront_response_headers() -> dict[str, str]:
+    return {
+        "Cache-Control": PRIVATE_CACHE_CONTROL,
+        "CDN-Cache-Control": PRIVATE_CDN_CACHE_CONTROL,
+        "Vary": STOREFRONT_VARY,
+    }
+
+
+def force_private_storefront_response_headers(
+    raw_headers: Iterable[tuple[bytes, bytes]],
+) -> list[tuple[bytes, bytes]]:
+    """Force private caching while preserving and de-duplicating Vary."""
+
+    retained: list[tuple[bytes, bytes]] = []
+    vary_tokens: list[str] = []
+    seen_vary: set[str] = set()
+    for name, value in raw_headers:
+        normalized_name = name.lower()
+        if normalized_name in {b"cache-control", b"cdn-cache-control"}:
+            continue
+        if normalized_name == b"vary":
+            for item in value.decode("latin-1").split(","):
+                token = item.strip()
+                normalized_token = token.lower()
+                if token and normalized_token not in seen_vary:
+                    vary_tokens.append(token)
+                    seen_vary.add(normalized_token)
+            continue
+        retained.append((name, value))
+
+    if STOREFRONT_VARY.lower() not in seen_vary:
+        vary_tokens.append(STOREFRONT_VARY)
+    retained.extend(
+        (
+            (b"cache-control", PRIVATE_CACHE_CONTROL.encode("ascii")),
+            (b"cdn-cache-control", PRIVATE_CDN_CACHE_CONTROL.encode("ascii")),
+            (b"vary", ", ".join(vary_tokens).encode("latin-1")),
+        )
+    )
+    return retained

--- a/core/storefront_request_gateway.py
+++ b/core/storefront_request_gateway.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from hashlib import sha256
+
+from starlette.responses import JSONResponse
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+from core.config import settings
+from core.storefront_request_auth import (
+    STOREFRONT_VERIFIED_ENVELOPE_SCOPE_KEY,
+    StorefrontEnvelopeAuthConfig,
+    authenticate_storefront_envelope,
+    resolve_allowed_api_hostname,
+)
+from core.storefront_request_envelope import (
+    force_private_storefront_response_headers,
+    storefront_signing_header_state,
+)
+from core.storefront_public_routes import requires_storefront_gateway
+
+
+class StorefrontRequestGatewayMiddleware:
+    """Authenticate signed storefront requests before FastAPI parses them."""
+
+    def __init__(self, app: ASGIApp, *, max_body_bytes: int) -> None:
+        self.app = app
+        self.max_body_bytes = int(max_body_bytes)
+
+    async def __call__(
+        self,
+        scope: Scope,
+        receive: Receive,
+        send: Send,
+    ) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        raw_headers = tuple(scope.get("headers", ()))
+        has_storefront_headers, complete = storefront_signing_header_state(
+            raw_headers
+        )
+
+        async def send_private(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                message = dict(message)
+                message["headers"] = force_private_storefront_response_headers(
+                    message.get("headers", ())
+                )
+            await send(message)
+
+        async def reject(status_code: int, detail: str) -> None:
+            response = JSONResponse(
+                status_code=status_code,
+                content={"detail": detail},
+            )
+            await response(scope, receive, send_private)
+
+        if not has_storefront_headers:
+            if not requires_storefront_gateway(
+                method=str(scope.get("method", "")),
+                path=str(scope.get("path", "")),
+            ):
+                await self.app(scope, receive, send)
+                return
+            try:
+                resolve_allowed_api_hostname(
+                    raw_headers=raw_headers,
+                    allowed_api_hosts=settings.storefront_context_api_hosts,
+                )
+            except (TypeError, ValueError):
+                await reject(401, "Invalid storefront context")
+                return
+            if settings.STOREFRONT_CONTEXT_REQUIRE_SIGNED_REQUESTS:
+                await reject(401, "Invalid storefront context")
+                return
+            await self.app(scope, receive, send)
+            return
+
+        if not complete:
+            await reject(401, "Invalid storefront context")
+            return
+
+        body = bytearray()
+        digest = sha256()
+        while True:
+            message = await receive()
+            if message["type"] == "http.disconnect":
+                return
+            chunk = bytes(message.get("body", b""))
+            if len(body) + len(chunk) > self.max_body_bytes:
+                await reject(413, "Storefront request body is too large")
+                return
+            body.extend(chunk)
+            digest.update(chunk)
+            if not message.get("more_body", False):
+                break
+
+        try:
+            verified = authenticate_storefront_envelope(
+                raw_headers=raw_headers,
+                method=str(scope.get("method", "")),
+                raw_path=bytes(scope.get("raw_path", b"")),
+                query_string=bytes(scope.get("query_string", b"")),
+                body_sha256=digest.hexdigest(),
+                config=StorefrontEnvelopeAuthConfig(
+                    primary_key_id=settings.STOREFRONT_CONTEXT_SIGNING_KEY_ID,
+                    primary_secret=settings.STOREFRONT_CONTEXT_SIGNING_SECRET,
+                    previous_key_id=(
+                        settings.STOREFRONT_CONTEXT_PREVIOUS_SIGNING_KEY_ID
+                    ),
+                    previous_secret=(
+                        settings.STOREFRONT_CONTEXT_PREVIOUS_SIGNING_SECRET
+                    ),
+                    allowed_api_hosts=settings.storefront_context_api_hosts,
+                    max_age_seconds=settings.STOREFRONT_CONTEXT_MAX_AGE_SECONDS,
+                ),
+            )
+        except (TypeError, ValueError):
+            await reject(401, "Invalid storefront context")
+            return
+
+        scope[STOREFRONT_VERIFIED_ENVELOPE_SCOPE_KEY] = verified
+        replayed = False
+
+        async def replay_receive() -> Message:
+            nonlocal replayed
+            if replayed:
+                return {"type": "http.request", "body": b"", "more_body": False}
+            replayed = True
+            return {
+                "type": "http.request",
+                "body": bytes(body),
+                "more_body": False,
+            }
+
+        await self.app(scope, replay_receive, send_private)

--- a/core/tenant_scope.py
+++ b/core/tenant_scope.py
@@ -1,15 +1,49 @@
 """Trusted tenant/storefront dependencies for public and internal callers."""
 
-from fastapi import Depends, Header, HTTPException, Request, Response, status
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from fastapi import Depends, HTTPException, Request, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from core.config import settings
 from core.database import get_session
-from services.tenant_scope_service import SystemTenantScopeResolver, TenantScope
-from services.storefront_context_service import StorefrontContextService
-from services.storefront_context_signature_service import (
-    StorefrontContextSignatureService,
+from core.storefront_request_auth import (
+    STOREFRONT_VERIFIED_ENVELOPE_SCOPE_KEY,
+    VerifiedStorefrontEnvelope,
+    resolve_allowed_api_hostname,
 )
+from core.storefront_request_envelope import (
+    private_storefront_response_headers,
+    storefront_signing_header_state,
+)
+from services.storefront_context_service import (
+    StorefrontContext,
+    StorefrontContextService,
+)
+from services.tenant_scope_service import SystemTenantScopeResolver, TenantScope
+
+
+@dataclass(frozen=True)
+class VerifiedPublicStorefrontRequest:
+    signed: bool
+    context: StorefrontContext | None = None
+
+
+def _invalid_context() -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Invalid storefront context",
+        headers=private_storefront_response_headers(),
+    )
+
+
+def _request_api_hostname(request: Request) -> str:
+    return resolve_allowed_api_hostname(
+        raw_headers=request.scope.get("headers", ()),
+        allowed_api_hosts=settings.storefront_context_api_hosts,
+    )
 
 
 async def get_system_tenant_scope(
@@ -19,81 +53,61 @@ async def get_system_tenant_scope(
     return await SystemTenantScopeResolver.resolve(session)
 
 
-async def get_public_tenant_scope(
+def _verified_public_storefront_envelope(
     request: Request,
-    response: Response,
-    session: AsyncSession = Depends(get_session),
-    storefront_host: str | None = Header(
-        default=None,
-        alias="X-MVN-Storefront-Host",
-    ),
-    storefront_timestamp: str | None = Header(
-        default=None,
-        alias="X-MVN-Storefront-Timestamp",
-    ),
-    storefront_signature: str | None = Header(
-        default=None,
-        alias="X-MVN-Storefront-Signature",
-    ),
-) -> TenantScope:
-    """Resolve public provenance without trusting browser-owned tenant IDs.
-
-    No headers preserves the current canonical MVN behaviour. Selecting any
-    other active storefront requires the complete short-lived HMAC envelope
-    produced by a trusted website server or edge proxy.
-    """
-
-    supplied = (
-        storefront_host is not None,
-        storefront_timestamp is not None,
-        storefront_signature is not None,
+) -> VerifiedStorefrontEnvelope | None:
+    has_signing_headers, _ = storefront_signing_header_state(
+        request.scope.get("headers", ())
     )
-    if not any(supplied):
-        return await SystemTenantScopeResolver.resolve(session)
-    if not all(supplied):
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Incomplete storefront context",
-        )
+    if not has_signing_headers:
+        try:
+            _request_api_hostname(request)
+        except (TypeError, ValueError) as exc:
+            raise _invalid_context() from exc
+        if settings.STOREFRONT_CONTEXT_REQUIRE_SIGNED_REQUESTS:
+            raise _invalid_context()
+        return None
 
-    primary_secret = settings.STOREFRONT_CONTEXT_SIGNING_SECRET
-    if not primary_secret:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid storefront context",
-        )
+    verified = request.scope.get(STOREFRONT_VERIFIED_ENVELOPE_SCOPE_KEY)
+    if not isinstance(verified, VerifiedStorefrontEnvelope):
+        raise _invalid_context()
+    return verified
 
-    try:
-        timestamp = int(str(storefront_timestamp))
-        hostname = StorefrontContextSignatureService.verify_any(
-            secrets=(
-                primary_secret,
-                settings.STOREFRONT_CONTEXT_PREVIOUS_SIGNING_SECRET,
-            ),
-            timestamp=timestamp,
-            method=request.method,
-            path=request.url.path,
-            hostname=str(storefront_host),
-            signature=str(storefront_signature),
-            max_age_seconds=settings.STOREFRONT_CONTEXT_MAX_AGE_SECONDS,
-        )
-    except (TypeError, ValueError) as exc:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid storefront context",
-        ) from exc
 
-    context = await StorefrontContextService.resolve_by_host(session, hostname)
+async def verify_public_storefront_request(
+    verified: VerifiedStorefrontEnvelope | None = Depends(
+        _verified_public_storefront_envelope
+    ),
+    session: AsyncSession = Depends(get_session),
+) -> VerifiedPublicStorefrontRequest:
+    """Resolve a request authenticated by the outer ASGI gateway."""
+
+    if verified is None:
+        return VerifiedPublicStorefrontRequest(signed=False)
+    context = await StorefrontContextService.resolve_by_host(
+        session,
+        verified.hostname,
+    )
     if context is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Storefront is unavailable",
+            headers=private_storefront_response_headers(),
         )
-    # Signed projections vary by a trusted header rather than by URL. Never
-    # let a shared browser/CDN cache replay one storefront into another.
-    response.headers["Cache-Control"] = "private, no-store"
-    response.headers["CDN-Cache-Control"] = "no-store"
-    response.headers["Vary"] = "X-MVN-Storefront-Host"
+    return VerifiedPublicStorefrontRequest(signed=True, context=context)
+
+
+async def get_public_tenant_scope(
+    verified: VerifiedPublicStorefrontRequest = Depends(
+        verify_public_storefront_request
+    ),
+    session: AsyncSession = Depends(get_session),
+) -> TenantScope:
+    """Resolve exact public provenance after authenticating the request."""
+
+    if verified.context is None:
+        return await SystemTenantScopeResolver.resolve(session)
+    context = verified.context
     return TenantScope(
         tenant_id=context.tenant_id,
         storefront_id=context.storefront_id,

--- a/docs/storefront-context-contract.md
+++ b/docs/storefront-context-contract.md
@@ -1,99 +1,203 @@
-# Trusted public storefront context
+# Trusted public storefront request contract
 
-## Purpose
+## Purpose and trust boundary
 
-Public Lead and Order provenance must come from the storefront serving the
-request, never from a browser-provided tenant or storefront ID. The canonical
-MVN website keeps working without extra headers. A second storefront is enabled
-only through a short-lived context signed by its trusted SSR or edge proxy.
+Public catalog reads, Lead creation and checkout must get their storefront from
+the server runtime that served the website. Browser-provided tenant or
+storefront IDs, `Origin`, `X-Forwarded-Host` and unsigned storefront headers are
+never authority.
 
-## Request envelope
+The canonical MVN website may temporarily call the ordinary API host without a
+signature. A non-canonical storefront is accepted only through a complete
+short-lived HMAC envelope produced by its trusted SSR or same-origin proxy.
 
-The trusted runtime sends all three headers:
+## Required signed headers
 
-- `X-MVN-Storefront-Host`: normalized public hostname, for example
+The trusted runtime sends exactly one value for each header:
+
+- `X-MVN-Storefront-Key-Id`: configured runtime key ID, for example
+  `mvn-web-2026-08`;
+- `X-MVN-Storefront-Host`: the public storefront hostname, for example
   `orsha.mvn.by`;
-- `X-MVN-Storefront-Timestamp`: Unix timestamp in seconds;
-- `X-MVN-Storefront-Signature`: `v1=<lowercase sha256 hex>`.
+- `X-MVN-Storefront-Timestamp`: canonical Unix seconds (`0` or a decimal value
+  with no sign, whitespace or leading zeroes);
+- `X-MVN-Storefront-Signature`: `v1=<64 lowercase SHA-256 hex characters>`.
 
-The HMAC-SHA256 input is UTF-8 text with no trailing newline:
+Any incomplete set, duplicate value, unknown `X-MVN-Storefront-*` header,
+unknown key ID or malformed value returns `401`. The browser-facing proxy must
+strip all incoming headers with that prefix before creating its own envelope.
+Incomplete, duplicate and unknown sets are rejected at the outer ASGI boundary
+without reading or parsing the request body.
+These infrastructure credentials are deliberately omitted from the generated
+OpenAPI/browser client; this document is the signing contract for trusted
+server runtimes.
+
+## Canonical v1 message
+
+The signature is HMAC-SHA256 over these seven fields in this exact order:
 
 ```text
 v1
 <timestamp>
-<UPPERCASE HTTP method>
-<request path beginning with />
-<lowercase IDNA hostname without port or trailing dot>
+<HTTP method>
+<raw path and optional raw query>
+<upstream API hostname>
+<storefront hostname>
+<lowercase SHA-256 hex of the exact request body>
 ```
 
-The signing key is `STOREFRONT_CONTEXT_SIGNING_SECRET` and must contain at
-least 32 bytes. The API accepts a timestamp no more than
-`STOREFRONT_CONTEXT_MAX_AGE_SECONDS` in the past or future; the allowed range
-for that setting is 30–900 seconds.
+There is one ASCII LF byte (`0x0a`) between fields and no trailing newline.
+The complete byte sequence is signed with the UTF-8 secret.
 
-Signatures are bound to method, path and hostname. Query parameters and request
-bodies are deliberately excluded: this envelope selects public provenance; it
-does not replace endpoint validation, idempotency or authentication.
+Canonicalization rules:
 
-## Fail-closed behaviour
+1. `timestamp` is canonical base-10 Unix seconds.
+2. The HTTP method is uppercased as ASCII.
+3. The target starts with `/`. Append `?` and the raw query bytes only when the
+   query is non-empty. Do not decode, reorder or re-encode query parameters.
+   The fragment is never present. CR or LF is invalid.
+4. The upstream API hostname comes from the actual HTTP `Host`/`:authority`
+   received by air-api. It is lowercased, converted to IDNA ASCII and stripped
+   of a port and trailing dot. It must also be in
+   `STOREFRONT_CONTEXT_API_HOSTS` (the production default includes
+   `api.mvn.by` and loopback smoke-check hosts).
+5. The storefront hostname uses the same lowercase IDNA/no-port/no-trailing-dot
+   normalization.
+6. Hash the exact transmitted body bytes, before JSON/form parsing. The empty
+   body digest is
+   `e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`.
 
-- no context headers: resolve canonical active `mvn/main` exactly as before;
-- incomplete, malformed, expired or forged envelope: `401`;
-- envelope supplied while signing is not configured securely: `401`;
-- valid signature for an unknown, disabled or non-public hostname: `404`;
-- valid context: resolve the active `StorefrontDomain -> Storefront -> Tenant`
-  relation and pass the resulting immutable `TenantScope` to the command.
+For a structurally complete envelope, air-api reads the exact bounded body,
+checks the API host, key ID, timestamp, raw target, storefront host, digest and
+HMAC, and only then calls FastAPI. The verified normalized storefront hostname
+is carried inward as an immutable ASGI scope marker; route dependencies never
+re-authenticate from raw headers. The body is replayed unchanged for JSON or
+multipart parsing. This buffer is hard-limited by
+`STOREFRONT_CONTEXT_MAX_BODY_BYTES` (20 MiB by default, matching the current API
+ingress limit); an oversized signed request returns `413` without reaching the
+endpoint. A valid signature with malformed JSON can therefore return `422`,
+while a partial or forged envelope with the same bytes returns `401` before the
+parser or database dependency runs.
+
+Changing method, raw path, raw query, upstream API host, storefront host or any
+body byte invalidates the signature.
+
+## Runtime keyring and rotation
+
+Keys exist only in runtime secret configuration:
+
+- `STOREFRONT_CONTEXT_SIGNING_KEY_ID` and
+  `STOREFRONT_CONTEXT_SIGNING_SECRET` are the primary pair;
+- `STOREFRONT_CONTEXT_PREVIOUS_SIGNING_KEY_ID` and
+  `STOREFRONT_CONTEXT_PREVIOUS_SIGNING_SECRET` are the optional rotation pair;
+- every secret contains at least 32 UTF-8 bytes;
+- key IDs are a case-sensitive allowlist and are never supplied by the
+  database or a public payload.
+
+The API selects one allowed key by ID and compares the HMAC in constant time.
+The previous key is accepted only while a complete primary pair is configured.
+Clearing the primary pair disables every signed request, including a request
+using a stale previous key.
+
+Zero-downtime rotation:
+
+1. Add the new pair as primary and keep the old pair as previous.
+2. Deploy air-api, then switch each trusted storefront runtime to the new key.
+3. Run read, Lead and Order canaries with the new key.
+4. Wait longer than `STOREFRONT_CONTEXT_MAX_AGE_SECONDS`.
+5. Remove the previous pair.
+
+Never reuse `SECRET_KEY`, bot credentials or a Cloudflare token.
+
+The current primary/previous slots form one MVN-operated platform keyring: a
+holder can sign for any active storefront domain. It is therefore suitable only
+for runtimes controlled by MVN. Before an external tenant controls its own
+runtime, introduce per-runtime credentials bound to an explicit storefront-host
+allowlist or keep signing in the centrally managed MVN edge.
+
+## Replay boundary
+
+`STOREFRONT_CONTEXT_MAX_AGE_SECONDS` is constrained to 30–900 seconds. Requests
+outside the past/future window fail closed. The body digest prevents changing a
+captured request.
+
+There is deliberately no in-memory nonce cache: it would allow replay against
+another HA replica. Until a shared PostgreSQL/Redis nonce ledger is introduced,
+an identical captured request can be replayed within the accepted time window.
+Every public write therefore still needs its domain idempotency contract. Keep
+the window short, use TLS, never log the envelope, and do not treat this HMAC as
+user authentication.
+
+## Resolution and compatibility
+
+- No signing headers, an allowed ordinary API host and
+  `STOREFRONT_CONTEXT_REQUIRE_SIGNED_REQUESTS=false`: resolve only canonical
+  active `mvn/main`; `Host`, `Origin` or forwarded browser headers cannot select
+  another storefront.
+- No signing headers on an unapproved/non-API host: `401`.
+- `STOREFRONT_CONTEXT_REQUIRE_SIGNED_REQUESTS=true`: every protected public
+  storefront request must be signed, including canonical MVN traffic.
+- Invalid, stale or forged envelope: `401`.
+- Valid signature for an unknown, disabled or non-public
+  `StorefrontDomain -> Storefront -> Tenant` relation: `404`.
+- Valid relation: pass its immutable `TenantScope` to the public command.
+
+For protected `/api/v1/**` routes, unsigned API-host validation and the
+require-signed switch also run at the outer ASGI boundary. A wrong `Host` or an
+unsigned request while the switch is enabled therefore returns `401` before
+body parsing. Canonical unsigned requests remain unbuffered when the switch is
+off, preserving ordinary browser CORS behavior.
+
+Every response to a request containing any `X-MVN-Storefront-*` header is
+forced to `Cache-Control: private, no-store`, `CDN-Cache-Control: no-store` and
+`Vary: X-MVN-Storefront-Host`. This is applied at the final ASGI response
+boundary, so it also covers rejected oversized bodies (`413`), FastAPI body
+validation (`422`), route misses (`404`) and invalid/partial envelopes (`401`).
+Existing `Vary` values are preserved and de-duplicated. Unhandled errors are
+given the same headers explicitly by the global exception handler because
+Starlette's outer error middleware creates that response outside the user
+middleware chain. Shared caching belongs behind the trusted storefront runtime
+and must be keyed by storefront.
+
+The signing envelope is a server-to-server contract for trusted SSR or a
+same-origin website proxy. Browsers must not receive credentials or send these
+headers directly, and CORS preflight is not an authentication or signing
+boundary. In air-api the signed-gateway/private-response middleware wraps CORS,
+session and routing middleware; CORS behavior therefore remains unchanged while
+all storefront-marked responses remain non-cacheable by shared intermediaries.
 
 Neither `tenant_id` nor `storefront_id` is accepted from public payloads. The
-public `GET /api/v1/storefront/context` projection exposes slugs, branding
-identity, domain, city, locale and currency, but no internal IDs.
+public context DTO exposes only public slugs and display attributes.
 
-## Proxy boundary
+## Protected public surfaces
 
-The browser must not know the signing secret. A non-canonical storefront sends
-browser writes to a same-origin server route; that trusted route strips any
-incoming `X-MVN-Storefront-*` headers, signs the API target itself and forwards
-the request. Direct client-controlled headers are not authority.
+The gateway is attached to storefront context, catalog/revision/spec/filter,
+content/config/collection reads, public Lead adapters and public Order checkout.
+It is not attached to Manager, internal bot, system or health/readiness
+boundaries. The only intentionally open `/api/v1` routes are the exact `GET`
+endpoints for EGR proxy, bank proxy, address suggestions and Yandex Business
+feed; an app-level route inventory test rejects any new unclassified route.
 
-The same rule applies to server-rendered catalog and configuration reads. Edge
-or SSR logs must not record the secret or the complete signature envelope.
-Every successfully signed API response is marked `Cache-Control: private,
-no-store` and `CDN-Cache-Control: no-store`; shared caching belongs behind the
-same-origin storefront runtime and must be keyed by storefront identity.
+## Production canary and rollback
 
-The current key is platform-wide and is suitable only for MVN-owned runtimes.
-Do not distribute it to an external tenant. Before an external white-label
-runtime is operated outside MVN-controlled infrastructure, replace this key
-with a per-runtime credential/key ID or keep signing in one centrally managed
-edge boundary.
+Before enabling a second storefront:
 
-## Rotation without downtime
+1. Keep `STOREFRONT_CONTEXT_REQUIRE_SIGNED_REQUESTS=false`.
+2. Configure the API primary key pair and allowed upstream API host on both HA
+   runtimes; configure the same pair only in the trusted storefront server.
+3. Create the second `Storefront` and active primary `StorefrontDomain` through
+   the reviewed tenant setup path. Do not put test domains in migrations.
+4. Call `GET /api/v1/storefront/context` through the proxy and verify its public
+   identity and no-store headers.
+5. Run one signed catalog query, one Lead and one Order canary. Verify exact
+   persisted `tenant_id/storefront_id` and Manager visibility.
+6. Tamper with query, body, host and signature; each request must return `401`
+   and create no row.
+7. Keep canonical unsigned `mvn.by` smoke checks green. Turn on
+   `STOREFRONT_CONTEXT_REQUIRE_SIGNED_REQUESTS` only after canonical traffic is
+   also server-signed.
 
-1. Generate a new random secret of at least 32 bytes.
-2. Deploy the API with the new value in
-   `STOREFRONT_CONTEXT_SIGNING_SECRET` and the old value in
-   `STOREFRONT_CONTEXT_PREVIOUS_SIGNING_SECRET`.
-3. Switch every trusted storefront runtime to the new primary secret.
-4. Verify both Lead and Order canaries and wait longer than the maximum
-   signature lifetime.
-5. Clear `STOREFRONT_CONTEXT_PREVIOUS_SIGNING_SECRET` from the API.
-
-The previous key is accepted only while a non-empty primary key is configured.
-Clearing the primary key is the fail-closed kill switch and disables signed
-context even if a stale previous-key variable remains in the environment.
-
-Never reuse `SECRET_KEY`, bot credentials or a Cloudflare token for this
-contract.
-
-## Canary gate
-
-Before enabling traffic for a second storefront:
-
-1. create its `Storefront` and primary active `StorefrontDomain`;
-2. call `GET /api/v1/storefront/context` with a valid signed envelope and check
-   the expected slug, hostname, city, locale and currency;
-3. create one test Lead and one test Order through the same trusted proxy;
-4. verify their persisted `tenant_id/storefront_id` pair and Manager visibility;
-5. repeat each mutation with a forged signature and verify `401` with no row;
-6. test rollback by removing the new domain from routing while keeping
-   canonical `mvn/main` healthy.
+Rollback is configuration-first: remove second-storefront routing, disable the
+require-signed switch, and clear the primary/previous key pairs if the trusted
+proxy is suspected. Canonical unsigned `mvn/main` remains available while the
+switch is false. No schema rollback is required.

--- a/docs/tenant-scope-rollout.md
+++ b/docs/tenant-scope-rollout.md
@@ -44,18 +44,20 @@ membership role is authoritative; a role stored in an old token is ignored.
 Until the Manager UI has an explicit tenant switcher, zero or more than one
 active membership candidate fails closed with `403`.
 
-Canonical MVN fallback remains available for compatibility. A second
-storefront now uses the signed server-to-server contract documented in
+Canonical MVN fallback remains available for compatibility on the approved API
+host. A second storefront now uses the signed server-to-server contract
+documented in
 [`storefront-context-contract.md`](storefront-context-contract.md). Public Lead
-and Order endpoints accept only that complete short-lived envelope when
-selecting a non-canonical storefront; internal IDs and unsigned host headers
-remain untrusted.
+and Order endpoints, checkout, public context and storefront-facing read APIs
+accept only that complete method/path/query/API-host/storefront-host/body-bound
+envelope when selecting a non-canonical storefront; internal IDs and unsigned
+host headers remain untrusted.
 
 Before a second storefront receives traffic, the remaining consumers must use
 the same boundary:
 
-- storefront catalog/config requests must pass through its trusted proxy or
-  signed server runtime;
+- storefront catalog/config requests pass through its trusted proxy or signed
+  server runtime; tenant-aware projections are enabled independently;
 - Manager needs an explicit, server-validated membership selector before one
   user may actively work in more than one tenant;
 - scheduled integrations need a tenant-bound server configuration.

--- a/manager_frontend/src/client/services/ApiService.ts
+++ b/manager_frontend/src/client/services/ApiService.ts
@@ -295,26 +295,15 @@ export class ApiService {
     /**
      * Create Public Contact Lead
      * @param requestBody
-     * @param xMvnStorefrontHost
-     * @param xMvnStorefrontTimestamp
-     * @param xMvnStorefrontSignature
      * @returns PublicContactLeadResponse Successful Response
      * @throws ApiError
      */
     public static createPublicContactLead(
         requestBody: PublicContactLeadPayload,
-        xMvnStorefrontHost?: (string | null),
-        xMvnStorefrontTimestamp?: (string | null),
-        xMvnStorefrontSignature?: (string | null),
     ): CancelablePromise<PublicContactLeadResponse> {
         return __request(OpenAPI, {
             method: 'POST',
             url: '/api/v1/leads/contact',
-            headers: {
-                'X-MVN-Storefront-Host': xMvnStorefrontHost,
-                'X-MVN-Storefront-Timestamp': xMvnStorefrontTimestamp,
-                'X-MVN-Storefront-Signature': xMvnStorefrontSignature,
-            },
             body: requestBody,
             mediaType: 'application/json',
             errors: {
@@ -326,27 +315,18 @@ export class ApiService {
      * Create Installation Estimate Lead
      * @param idempotencyKey
      * @param formData
-     * @param xMvnStorefrontHost
-     * @param xMvnStorefrontTimestamp
-     * @param xMvnStorefrontSignature
      * @returns InstallationEstimateLeadResponse Successful Response
      * @throws ApiError
      */
     public static createInstallationEstimateLead(
         idempotencyKey: string,
         formData: Body_create_installation_estimate_lead,
-        xMvnStorefrontHost?: (string | null),
-        xMvnStorefrontTimestamp?: (string | null),
-        xMvnStorefrontSignature?: (string | null),
     ): CancelablePromise<InstallationEstimateLeadResponse> {
         return __request(OpenAPI, {
             method: 'POST',
             url: '/api/v1/leads/installation-estimate',
             headers: {
                 'Idempotency-Key': idempotencyKey,
-                'X-MVN-Storefront-Host': xMvnStorefrontHost,
-                'X-MVN-Storefront-Timestamp': xMvnStorefrontTimestamp,
-                'X-MVN-Storefront-Signature': xMvnStorefrontSignature,
             },
             formData: formData,
             mediaType: 'multipart/form-data',
@@ -361,26 +341,15 @@ export class ApiService {
     /**
      * Create Product Availability Lead
      * @param requestBody
-     * @param xMvnStorefrontHost
-     * @param xMvnStorefrontTimestamp
-     * @param xMvnStorefrontSignature
      * @returns ProductAvailabilityLeadResponse Successful Response
      * @throws ApiError
      */
     public static createProductAvailabilityLead(
         requestBody: ProductAvailabilityLeadPayload,
-        xMvnStorefrontHost?: (string | null),
-        xMvnStorefrontTimestamp?: (string | null),
-        xMvnStorefrontSignature?: (string | null),
     ): CancelablePromise<ProductAvailabilityLeadResponse> {
         return __request(OpenAPI, {
             method: 'POST',
             url: '/api/v1/leads/product-availability',
-            headers: {
-                'X-MVN-Storefront-Host': xMvnStorefrontHost,
-                'X-MVN-Storefront-Timestamp': xMvnStorefrontTimestamp,
-                'X-MVN-Storefront-Signature': xMvnStorefrontSignature,
-            },
             body: requestBody,
             mediaType: 'application/json',
             errors: {
@@ -391,26 +360,15 @@ export class ApiService {
     /**
      * Create Repair Diagnostic Lead
      * @param formData
-     * @param xMvnStorefrontHost
-     * @param xMvnStorefrontTimestamp
-     * @param xMvnStorefrontSignature
      * @returns RepairDiagnosticLeadResponse Successful Response
      * @throws ApiError
      */
     public static createRepairDiagnosticLead(
         formData: Body_create_repair_diagnostic_lead,
-        xMvnStorefrontHost?: (string | null),
-        xMvnStorefrontTimestamp?: (string | null),
-        xMvnStorefrontSignature?: (string | null),
     ): CancelablePromise<RepairDiagnosticLeadResponse> {
         return __request(OpenAPI, {
             method: 'POST',
             url: '/api/v1/leads/repair-diagnostic',
-            headers: {
-                'X-MVN-Storefront-Host': xMvnStorefrontHost,
-                'X-MVN-Storefront-Timestamp': xMvnStorefrontTimestamp,
-                'X-MVN-Storefront-Signature': xMvnStorefrontSignature,
-            },
             formData: formData,
             mediaType: 'multipart/form-data',
             errors: {
@@ -423,26 +381,15 @@ export class ApiService {
      * Create a new order from website.
      * Accepts customer information and cart items.
      * @param requestBody
-     * @param xMvnStorefrontHost
-     * @param xMvnStorefrontTimestamp
-     * @param xMvnStorefrontSignature
      * @returns OrderResponse Successful Response
      * @throws ApiError
      */
     public static createOrder(
         requestBody: OrderPayload,
-        xMvnStorefrontHost?: (string | null),
-        xMvnStorefrontTimestamp?: (string | null),
-        xMvnStorefrontSignature?: (string | null),
     ): CancelablePromise<OrderResponse> {
         return __request(OpenAPI, {
             method: 'POST',
             url: '/api/v1/orders',
-            headers: {
-                'X-MVN-Storefront-Host': xMvnStorefrontHost,
-                'X-MVN-Storefront-Timestamp': xMvnStorefrontTimestamp,
-                'X-MVN-Storefront-Signature': xMvnStorefrontSignature,
-            },
             body: requestBody,
             mediaType: 'application/json',
             errors: {
@@ -805,28 +752,13 @@ export class ApiService {
     }
     /**
      * Get Public Storefront Context
-     * @param xMvnStorefrontHost
-     * @param xMvnStorefrontTimestamp
-     * @param xMvnStorefrontSignature
      * @returns PublicStorefrontContextResponse Successful Response
      * @throws ApiError
      */
-    public static getPublicStorefrontContext(
-        xMvnStorefrontHost?: (string | null),
-        xMvnStorefrontTimestamp?: (string | null),
-        xMvnStorefrontSignature?: (string | null),
-    ): CancelablePromise<PublicStorefrontContextResponse> {
+    public static getPublicStorefrontContext(): CancelablePromise<PublicStorefrontContextResponse> {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/api/v1/storefront/context',
-            headers: {
-                'X-MVN-Storefront-Host': xMvnStorefrontHost,
-                'X-MVN-Storefront-Timestamp': xMvnStorefrontTimestamp,
-                'X-MVN-Storefront-Signature': xMvnStorefrontSignature,
-            },
-            errors: {
-                422: `Validation Error`,
-            },
         });
     }
     /**

--- a/openapi.json
+++ b/openapi.json
@@ -2456,65 +2456,15 @@
         ],
         "summary": "Create Public Contact Lead",
         "operationId": "create_public_contact_lead",
-        "parameters": [
-          {
-            "name": "X-MVN-Storefront-Host",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "X-Mvn-Storefront-Host"
-            }
-          },
-          {
-            "name": "X-MVN-Storefront-Timestamp",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "X-Mvn-Storefront-Timestamp"
-            }
-          },
-          {
-            "name": "X-MVN-Storefront-Signature",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "X-Mvn-Storefront-Signature"
-            }
-          }
-        ],
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/PublicContactLeadPayload"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
@@ -2559,54 +2509,6 @@
               "maxLength": 128,
               "pattern": "^[A-Za-z0-9._:-]+$",
               "title": "Idempotency-Key"
-            }
-          },
-          {
-            "name": "X-MVN-Storefront-Host",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "X-Mvn-Storefront-Host"
-            }
-          },
-          {
-            "name": "X-MVN-Storefront-Timestamp",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "X-Mvn-Storefront-Timestamp"
-            }
-          },
-          {
-            "name": "X-MVN-Storefront-Signature",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "X-Mvn-Storefront-Signature"
             }
           }
         ],
@@ -2661,65 +2563,15 @@
         ],
         "summary": "Create Product Availability Lead",
         "operationId": "create_product_availability_lead",
-        "parameters": [
-          {
-            "name": "X-MVN-Storefront-Host",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "X-Mvn-Storefront-Host"
-            }
-          },
-          {
-            "name": "X-MVN-Storefront-Timestamp",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "X-Mvn-Storefront-Timestamp"
-            }
-          },
-          {
-            "name": "X-MVN-Storefront-Signature",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "X-Mvn-Storefront-Signature"
-            }
-          }
-        ],
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/ProductAvailabilityLeadPayload"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
@@ -2753,65 +2605,15 @@
         ],
         "summary": "Create Repair Diagnostic Lead",
         "operationId": "create_repair_diagnostic_lead",
-        "parameters": [
-          {
-            "name": "X-MVN-Storefront-Host",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "X-Mvn-Storefront-Host"
-            }
-          },
-          {
-            "name": "X-MVN-Storefront-Timestamp",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "X-Mvn-Storefront-Timestamp"
-            }
-          },
-          {
-            "name": "X-MVN-Storefront-Signature",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "X-Mvn-Storefront-Signature"
-            }
-          }
-        ],
         "requestBody": {
-          "required": true,
           "content": {
             "multipart/form-data": {
               "schema": {
                 "$ref": "#/components/schemas/Body_create_repair_diagnostic_lead"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
@@ -2846,65 +2648,15 @@
         "summary": "Create Order",
         "description": "Create a new order from website.\nAccepts customer information and cart items.",
         "operationId": "create_order",
-        "parameters": [
-          {
-            "name": "X-MVN-Storefront-Host",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "X-Mvn-Storefront-Host"
-            }
-          },
-          {
-            "name": "X-MVN-Storefront-Timestamp",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "X-Mvn-Storefront-Timestamp"
-            }
-          },
-          {
-            "name": "X-MVN-Storefront-Signature",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "X-Mvn-Storefront-Signature"
-            }
-          }
-        ],
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/OrderPayload"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
@@ -4013,56 +3765,6 @@
         ],
         "summary": "Get Public Storefront Context",
         "operationId": "get_public_storefront_context",
-        "parameters": [
-          {
-            "name": "X-MVN-Storefront-Host",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "X-Mvn-Storefront-Host"
-            }
-          },
-          {
-            "name": "X-MVN-Storefront-Timestamp",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "X-Mvn-Storefront-Timestamp"
-            }
-          },
-          {
-            "name": "X-MVN-Storefront-Signature",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "X-Mvn-Storefront-Signature"
-            }
-          }
-        ],
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -4070,16 +3772,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/PublicStorefrontContextResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }

--- a/routers/api_catalog_revision.py
+++ b/routers/api_catalog_revision.py
@@ -4,11 +4,15 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from core.database import get_session
+from core.tenant_scope import verify_public_storefront_request
 from schemas import CatalogRevisionResponse
 from services.catalog_revision_service import CatalogRevisionService
 
 
-router = APIRouter(tags=["api"])
+router = APIRouter(
+    tags=["api"],
+    dependencies=[Depends(verify_public_storefront_request)],
+)
 
 
 @router.get(

--- a/routers/api_content.py
+++ b/routers/api_content.py
@@ -5,6 +5,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from typing import List
 
 from core.database import get_session
+from core.tenant_scope import verify_public_storefront_request
 from schemas import (
     ArticleResponse,
     PublicBrandDetailResponse,
@@ -17,7 +18,10 @@ from services.content_api_service import ContentApiService
 from services.installation_service import InstallationService
 from services.public_series_page_service import PublicSeriesPageService
 
-router = APIRouter(tags=["api"])
+router = APIRouter(
+    tags=["api"],
+    dependencies=[Depends(verify_public_storefront_request)],
+)
 
 
 @router.get("/v1/content/articles", response_model=List[ArticleResponse])

--- a/routers/api_leads.py
+++ b/routers/api_leads.py
@@ -9,7 +9,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from core.config import settings
 from core.database import get_session
-from core.tenant_scope import get_public_tenant_scope
+from core.tenant_scope import (
+    get_public_tenant_scope,
+    verify_public_storefront_request,
+)
 from schemas_installation_estimate import (
     InstallationEstimateLeadPayload,
     InstallationEstimateLeadResponse,
@@ -32,7 +35,10 @@ from services.installation_estimate_lead_service import (
 from services.website_lead_service import WebsiteLeadService
 from services.tenant_scope_service import TenantScope
 
-router = APIRouter(tags=["api"])
+router = APIRouter(
+    tags=["api"],
+    dependencies=[Depends(verify_public_storefront_request)],
+)
 
 
 async def installation_estimate_form_payload(

--- a/routers/api_orders.py
+++ b/routers/api_orders.py
@@ -4,13 +4,19 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from core.database import get_session
-from core.tenant_scope import get_public_tenant_scope
+from core.tenant_scope import (
+    get_public_tenant_scope,
+    verify_public_storefront_request,
+)
 from schemas import OrderPayload, OrderResponse, PublicOrderPricingErrorResponse
 from services.installation_pricing_service import InstallationPricingError
 from services.website_order_service import WebsiteOrderService
 from services.tenant_scope_service import TenantScope
 
-router = APIRouter(tags=["api"])
+router = APIRouter(
+    tags=["api"],
+    dependencies=[Depends(verify_public_storefront_request)],
+)
 
 
 @router.post(

--- a/routers/api_product_collections.py
+++ b/routers/api_product_collections.py
@@ -3,10 +3,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from api_contracts.product_collections import PublicProductCollectionPlacementResponse
 from core.database import get_session
+from core.tenant_scope import verify_public_storefront_request
 from services.product_collection_resolver import ProductCollectionResolver
 
 
-router = APIRouter(tags=["api"])
+router = APIRouter(
+    tags=["api"],
+    dependencies=[Depends(verify_public_storefront_request)],
+)
 
 
 @router.get(

--- a/routers/api_products.py
+++ b/routers/api_products.py
@@ -7,6 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from core.database import get_session
 from core.security import get_current_username
+from core.tenant_scope import verify_public_storefront_request
 from schemas import (
     CatalogResponse,
     FiltersConfigResponse,
@@ -23,21 +24,37 @@ from services.product_service import ProductService
 from services.feature_resolver_service import FeatureResolverService
 
 router = APIRouter(tags=["api"])
+_PUBLIC_STOREFRONT_DEPENDENCIES = [Depends(verify_public_storefront_request)]
 
 
-@router.get("/v1/specs/keys", response_model=SpecsKeysResponse, operation_id="get_public_spec_keys")
+@router.get(
+    "/v1/specs/keys",
+    response_model=SpecsKeysResponse,
+    operation_id="get_public_spec_keys",
+    dependencies=_PUBLIC_STOREFRONT_DEPENDENCIES,
+)
 async def get_public_spec_keys(session: AsyncSession = Depends(get_session)):
     payload = await ProductService.get_public_spec_keys(session)
     return SpecsKeysResponse(**payload)
 
 
-@router.get("/v1/specs/registry", response_model=SpecRegistryResponse, operation_id="get_public_spec_registry")
+@router.get(
+    "/v1/specs/registry",
+    response_model=SpecRegistryResponse,
+    operation_id="get_public_spec_registry",
+    dependencies=_PUBLIC_STOREFRONT_DEPENDENCIES,
+)
 async def get_public_spec_registry():
     payload = ProductService.get_specs_registry()
     return SpecRegistryResponse(**payload)
 
 
-@router.get("/v1/filters/config", response_model=FiltersConfigResponse, operation_id="get_filters_config")
+@router.get(
+    "/v1/filters/config",
+    response_model=FiltersConfigResponse,
+    operation_id="get_filters_config",
+    dependencies=_PUBLIC_STOREFRONT_DEPENDENCIES,
+)
 async def get_filters_config(session: AsyncSession = Depends(get_session)):
     return await ProductService.get_filters_config(session)
 
@@ -52,8 +69,18 @@ async def generate_product_description(
     return {"description": text}
 
 
-@router.get("/v1/catalog", response_model=CatalogResponse, operation_id="get_products")
-@router.get("/v1/products", response_model=CatalogResponse, operation_id="get_products_v1")
+@router.get(
+    "/v1/catalog",
+    response_model=CatalogResponse,
+    operation_id="get_products",
+    dependencies=_PUBLIC_STOREFRONT_DEPENDENCIES,
+)
+@router.get(
+    "/v1/products",
+    response_model=CatalogResponse,
+    operation_id="get_products_v1",
+    dependencies=_PUBLIC_STOREFRONT_DEPENDENCIES,
+)
 async def get_catalog(
     page: int = 1,
     limit: int = 20,
@@ -122,6 +149,7 @@ async def get_catalog(
     "/v1/products/vitebsk-featured",
     response_model=List[ProductResponse],
     operation_id="get_vitebsk_featured_products",
+    dependencies=_PUBLIC_STOREFRONT_DEPENDENCIES,
 )
 async def get_vitebsk_featured_products(session: AsyncSession = Depends(get_session)):
     products = await CatalogService.get_vitebsk_featured_products(session, limit=6)
@@ -140,12 +168,18 @@ async def get_vitebsk_featured_products(session: AsyncSession = Depends(get_sess
     "/v1/product-series/navigation",
     response_model=ProductSeriesNavigationResponse,
     operation_id="get_product_series_navigation",
+    dependencies=_PUBLIC_STOREFRONT_DEPENDENCIES,
 )
 async def get_product_series_navigation(session: AsyncSession = Depends(get_session)):
     return await ProductService.get_series_navigation(session)
 
 
-@router.get("/v1/products/{identifier}", response_model=ProductResponse, operation_id="get_product")
+@router.get(
+    "/v1/products/{identifier}",
+    response_model=ProductResponse,
+    operation_id="get_product",
+    dependencies=_PUBLIC_STOREFRONT_DEPENDENCIES,
+)
 async def get_product_by_identifier(identifier: str, session: AsyncSession = Depends(get_session)):
     product = await ProductService.get_public_product_by_identifier(session, identifier)
     if not product:

--- a/routers/api_storefront.py
+++ b/routers/api_storefront.py
@@ -2,13 +2,19 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from core.database import get_session
-from core.tenant_scope import get_public_tenant_scope
+from core.tenant_scope import (
+    get_public_tenant_scope,
+    verify_public_storefront_request,
+)
 from models.tenancy import TenantScope
 from schemas_tenancy import PublicStorefrontContextResponse
 from services.storefront_context_service import StorefrontContextService
 
 
-router = APIRouter(tags=["api"])
+router = APIRouter(
+    tags=["api"],
+    dependencies=[Depends(verify_public_storefront_request)],
+)
 
 
 @router.get(

--- a/services/storefront_context_signature_service.py
+++ b/services/storefront_context_signature_service.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
 import hmac
+import re
 import time
 from hashlib import sha256
-from typing import Iterable
 
 from services.storefront_context_service import StorefrontContextService
+
+
+_BODY_SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+_SIGNATURE_PATTERN = re.compile(r"^v1=[0-9a-f]{64}$")
+_HTTP_METHOD_PATTERN = re.compile(r"^[A-Z][A-Z0-9!#$%&'*+.^_`|~-]*$")
 
 
 class InvalidStorefrontContextSignature(ValueError):
@@ -13,9 +18,28 @@ class InvalidStorefrontContextSignature(ValueError):
 
 
 class StorefrontContextSignatureService:
-    """Sign the storefront hostname selected by a trusted website runtime."""
+    """Create and verify the trusted storefront request envelope."""
 
     VERSION = "v1"
+    EMPTY_BODY_SHA256 = sha256(b"").hexdigest()
+
+    @staticmethod
+    def body_sha256(body: bytes) -> str:
+        return sha256(bytes(body)).hexdigest()
+
+    @staticmethod
+    def request_target(*, raw_path: bytes, query_string: bytes = b"") -> bytes:
+        path = bytes(raw_path)
+        query = bytes(query_string)
+        if not path.startswith(b"/") or b"\r" in path or b"\n" in path:
+            raise InvalidStorefrontContextSignature(
+                "Storefront context request path is invalid"
+            )
+        if b"\r" in query or b"\n" in query or b"#" in query:
+            raise InvalidStorefrontContextSignature(
+                "Storefront context query string is invalid"
+            )
+        return path + (b"?" + query if query else b"")
 
     @classmethod
     def canonical_message(
@@ -23,20 +47,49 @@ class StorefrontContextSignatureService:
         *,
         timestamp: int,
         method: str,
-        path: str,
-        hostname: str,
+        path_and_query: str | bytes,
+        api_hostname: str,
+        storefront_hostname: str,
+        body_sha256: str,
     ) -> bytes:
-        normalized_hostname = StorefrontContextService.normalize_hostname(hostname)
         normalized_method = str(method or "").strip().upper()
-        normalized_path = str(path or "").strip()
-        if not normalized_method or not normalized_path.startswith("/"):
+        if not _HTTP_METHOD_PATTERN.fullmatch(normalized_method):
+            raise InvalidStorefrontContextSignature(
+                "Storefront context HTTP method is invalid"
+            )
+
+        if isinstance(path_and_query, bytes):
+            target = bytes(path_and_query)
+        else:
+            target = str(path_and_query or "").encode("utf-8")
+        if not target.startswith(b"/") or b"\r" in target or b"\n" in target:
             raise InvalidStorefrontContextSignature(
                 "Storefront context request target is invalid"
             )
-        return (
-            f"{cls.VERSION}\n{int(timestamp)}\n{normalized_method}\n"
-            f"{normalized_path}\n{normalized_hostname}"
-        ).encode("utf-8")
+
+        normalized_api_hostname = StorefrontContextService.normalize_hostname(
+            api_hostname
+        )
+        normalized_storefront_hostname = (
+            StorefrontContextService.normalize_hostname(storefront_hostname)
+        )
+        normalized_body_sha256 = str(body_sha256 or "")
+        if not _BODY_SHA256_PATTERN.fullmatch(normalized_body_sha256):
+            raise InvalidStorefrontContextSignature(
+                "Storefront context body digest is invalid"
+            )
+
+        return b"\n".join(
+            (
+                cls.VERSION.encode("ascii"),
+                str(int(timestamp)).encode("ascii"),
+                normalized_method.encode("ascii"),
+                target,
+                normalized_api_hostname.encode("ascii"),
+                normalized_storefront_hostname.encode("ascii"),
+                normalized_body_sha256.encode("ascii"),
+            )
+        )
 
     @classmethod
     def sign(
@@ -45,8 +98,10 @@ class StorefrontContextSignatureService:
         secret: str,
         timestamp: int,
         method: str,
-        path: str,
-        hostname: str,
+        path_and_query: str | bytes,
+        api_hostname: str,
+        storefront_hostname: str,
+        body_sha256: str,
     ) -> str:
         normalized_secret = str(secret or "")
         if len(normalized_secret.encode("utf-8")) < 32:
@@ -58,8 +113,10 @@ class StorefrontContextSignatureService:
             cls.canonical_message(
                 timestamp=timestamp,
                 method=method,
-                path=path,
-                hostname=hostname,
+                path_and_query=path_and_query,
+                api_hostname=api_hostname,
+                storefront_hostname=storefront_hostname,
+                body_sha256=body_sha256,
             ),
             sha256,
         ).hexdigest()
@@ -72,8 +129,10 @@ class StorefrontContextSignatureService:
         secret: str,
         timestamp: int,
         method: str,
-        path: str,
-        hostname: str,
+        path_and_query: str | bytes,
+        api_hostname: str,
+        storefront_hostname: str,
+        body_sha256: str,
         signature: str,
         max_age_seconds: int,
         now: int | None = None,
@@ -96,53 +155,25 @@ class StorefrontContextSignatureService:
                 "Storefront context signature has expired"
             )
 
-        normalized_hostname = StorefrontContextService.normalize_hostname(hostname)
+        normalized_signature = str(signature or "")
+        if not _SIGNATURE_PATTERN.fullmatch(normalized_signature):
+            raise InvalidStorefrontContextSignature(
+                "Storefront context signature is invalid"
+            )
+        normalized_storefront_hostname = (
+            StorefrontContextService.normalize_hostname(storefront_hostname)
+        )
         expected = cls.sign(
             secret=normalized_secret,
             timestamp=signed_timestamp,
             method=method,
-            path=path,
-            hostname=normalized_hostname,
+            path_and_query=path_and_query,
+            api_hostname=api_hostname,
+            storefront_hostname=normalized_storefront_hostname,
+            body_sha256=body_sha256,
         )
-        if not hmac.compare_digest(expected, str(signature or "")):
+        if not hmac.compare_digest(expected, normalized_signature):
             raise InvalidStorefrontContextSignature(
                 "Storefront context signature is invalid"
             )
-        return normalized_hostname
-
-    @classmethod
-    def verify_any(
-        cls,
-        *,
-        secrets: Iterable[str],
-        timestamp: int,
-        method: str,
-        path: str,
-        hostname: str,
-        signature: str,
-        max_age_seconds: int,
-        now: int | None = None,
-    ) -> str:
-        configured = [str(secret or "") for secret in secrets if str(secret or "")]
-        if not configured:
-            raise InvalidStorefrontContextSignature(
-                "Storefront context signing secret is not configured securely"
-            )
-
-        for secret in configured:
-            try:
-                return cls.verify(
-                    secret=secret,
-                    timestamp=timestamp,
-                    method=method,
-                    path=path,
-                    hostname=hostname,
-                    signature=signature,
-                    max_age_seconds=max_age_seconds,
-                    now=now,
-                )
-            except InvalidStorefrontContextSignature:
-                continue
-        raise InvalidStorefrontContextSignature(
-            "Storefront context signature is invalid"
-        )
+        return normalized_storefront_hostname

--- a/tests/integration/test_public_storefront_context.py
+++ b/tests/integration/test_public_storefront_context.py
@@ -1,3 +1,4 @@
+import json
 import time
 
 import pytest
@@ -12,6 +13,7 @@ from services.storefront_context_signature_service import (
 
 
 _PATH = "/api/v1/leads/contact"
+_KEY_ID = "test-mvn-web"
 _SECRET = "test-storefront-secret-at-least-32-bytes"
 
 
@@ -43,10 +45,13 @@ def _headers(
     *,
     path: str = _PATH,
     method: str = "POST",
+    body: bytes = b"",
     signature: str | None = None,
 ) -> dict[str, str]:
     timestamp = int(time.time())
     return {
+        "Host": "test",
+        "X-MVN-Storefront-Key-Id": _KEY_ID,
         "X-MVN-Storefront-Host": "orsha.internal.mvn.by",
         "X-MVN-Storefront-Timestamp": str(timestamp),
         "X-MVN-Storefront-Signature": signature
@@ -54,8 +59,10 @@ def _headers(
             secret=_SECRET,
             timestamp=timestamp,
             method=method,
-            path=path,
-            hostname="orsha.internal.mvn.by",
+            path_and_query=path,
+            api_hostname="test",
+            storefront_hostname="orsha.internal.mvn.by",
+            body_sha256=StorefrontContextSignatureService.body_sha256(body),
         ),
     }
 
@@ -69,6 +76,29 @@ def _payload() -> dict[str, str]:
     }
 
 
+def _json_body(payload: dict) -> bytes:
+    return json.dumps(
+        payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def _configure_signing(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "STOREFRONT_CONTEXT_SIGNING_KEY_ID", _KEY_ID)
+    monkeypatch.setattr(settings, "STOREFRONT_CONTEXT_SIGNING_SECRET", _SECRET)
+    monkeypatch.setattr(
+        settings,
+        "STOREFRONT_CONTEXT_PREVIOUS_SIGNING_KEY_ID",
+        "",
+    )
+    monkeypatch.setattr(
+        settings,
+        "STOREFRONT_CONTEXT_PREVIOUS_SIGNING_SECRET",
+        "",
+    )
+
+
 @pytest.mark.asyncio
 async def test_signed_context_routes_public_lead_to_secondary_storefront(
     async_client,
@@ -76,9 +106,15 @@ async def test_signed_context_routes_public_lead_to_secondary_storefront(
     monkeypatch,
 ):
     storefront = await _seed_secondary_storefront(db)
-    monkeypatch.setattr(settings, "STOREFRONT_CONTEXT_SIGNING_SECRET", _SECRET)
+    _configure_signing(monkeypatch)
+    payload = _payload()
+    body = _json_body(payload)
 
-    response = await async_client.post(_PATH, json=_payload(), headers=_headers())
+    response = await async_client.post(
+        _PATH,
+        content=body,
+        headers={**_headers(body=body), "Content-Type": "application/json"},
+    )
 
     assert response.status_code == 200
     lead = await db.get(Lead, response.json()["lead_id"])
@@ -102,29 +138,35 @@ async def test_signed_context_routes_public_order_to_secondary_storefront(
     db.add(product)
     await db.commit()
     await db.refresh(product)
-    monkeypatch.setattr(settings, "STOREFRONT_CONTEXT_SIGNING_SECRET", _SECRET)
+    _configure_signing(monkeypatch)
+
+    payload = {
+        "customer": {
+            "name": "Покупатель Орша",
+            "phone": "+375291112234",
+            "email": "orsha@example.test",
+            "address": "Орша",
+            "type": "individual",
+        },
+        "items": [
+            {
+                "product_id": product.id,
+                "quantity": 1,
+                "with_installation": False,
+                "installation_options": [],
+            }
+        ],
+        "comment": "Проверка provenance заказа",
+    }
+    body = _json_body(payload)
 
     response = await async_client.post(
         "/api/v1/orders",
-        json={
-            "customer": {
-                "name": "Покупатель Орша",
-                "phone": "+375291112234",
-                "email": "orsha@example.test",
-                "address": "Орша",
-                "type": "individual",
-            },
-            "items": [
-                {
-                    "product_id": product.id,
-                    "quantity": 1,
-                    "with_installation": False,
-                    "installation_options": [],
-                }
-            ],
-            "comment": "Проверка provenance заказа",
+        content=body,
+        headers={
+            **_headers(path="/api/v1/orders", body=body),
+            "Content-Type": "application/json",
         },
-        headers=_headers(path="/api/v1/orders"),
     )
 
     assert response.status_code == 200
@@ -140,7 +182,7 @@ async def test_signed_context_exposes_public_storefront_dto_without_ids(
     monkeypatch,
 ):
     await _seed_secondary_storefront(db)
-    monkeypatch.setattr(settings, "STOREFRONT_CONTEXT_SIGNING_SECRET", _SECRET)
+    _configure_signing(monkeypatch)
     path = "/api/v1/storefront/context"
 
     response = await async_client.get(
@@ -167,7 +209,36 @@ async def test_signed_context_exposes_public_storefront_dto_without_ids(
 
 
 @pytest.mark.asyncio
-async def test_unsigned_host_header_cannot_select_secondary_storefront(
+async def test_signed_context_authenticates_public_catalog_raw_query(
+    async_client,
+    db,
+    monkeypatch,
+):
+    await _seed_secondary_storefront(db)
+    db.add(
+        Product(
+            title="Signed catalog product",
+            slug="signed-catalog-product",
+            price=1800,
+            is_published=True,
+        )
+    )
+    await db.commit()
+    _configure_signing(monkeypatch)
+    target = "/api/v1/products?limit=1"
+
+    response = await async_client.get(
+        target,
+        headers=_headers(path=target, method="GET"),
+    )
+
+    assert response.status_code == 200
+    assert response.json()["items"]
+    assert response.headers["cache-control"] == "private, no-store"
+
+
+@pytest.mark.asyncio
+async def test_unsigned_non_api_host_is_rejected_without_creating_lead(
     async_client,
     db,
 ):
@@ -177,6 +248,28 @@ async def test_unsigned_host_header_cannot_select_secondary_storefront(
         _PATH,
         json=_payload(),
         headers={"Host": "orsha.internal.mvn.by"},
+    )
+
+    assert response.status_code == 401
+    leads = (await db.execute(select(Lead))).scalars().all()
+    assert leads == []
+
+
+@pytest.mark.asyncio
+async def test_unsigned_browser_origin_headers_cannot_switch_canonical_scope(
+    async_client,
+    db,
+):
+    await _seed_secondary_storefront(db)
+
+    response = await async_client.post(
+        _PATH,
+        json=_payload(),
+        headers={
+            "Host": "test",
+            "Origin": "https://orsha.internal.mvn.by",
+            "X-Forwarded-Host": "orsha.internal.mvn.by",
+        },
     )
 
     assert response.status_code == 200
@@ -215,21 +308,54 @@ async def test_partial_or_tampered_context_fails_closed(
     monkeypatch,
 ):
     await _seed_secondary_storefront(db)
-    monkeypatch.setattr(settings, "STOREFRONT_CONTEXT_SIGNING_SECRET", _SECRET)
+    _configure_signing(monkeypatch)
+
+    body = _json_body(_payload())
 
     partial = await async_client.post(
         _PATH,
-        json=_payload(),
-        headers={"X-MVN-Storefront-Host": "orsha.internal.mvn.by"},
+        content=body,
+        headers={
+            "Content-Type": "application/json",
+            "X-MVN-Storefront-Host": "orsha.internal.mvn.by",
+        },
     )
     wrong_path = await async_client.post(
         _PATH,
-        json=_payload(),
-        headers=_headers(path="/api/v1/orders"),
+        content=body,
+        headers={
+            **_headers(path="/api/v1/orders", body=body),
+            "Content-Type": "application/json",
+        },
     )
 
     assert partial.status_code == 401
     assert wrong_path.status_code == 401
+    leads = (await db.execute(select(Lead))).scalars().all()
+    assert leads == []
+
+
+@pytest.mark.asyncio
+async def test_signed_context_rejects_body_tamper_without_creating_lead(
+    async_client,
+    db,
+    monkeypatch,
+):
+    await _seed_secondary_storefront(db)
+    _configure_signing(monkeypatch)
+    signed_body = _json_body(_payload())
+    tampered_body = _json_body({**_payload(), "message": "Подменённый текст"})
+
+    response = await async_client.post(
+        _PATH,
+        content=tampered_body,
+        headers={
+            **_headers(body=signed_body),
+            "Content-Type": "application/json",
+        },
+    )
+
+    assert response.status_code == 401
     leads = (await db.execute(select(Lead))).scalars().all()
     assert leads == []
 
@@ -241,14 +367,25 @@ async def test_context_selection_is_disabled_without_server_secret(
     monkeypatch,
 ):
     await _seed_secondary_storefront(db)
+    monkeypatch.setattr(settings, "STOREFRONT_CONTEXT_SIGNING_KEY_ID", "")
     monkeypatch.setattr(settings, "STOREFRONT_CONTEXT_SIGNING_SECRET", "")
+    monkeypatch.setattr(
+        settings,
+        "STOREFRONT_CONTEXT_PREVIOUS_SIGNING_KEY_ID",
+        _KEY_ID,
+    )
     monkeypatch.setattr(
         settings,
         "STOREFRONT_CONTEXT_PREVIOUS_SIGNING_SECRET",
         _SECRET,
     )
+    body = _json_body(_payload())
 
-    response = await async_client.post(_PATH, json=_payload(), headers=_headers())
+    response = await async_client.post(
+        _PATH,
+        content=body,
+        headers={**_headers(body=body), "Content-Type": "application/json"},
+    )
 
     assert response.status_code == 401
     leads = (await db.execute(select(Lead))).scalars().all()

--- a/tests/unit/storefront_gateway_test_support.py
+++ b/tests/unit/storefront_gateway_test_support.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import time
+
+import pytest
+from fastapi import Depends, FastAPI, File, Request, UploadFile
+from fastapi.responses import JSONResponse
+from httpx import ASGITransport, AsyncClient
+from pydantic import BaseModel
+
+from core.config import settings
+from core.database import get_session
+from core.storefront_request_gateway import StorefrontRequestGatewayMiddleware
+from core.tenant_scope import (
+    get_public_tenant_scope,
+    verify_public_storefront_request,
+)
+from models.tenancy import TenantScope
+from services.storefront_context_service import (
+    StorefrontContext,
+    StorefrontContextService,
+)
+from services.storefront_context_signature_service import (
+    StorefrontContextSignatureService,
+)
+from services.tenant_scope_service import SystemTenantScopeResolver
+
+
+PRIMARY_KEY_ID = "mvn-web-current"
+PRIMARY_SECRET = "primary-storefront-secret-at-least-32-bytes"
+PREVIOUS_KEY_ID = "mvn-web-previous"
+PREVIOUS_SECRET = "previous-storefront-secret-at-least-32-bytes"
+STOREFRONT_HOST = "orsha.internal.mvn.by"
+
+
+class ValidatedPayload(BaseModel):
+    name: str
+
+
+def signed_headers(
+    *,
+    body: bytes = b"",
+    method: str = "POST",
+    target: bytes = b"/api/v1/echo",
+    api_hostname: str = "api.mvn.by",
+    storefront_hostname: str = STOREFRONT_HOST,
+    key_id: str = PRIMARY_KEY_ID,
+    secret: str = PRIMARY_SECRET,
+    timestamp: int | None = None,
+) -> dict[str, str]:
+    signed_at = int(time.time()) if timestamp is None else timestamp
+    return {
+        "Host": api_hostname,
+        "X-MVN-Storefront-Key-Id": key_id,
+        "X-MVN-Storefront-Host": storefront_hostname,
+        "X-MVN-Storefront-Timestamp": str(signed_at),
+        "X-MVN-Storefront-Signature": StorefrontContextSignatureService.sign(
+            secret=secret,
+            timestamp=signed_at,
+            method=method,
+            path_and_query=target,
+            api_hostname=api_hostname,
+            storefront_hostname=storefront_hostname,
+            body_sha256=StorefrontContextSignatureService.body_sha256(body),
+        ),
+    }
+
+
+def configure_signing_settings(monkeypatch) -> None:
+    values = {
+        "STOREFRONT_CONTEXT_SIGNING_KEY_ID": PRIMARY_KEY_ID,
+        "STOREFRONT_CONTEXT_SIGNING_SECRET": PRIMARY_SECRET,
+        "STOREFRONT_CONTEXT_PREVIOUS_SIGNING_KEY_ID": "",
+        "STOREFRONT_CONTEXT_PREVIOUS_SIGNING_SECRET": "",
+        "STOREFRONT_CONTEXT_REQUIRE_SIGNED_REQUESTS": False,
+        "STOREFRONT_CONTEXT_API_HOSTS": "api.mvn.by,localhost",
+    }
+    for name, value in values.items():
+        monkeypatch.setattr(settings, name, value)
+
+
+@pytest.fixture
+def gateway_app(monkeypatch):
+    app = FastAPI()
+    app.add_middleware(
+        StorefrontRequestGatewayMiddleware,
+        max_body_bytes=1024 * 1024,
+    )
+    app.state.session_calls = 0
+    app.state.validated_endpoint_calls = 0
+    canonical_scope = TenantScope(tenant_id=1, storefront_id=1, is_system=True)
+    orsha_context = StorefrontContext(
+        tenant_id=1,
+        tenant_slug="mvn",
+        tenant_kind="operator",
+        storefront_id=2,
+        storefront_slug="orsha",
+        storefront_name="MVN Орша",
+        hostname=STOREFRONT_HOST,
+        city="Орша",
+        default_locale="ru-BY",
+        currency="BYN",
+        tenant_is_system=True,
+    )
+
+    async def override_session():
+        app.state.session_calls += 1
+        yield object()
+
+    async def resolve_system(_session, **_kwargs):
+        return canonical_scope
+
+    async def resolve_storefront(_session, raw_host):
+        if raw_host == STOREFRONT_HOST:
+            return orsha_context
+        return None
+
+    monkeypatch.setattr(SystemTenantScopeResolver, "resolve", resolve_system)
+    monkeypatch.setattr(
+        StorefrontContextService,
+        "resolve_by_host",
+        resolve_storefront,
+    )
+    configure_signing_settings(monkeypatch)
+    app.dependency_overrides[get_session] = override_session
+
+    @app.api_route(
+        "/api/v1/echo",
+        methods=["GET", "POST"],
+        dependencies=[Depends(verify_public_storefront_request)],
+    )
+    async def echo(
+        request: Request,
+        tenant_scope: TenantScope = Depends(get_public_tenant_scope),
+    ):
+        return {
+            "tenant_id": tenant_scope.tenant_id,
+            "storefront_id": tenant_scope.storefront_id,
+            "body": (await request.body()).decode("utf-8"),
+        }
+
+    @app.post(
+        "/api/v1/upload",
+        dependencies=[Depends(verify_public_storefront_request)],
+    )
+    async def upload(
+        file: UploadFile = File(),
+        tenant_scope: TenantScope = Depends(get_public_tenant_scope),
+    ):
+        return {
+            "storefront_id": tenant_scope.storefront_id,
+            "filename": file.filename,
+            "content": (await file.read()).decode("utf-8"),
+        }
+
+    @app.post(
+        "/api/v1/validated",
+        dependencies=[Depends(verify_public_storefront_request)],
+    )
+    async def validated(payload: ValidatedPayload):
+        app.state.validated_endpoint_calls += 1
+        return payload
+
+    @app.get(
+        "/api/v1/vary",
+        dependencies=[Depends(verify_public_storefront_request)],
+    )
+    async def response_with_existing_vary():
+        return JSONResponse(
+            content={"ok": True},
+            headers={
+                "Cache-Control": "public, max-age=3600",
+                "CDN-Cache-Control": "public, max-age=3600",
+                "Vary": "Accept-Encoding, Origin, accept-encoding",
+            },
+        )
+
+    @app.get(
+        "/api/v1/path/{value:path}",
+        dependencies=[Depends(verify_public_storefront_request)],
+    )
+    async def encoded_path(value: str):
+        return {"value": value}
+
+    return app
+
+
+async def gateway_request(
+    app: FastAPI,
+    method: str,
+    path: str = "/api/v1/echo",
+    **kwargs,
+):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport,
+        base_url="https://api.mvn.by",
+    ) as client:
+        return await client.request(method, path, **kwargs)

--- a/tests/unit/test_public_storefront_gateway.py
+++ b/tests/unit/test_public_storefront_gateway.py
@@ -1,0 +1,275 @@
+import time
+
+import pytest
+
+from core.config import settings
+from tests.unit.storefront_gateway_test_support import (
+    PREVIOUS_KEY_ID,
+    PREVIOUS_SECRET,
+    STOREFRONT_HOST,
+    gateway_app,
+    gateway_request,
+    signed_headers,
+)
+
+
+@pytest.mark.asyncio
+async def test_valid_signed_request_resolves_exact_storefront_and_preserves_body(
+    gateway_app,
+):
+    body = b'{"name":"Orsha"}'
+
+    response = await gateway_request(
+        gateway_app,
+        "POST",
+        content=body,
+        headers=signed_headers(body=body),
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "tenant_id": 1,
+        "storefront_id": 2,
+        "body": body.decode("utf-8"),
+    }
+    assert response.headers["cache-control"] == "private, no-store"
+    assert response.headers["cdn-cache-control"] == "no-store"
+    assert response.headers["vary"] == "X-MVN-Storefront-Host"
+
+
+@pytest.mark.asyncio
+async def test_signed_gateway_preserves_multipart_body_for_upload_parser(gateway_app):
+    boundary = "mvn-signed-upload-boundary"
+    body = (
+        f"--{boundary}\r\n"
+        'Content-Disposition: form-data; name="file"; filename="canary.txt"\r\n'
+        "Content-Type: text/plain\r\n\r\n"
+        "signed upload\r\n"
+        f"--{boundary}--\r\n"
+    ).encode("utf-8")
+    headers = signed_headers(
+        body=body,
+        target=b"/api/v1/upload",
+    )
+    headers["Content-Type"] = f"multipart/form-data; boundary={boundary}"
+
+    response = await gateway_request(
+        gateway_app,
+        "POST",
+        "/api/v1/upload",
+        content=body,
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "storefront_id": 2,
+        "filename": "canary.txt",
+        "content": "signed upload",
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "case",
+    ["signature", "stale", "method", "path", "query", "body", "api_host"],
+)
+async def test_forged_or_tampered_envelope_fails_closed(gateway_app, case):
+    body = b'{"name":"Orsha"}'
+    method = "POST"
+    target = b"/api/v1/echo"
+    api_hostname = "api.mvn.by"
+    timestamp = int(time.time())
+
+    if case == "stale":
+        timestamp -= settings.STOREFRONT_CONTEXT_MAX_AGE_SECONDS + 1
+    if case == "method":
+        method = "GET"
+    if case == "path":
+        target = b"/api/v1/other"
+    if case == "query":
+        target = b"/api/v1/echo?city=orsha"
+    headers = signed_headers(
+        body=body,
+        method=method,
+        target=target,
+        api_hostname=api_hostname,
+        timestamp=timestamp,
+    )
+    request_body = b'{"name":"Minsk"}' if case == "body" else body
+    if case == "api_host":
+        headers["Host"] = "localhost"
+    if case == "signature":
+        headers["X-MVN-Storefront-Signature"] = "v1=" + "0" * 64
+
+    response = await gateway_request(
+        gateway_app,
+        "POST",
+        content=request_body,
+        headers=headers,
+    )
+
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_raw_query_is_part_of_the_signed_target(gateway_app):
+    headers = signed_headers(
+        method="GET",
+        target=b"/api/v1/echo?brand=midea&q=a%2Fb",
+    )
+
+    response = await gateway_request(
+        gateway_app,
+        "GET",
+        "/api/v1/echo?brand=midea&q=a%2Fb",
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json()["storefront_id"] == 2
+
+
+@pytest.mark.asyncio
+async def test_raw_percent_encoded_path_is_part_of_signed_target(gateway_app):
+    headers = signed_headers(
+        method="GET",
+        target=b"/api/v1/path/a%2Fb",
+    )
+
+    response = await gateway_request(
+        gateway_app,
+        "GET",
+        "/api/v1/path/a%2Fb",
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"value": "a/b"}
+
+
+@pytest.mark.asyncio
+async def test_unknown_key_id_fails_without_trying_other_keys(gateway_app):
+    headers = signed_headers(key_id="unknown-runtime")
+
+    response = await gateway_request(gateway_app, "POST", headers=headers)
+
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_previous_key_pair_is_accepted_during_rotation(
+    gateway_app,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        settings,
+        "STOREFRONT_CONTEXT_PREVIOUS_SIGNING_KEY_ID",
+        PREVIOUS_KEY_ID,
+    )
+    monkeypatch.setattr(
+        settings,
+        "STOREFRONT_CONTEXT_PREVIOUS_SIGNING_SECRET",
+        PREVIOUS_SECRET,
+    )
+    headers = signed_headers(
+        key_id=PREVIOUS_KEY_ID,
+        secret=PREVIOUS_SECRET,
+    )
+
+    response = await gateway_request(gateway_app, "POST", headers=headers)
+
+    assert response.status_code == 200
+    assert response.json()["storefront_id"] == 2
+
+
+@pytest.mark.asyncio
+async def test_clearing_primary_pair_disables_stale_previous_key(
+    gateway_app,
+    monkeypatch,
+):
+    monkeypatch.setattr(settings, "STOREFRONT_CONTEXT_SIGNING_KEY_ID", "")
+    monkeypatch.setattr(settings, "STOREFRONT_CONTEXT_SIGNING_SECRET", "")
+    monkeypatch.setattr(
+        settings,
+        "STOREFRONT_CONTEXT_PREVIOUS_SIGNING_KEY_ID",
+        PREVIOUS_KEY_ID,
+    )
+    monkeypatch.setattr(
+        settings,
+        "STOREFRONT_CONTEXT_PREVIOUS_SIGNING_SECRET",
+        PREVIOUS_SECRET,
+    )
+
+    response = await gateway_request(
+        gateway_app,
+        "POST",
+        headers=signed_headers(
+            key_id=PREVIOUS_KEY_ID,
+            secret=PREVIOUS_SECRET,
+        ),
+    )
+
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_valid_signature_for_unknown_or_inactive_domain_is_safe_404(
+    gateway_app,
+):
+    headers = signed_headers(storefront_hostname="disabled.mvn.by")
+
+    response = await gateway_request(gateway_app, "POST", headers=headers)
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Storefront is unavailable"}
+    assert response.headers["cache-control"] == "private, no-store"
+
+
+@pytest.mark.asyncio
+async def test_unsigned_ordinary_api_host_keeps_canonical_main_scope(gateway_app):
+    response = await gateway_request(
+        gateway_app,
+        "POST",
+        headers={
+            "Host": "api.mvn.by",
+            "Origin": "https://orsha.internal.mvn.by",
+            "X-Forwarded-Host": "orsha.internal.mvn.by",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["storefront_id"] == 1
+
+
+@pytest.mark.asyncio
+async def test_unsigned_non_api_host_is_rejected_instead_of_switching_scope(
+    gateway_app,
+):
+    response = await gateway_request(
+        gateway_app,
+        "POST",
+        headers={"Host": STOREFRONT_HOST},
+    )
+
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_require_signed_switch_rejects_unsigned_canonical_request(
+    gateway_app,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        settings,
+        "STOREFRONT_CONTEXT_REQUIRE_SIGNED_REQUESTS",
+        True,
+    )
+
+    response = await gateway_request(
+        gateway_app,
+        "POST",
+        headers={"Host": "api.mvn.by"},
+    )
+
+    assert response.status_code == 401

--- a/tests/unit/test_public_storefront_gateway_routing.py
+++ b/tests/unit/test_public_storefront_gateway_routing.py
@@ -1,0 +1,87 @@
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.routing import APIRoute
+
+from core.storefront_public_routes import (
+    INTENTIONALLY_OPEN_PUBLIC_V1_REQUESTS,
+    requires_storefront_gateway,
+)
+from core.storefront_request_gateway import StorefrontRequestGatewayMiddleware
+from core.tenant_scope import verify_public_storefront_request
+from main import app
+from routers.api_products import router as products_router
+
+
+_INTENTIONALLY_OPEN_V1_ROUTES = {
+    ("/api/v1/address-suggest", frozenset({"GET"})),
+    ("/api/v1/feeds/yandex-business.yml", frozenset({"GET"})),
+    ("/api/v1/proxy/bank", frozenset({"GET"})),
+    ("/api/v1/proxy/egr", frozenset({"GET"})),
+}
+
+
+def _group_open_requests_by_route() -> set[tuple[str, frozenset[str]]]:
+    paths = {path for _, path in INTENTIONALLY_OPEN_PUBLIC_V1_REQUESTS}
+    return {
+        (
+            path,
+            frozenset(
+                method
+                for method, request_path in INTENTIONALLY_OPEN_PUBLIC_V1_REQUESTS
+                if request_path == path
+            ),
+        )
+        for path in paths
+    }
+
+
+def _has_gateway_dependency(route: APIRoute) -> bool:
+    pending = list(route.dependant.dependencies)
+    while pending:
+        dependency = pending.pop()
+        if dependency.call is verify_public_storefront_request:
+            return True
+        pending.extend(dependency.dependencies)
+    return False
+
+
+def test_every_app_v1_route_is_gateway_protected_or_exactly_allowlisted():
+    routes = [
+        route
+        for route in app.routes
+        if isinstance(route, APIRoute) and route.path.startswith("/api/v1/")
+    ]
+    unprotected = {
+        (route.path, frozenset(route.methods or ()))
+        for route in routes
+        if not _has_gateway_dependency(route)
+    }
+    assert routes
+    assert _group_open_requests_by_route() == _INTENTIONALLY_OPEN_V1_ROUTES
+    assert unprotected == _INTENTIONALLY_OPEN_V1_ROUTES
+
+
+def test_intentionally_open_request_allowlist_matches_method_and_path_exactly():
+    for method, path in INTENTIONALLY_OPEN_PUBLIC_V1_REQUESTS:
+        assert not requires_storefront_gateway(method=method, path=path)
+        assert requires_storefront_gateway(method="POST", path=path)
+        assert requires_storefront_gateway(method=method, path=f"{path}/")
+
+
+def test_legacy_authenticated_description_endpoint_does_not_gain_gateway_auth():
+    route = next(
+        route
+        for route in products_router.routes
+        if isinstance(route, APIRoute)
+        and route.path == "/products/{product_id}/generate-description"
+    )
+
+    assert not _has_gateway_dependency(route)
+
+
+def test_application_installs_signed_gateway_before_route_parsing():
+    middleware_classes = [item.cls for item in app.user_middleware]
+
+    assert StorefrontRequestGatewayMiddleware in middleware_classes
+    assert middleware_classes.index(StorefrontRequestGatewayMiddleware) < (
+        middleware_classes.index(CORSMiddleware)
+    )

--- a/tests/unit/test_storefront_context_settings.py
+++ b/tests/unit/test_storefront_context_settings.py
@@ -1,0 +1,68 @@
+import pytest
+from pydantic import ValidationError
+
+from core.config import Settings
+
+
+_PRIMARY_SECRET = "primary-storefront-secret-at-least-32-bytes"
+_PREVIOUS_SECRET = "previous-storefront-secret-at-least-32-bytes"
+
+
+def _settings(**overrides) -> Settings:
+    return Settings(_env_file=None, **overrides)
+
+
+def test_primary_storefront_signing_key_requires_complete_pair():
+    with pytest.raises(ValidationError, match="must be configured together"):
+        _settings(
+            STOREFRONT_CONTEXT_SIGNING_KEY_ID="mvn-web-current",
+            STOREFRONT_CONTEXT_SIGNING_SECRET="",
+        )
+
+
+def test_previous_storefront_key_requires_primary_pair():
+    with pytest.raises(ValidationError, match="requires a configured primary"):
+        _settings(
+            STOREFRONT_CONTEXT_PREVIOUS_SIGNING_KEY_ID="mvn-web-previous",
+            STOREFRONT_CONTEXT_PREVIOUS_SIGNING_SECRET=_PREVIOUS_SECRET,
+        )
+
+
+def test_rotation_key_ids_must_be_distinct():
+    with pytest.raises(ValidationError, match="key IDs must differ"):
+        _settings(
+            STOREFRONT_CONTEXT_SIGNING_KEY_ID="mvn-web-current",
+            STOREFRONT_CONTEXT_SIGNING_SECRET=_PRIMARY_SECRET,
+            STOREFRONT_CONTEXT_PREVIOUS_SIGNING_KEY_ID="mvn-web-current",
+            STOREFRONT_CONTEXT_PREVIOUS_SIGNING_SECRET=_PREVIOUS_SECRET,
+        )
+
+
+def test_require_signed_switch_needs_primary_key_at_startup():
+    with pytest.raises(
+        ValidationError,
+        match="cannot be required without a primary signing key",
+    ):
+        _settings(STOREFRONT_CONTEXT_REQUIRE_SIGNED_REQUESTS=True)
+
+
+@pytest.mark.parametrize("value", [1023, 64 * 1024 * 1024 + 1])
+def test_signed_body_buffer_must_remain_bounded(value):
+    with pytest.raises(ValidationError, match="between 1 KiB and 64 MiB"):
+        _settings(STOREFRONT_CONTEXT_MAX_BODY_BYTES=value)
+
+
+def test_complete_rotation_keyring_is_accepted():
+    configured = _settings(
+        STOREFRONT_CONTEXT_SIGNING_KEY_ID="mvn-web-current",
+        STOREFRONT_CONTEXT_SIGNING_SECRET=_PRIMARY_SECRET,
+        STOREFRONT_CONTEXT_PREVIOUS_SIGNING_KEY_ID="mvn-web-previous",
+        STOREFRONT_CONTEXT_PREVIOUS_SIGNING_SECRET=_PREVIOUS_SECRET,
+        STOREFRONT_CONTEXT_REQUIRE_SIGNED_REQUESTS=True,
+        STOREFRONT_CONTEXT_API_HOSTS="api.mvn.by,api.internal.mvn.by",
+    )
+
+    assert configured.storefront_context_api_hosts == (
+        "api.mvn.by",
+        "api.internal.mvn.by",
+    )

--- a/tests/unit/test_storefront_context_signature_service.py
+++ b/tests/unit/test_storefront_context_signature_service.py
@@ -7,6 +7,8 @@ from services.storefront_context_signature_service import (
 
 
 _SECRET = "test-storefront-secret-at-least-32-bytes"
+_BODY = b'{"name":"Orsha"}'
+_BODY_SHA256 = StorefrontContextSignatureService.body_sha256(_BODY)
 
 
 def _signature(*, timestamp: int = 1_700_000_000) -> str:
@@ -14,20 +16,45 @@ def _signature(*, timestamp: int = 1_700_000_000) -> str:
         secret=_SECRET,
         timestamp=timestamp,
         method="POST",
-        path="/api/v1/leads/contact",
-        hostname="CITY.MVN.BY:443",
+        path_and_query=b"/api/v1/leads/contact?source=city%20page&tag=a%2Fb",
+        api_hostname="API.MVN.BY:443",
+        storefront_hostname="CITY.MVN.BY:443",
+        body_sha256=_BODY_SHA256,
     )
 
 
-def test_signature_round_trip_returns_normalized_hostname():
+def test_canonical_message_has_exact_v1_field_order_and_no_trailing_newline():
+    message = StorefrontContextSignatureService.canonical_message(
+        timestamp=1_700_000_000,
+        method="post",
+        path_and_query=b"/api/v1/leads/contact?b=2&a=%2F",
+        api_hostname="API.MVN.BY:443",
+        storefront_hostname="CITY.MVN.BY.",
+        body_sha256=_BODY_SHA256,
+    )
+
+    assert message == (
+        b"v1\n"
+        b"1700000000\n"
+        b"POST\n"
+        b"/api/v1/leads/contact?b=2&a=%2F\n"
+        b"api.mvn.by\n"
+        b"city.mvn.by\n" + _BODY_SHA256.encode("ascii")
+    )
+    assert not message.endswith(b"\n")
+
+
+def test_signature_round_trip_returns_normalized_storefront_hostname():
     signature = _signature()
 
     hostname = StorefrontContextSignatureService.verify(
         secret=_SECRET,
         timestamp=1_700_000_000,
         method="post",
-        path="/api/v1/leads/contact",
-        hostname="city.mvn.by",
+        path_and_query=b"/api/v1/leads/contact?source=city%20page&tag=a%2Fb",
+        api_hostname="api.mvn.by",
+        storefront_hostname="city.mvn.by",
+        body_sha256=_BODY_SHA256,
         signature=signature,
         max_age_seconds=300,
         now=1_700_000_100,
@@ -41,18 +68,22 @@ def test_signature_round_trip_returns_normalized_hostname():
     ("field", "value"),
     [
         ("method", "GET"),
-        ("path", "/api/v1/orders"),
-        ("hostname", "other.mvn.by"),
+        ("path_and_query", b"/api/v1/leads/contact?tag=a%2fb&source=city%20page"),
+        ("api_hostname", "other-api.mvn.by"),
+        ("storefront_hostname", "other.mvn.by"),
+        ("body_sha256", StorefrontContextSignatureService.body_sha256(b"tampered")),
         ("signature", "v1=" + "0" * 64),
     ],
 )
-def test_signature_rejects_tampered_request_target(field, value):
+def test_signature_rejects_tampered_request(field, value):
     kwargs = {
         "secret": _SECRET,
         "timestamp": 1_700_000_000,
         "method": "POST",
-        "path": "/api/v1/leads/contact",
-        "hostname": "city.mvn.by",
+        "path_and_query": b"/api/v1/leads/contact?source=city%20page&tag=a%2Fb",
+        "api_hostname": "api.mvn.by",
+        "storefront_hostname": "city.mvn.by",
+        "body_sha256": _BODY_SHA256,
         "signature": _signature(),
         "max_age_seconds": 300,
         "now": 1_700_000_100,
@@ -66,7 +97,8 @@ def test_signature_rejects_tampered_request_target(field, value):
         StorefrontContextSignatureService.verify(**kwargs)
 
 
-def test_signature_rejects_expired_timestamp():
+@pytest.mark.parametrize("now", [1_699_999_699, 1_700_000_301])
+def test_signature_rejects_timestamp_outside_past_or_future_window(now):
     with pytest.raises(
         InvalidStorefrontContextSignature,
         match="has expired",
@@ -75,12 +107,58 @@ def test_signature_rejects_expired_timestamp():
             secret=_SECRET,
             timestamp=1_700_000_000,
             method="POST",
-            path="/api/v1/leads/contact",
-            hostname="city.mvn.by",
-            signature=_signature(),
+            path_and_query="/api/v1/leads/contact",
+            api_hostname="api.mvn.by",
+            storefront_hostname="city.mvn.by",
+            body_sha256=_BODY_SHA256,
+            signature=StorefrontContextSignatureService.sign(
+                secret=_SECRET,
+                timestamp=1_700_000_000,
+                method="POST",
+                path_and_query="/api/v1/leads/contact",
+                api_hostname="api.mvn.by",
+                storefront_hostname="city.mvn.by",
+                body_sha256=_BODY_SHA256,
+            ),
             max_age_seconds=300,
-            now=1_700_000_301,
+            now=now,
         )
+
+
+@pytest.mark.parametrize(
+    "signature",
+    [
+        "",
+        "v2=" + "0" * 64,
+        "v1=" + "A" * 64,
+        "v1=" + "0" * 63,
+        "v1=" + "0" * 65,
+    ],
+)
+def test_signature_rejects_noncanonical_signature_format(signature):
+    with pytest.raises(
+        InvalidStorefrontContextSignature,
+        match="signature is invalid",
+    ):
+        StorefrontContextSignatureService.verify(
+            secret=_SECRET,
+            timestamp=1_700_000_000,
+            method="POST",
+            path_and_query="/api/v1/leads/contact",
+            api_hostname="api.mvn.by",
+            storefront_hostname="city.mvn.by",
+            body_sha256=_BODY_SHA256,
+            signature=signature,
+            max_age_seconds=300,
+            now=1_700_000_100,
+        )
+
+
+def test_request_target_preserves_raw_query_bytes():
+    assert StorefrontContextSignatureService.request_target(
+        raw_path=b"/api/v1/products",
+        query_string=b"brand=midea&brand=gree&q=a%2Fb",
+    ) == b"/api/v1/products?brand=midea&brand=gree&q=a%2Fb"
 
 
 def test_signature_rejects_missing_secret():
@@ -92,29 +170,8 @@ def test_signature_rejects_missing_secret():
             secret="",
             timestamp=1_700_000_000,
             method="POST",
-            path="/api/v1/leads/contact",
-            hostname="city.mvn.by",
+            path_and_query="/api/v1/leads/contact",
+            api_hostname="api.mvn.by",
+            storefront_hostname="city.mvn.by",
+            body_sha256=_BODY_SHA256,
         )
-
-
-def test_verify_any_accepts_previous_secret_during_rotation():
-    signature = StorefrontContextSignatureService.sign(
-        secret=_SECRET,
-        timestamp=1_700_000_000,
-        method="POST",
-        path="/api/v1/leads/contact",
-        hostname="city.mvn.by",
-    )
-
-    hostname = StorefrontContextSignatureService.verify_any(
-        secrets=("new-storefront-secret-at-least-32-bytes", _SECRET),
-        timestamp=1_700_000_000,
-        method="POST",
-        path="/api/v1/leads/contact",
-        hostname="city.mvn.by",
-        signature=signature,
-        max_age_seconds=300,
-        now=1_700_000_100,
-    )
-
-    assert hostname == "city.mvn.by"

--- a/tests/unit/test_storefront_request_gateway_boundary.py
+++ b/tests/unit/test_storefront_request_gateway_boundary.py
@@ -1,0 +1,274 @@
+import pytest
+from fastapi import Depends, FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from core.app_http import configure_http
+from core.config import settings
+from core.database import get_session
+from core.tenant_scope import verify_public_storefront_request
+from tests.unit.storefront_gateway_test_support import (
+    STOREFRONT_HOST,
+    configure_signing_settings,
+    gateway_app,
+    gateway_request,
+    signed_headers,
+)
+
+
+@pytest.mark.asyncio
+async def test_complete_envelope_above_bounded_buffer_is_413(gateway_app):
+    body = b"x" * (1024 * 1024 + 1)
+
+    response = await gateway_request(
+        gateway_app,
+        "POST",
+        content=body,
+        headers=signed_headers(body=body),
+    )
+
+    assert response.status_code == 413
+    assert response.json() == {"detail": "Storefront request body is too large"}
+    assert response.headers["cache-control"] == "private, no-store"
+    assert response.headers["cdn-cache-control"] == "no-store"
+    assert response.headers["vary"] == "X-MVN-Storefront-Host"
+    assert gateway_app.state.session_calls == 0
+    assert gateway_app.state.validated_endpoint_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_valid_envelope_reaches_body_parser_and_keeps_422_private(gateway_app):
+    body = b'{"name":'
+    headers = signed_headers(body=body, target=b"/api/v1/validated")
+    headers["Content-Type"] = "application/json"
+
+    response = await gateway_request(
+        gateway_app,
+        "POST",
+        "/api/v1/validated",
+        content=body,
+        headers=headers,
+    )
+
+    assert response.status_code == 422
+    assert response.headers["cache-control"] == "private, no-store"
+    assert response.headers["cdn-cache-control"] == "no-store"
+    assert response.headers["vary"] == "X-MVN-Storefront-Host"
+    assert gateway_app.state.session_calls == 0
+    assert gateway_app.state.validated_endpoint_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_gateway_merges_existing_vary_without_duplicates(gateway_app):
+    response = await gateway_request(
+        gateway_app,
+        "GET",
+        "/api/v1/vary",
+        headers=signed_headers(method="GET", target=b"/api/v1/vary"),
+    )
+
+    assert response.status_code == 200
+    assert response.headers["cache-control"] == "private, no-store"
+    assert response.headers["cdn-cache-control"] == "no-store"
+    assert response.headers["vary"] == (
+        "Accept-Encoding, Origin, X-MVN-Storefront-Host"
+    )
+    raw_header_names = [name.lower() for name, _ in response.headers.raw]
+    assert raw_header_names.count(b"cache-control") == 1
+    assert raw_header_names.count(b"cdn-cache-control") == 1
+    assert raw_header_names.count(b"vary") == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "case",
+    [
+        "partial_malformed",
+        "forged_malformed",
+        "duplicate",
+        "unknown",
+        "partial_oversized",
+        "unsigned_wrong_host",
+        "unsigned_required",
+    ],
+)
+async def test_untrusted_request_fails_before_parser_or_dependencies(
+    gateway_app,
+    case,
+    monkeypatch,
+):
+    body = (
+        b"x" * (1024 * 1024 + 1)
+        if case == "partial_oversized"
+        else b'{"name":'
+    )
+    if case.startswith("partial"):
+        headers = {"X-MVN-Storefront-Host": STOREFRONT_HOST}
+    elif case == "unsigned_wrong_host":
+        headers = {"Host": STOREFRONT_HOST}
+    elif case == "unsigned_required":
+        monkeypatch.setattr(
+            settings,
+            "STOREFRONT_CONTEXT_REQUIRE_SIGNED_REQUESTS",
+            True,
+        )
+        headers = {"Host": "api.mvn.by"}
+    else:
+        headers = signed_headers(body=body, target=b"/api/v1/validated")
+        if case == "forged_malformed":
+            headers["X-MVN-Storefront-Signature"] = "v1=" + "0" * 64
+        elif case == "unknown":
+            headers["X-MVN-Storefront-Nonce"] = "unsupported"
+        elif case == "duplicate":
+            headers = list(headers.items())
+            headers.append(("X-MVN-Storefront-Host", STOREFRONT_HOST))
+    if isinstance(headers, dict):
+        headers["Content-Type"] = "application/json"
+    else:
+        headers.append(("Content-Type", "application/json"))
+
+    response = await gateway_request(
+        gateway_app,
+        "POST",
+        "/api/v1/validated",
+        content=body,
+        headers=headers,
+    )
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Invalid storefront context"}
+    assert response.headers["cache-control"] == "private, no-store"
+    assert response.headers["cdn-cache-control"] == "no-store"
+    assert response.headers["vary"] == "X-MVN-Storefront-Host"
+    assert gateway_app.state.session_calls == 0
+    assert gateway_app.state.validated_endpoint_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_partial_header_on_unknown_route_fails_closed_early(gateway_app):
+    response = await gateway_request(
+        gateway_app,
+        "GET",
+        "/api/v1/missing",
+        headers={"X-MVN-Storefront-Nonce": "unsupported"},
+    )
+
+    assert response.status_code == 401
+    assert response.headers["cache-control"] == "private, no-store"
+    assert response.headers["cdn-cache-control"] == "no-store"
+    assert response.headers["vary"] == "X-MVN-Storefront-Host"
+
+
+@pytest.mark.asyncio
+async def test_route_dependency_never_trusts_raw_headers_without_scope_marker():
+    app = FastAPI()
+    calls = {"session": 0, "endpoint": 0}
+
+    async def override_session():
+        calls["session"] += 1
+        yield object()
+
+    app.dependency_overrides[get_session] = override_session
+
+    @app.get(
+        "/api/v1/direct",
+        dependencies=[Depends(verify_public_storefront_request)],
+    )
+    async def direct():
+        calls["endpoint"] += 1
+        return {"ok": True}
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport,
+        base_url="https://api.mvn.by",
+    ) as client:
+        response = await client.get(
+            "/api/v1/direct",
+            headers=signed_headers(method="GET", target=b"/api/v1/direct"),
+        )
+
+    assert response.status_code == 401
+    assert calls == {"session": 0, "endpoint": 0}
+
+
+@pytest.mark.asyncio
+async def test_unhandled_signed_error_is_never_shared_cacheable(monkeypatch):
+    app = FastAPI()
+    configure_signing_settings(monkeypatch)
+    configure_http(app)
+    monkeypatch.setattr("core.app_http.logger.error", lambda *_args, **_kwargs: None)
+
+    @app.get("/api/v1/failure")
+    async def fail():
+        raise RuntimeError("test failure")
+
+    transport = ASGITransport(app=app, raise_app_exceptions=False)
+    async with AsyncClient(
+        transport=transport,
+        base_url="https://api.mvn.by",
+    ) as client:
+        response = await client.get(
+            "/api/v1/failure",
+            headers=signed_headers(method="GET", target=b"/api/v1/failure"),
+        )
+
+    assert response.status_code == 500
+    assert response.headers["cache-control"] == "private, no-store"
+    assert response.headers["cdn-cache-control"] == "no-store"
+    assert response.headers["vary"] == "X-MVN-Storefront-Host"
+
+
+@pytest.mark.asyncio
+async def test_unsigned_canonical_cors_preflight_is_unchanged(monkeypatch):
+    app = FastAPI()
+    configure_signing_settings(monkeypatch)
+    configure_http(app)
+    transport = ASGITransport(app=app)
+
+    async with AsyncClient(
+        transport=transport,
+        base_url="https://api.mvn.by",
+    ) as client:
+        response = await client.options(
+            "/api/v1/products",
+            headers={
+                "Host": "api.mvn.by",
+                "Origin": "https://mvn.by",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "https://mvn.by"
+
+
+@pytest.mark.asyncio
+async def test_duplicate_signing_header_fails_closed(gateway_app):
+    headers = list(signed_headers().items())
+    headers.append(("X-MVN-Storefront-Host", STOREFRONT_HOST))
+
+    response = await gateway_request(gateway_app, "POST", headers=headers)
+
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_duplicate_api_host_fails_closed(gateway_app):
+    headers = list(signed_headers().items())
+    headers.append(("Host", "api.mvn.by"))
+
+    response = await gateway_request(gateway_app, "POST", headers=headers)
+
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_noncanonical_timestamp_fails_closed(gateway_app):
+    headers = signed_headers()
+    headers["X-MVN-Storefront-Timestamp"] = (
+        "0" + headers["X-MVN-Storefront-Timestamp"]
+    )
+
+    response = await gateway_request(gateway_app, "POST", headers=headers)
+
+    assert response.status_code == 401


### PR DESCRIPTION
## What changed

- authenticates the complete storefront envelope in an outer ASGI gateway before FastAPI parses request bodies
- binds HMAC to key ID, timestamp, method, raw path and query, upstream API host, storefront host and exact body digest
- rejects partial, duplicate, unknown, stale or forged context headers before endpoint and database dependencies
- carries only a typed verified storefront marker inward and forces signed responses to private/no-store
- classifies every public v1 route with a deny-by-default inventory and a four-route exact open allowlist
- validates key rotation, host allowlists and bounded signed request bodies

## Compatibility and rollout

- canonical unsigned MVN traffic remains supported while STOREFRONT_CONTEXT_REQUIRE_SIGNED_REQUESTS=false
- signed-only mode must stay disabled until blue-green, post-deploy and VPS health probes are signed
- exact replay inside the short timestamp window remains possible; TLS, no envelope logging and domain idempotency remain required

## Validation

- 73 focused unit and PostgreSQL integration tests passed after rebasing onto current main
- Manager OpenAPI/client regeneration is idempotent
- Manager production build passed
- independent security review: SHIP, no confirmed HMAC or pre-parser bypasses
- git diff check and worktree are clean