### PR TITLE
Fix order writes rolled back after dependency autobegin

### DIFF
--- a/services/command_transaction.py
+++ b/services/command_transaction.py
@@ -1,10 +1,34 @@
 """Shared transaction boundary for composable application commands."""
 
-from sqlalchemy.ext.asyncio import AsyncSession, AsyncSessionTransaction
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import SessionTransactionOrigin
 
 
-def command_transaction(session: AsyncSession) -> AsyncSessionTransaction:
-    """Own a root transaction, or a SAVEPOINT inside an explicit caller UoW."""
-    if session.in_transaction():
-        return session.begin_nested()
-    return session.begin()
+@asynccontextmanager
+async def command_transaction(session: AsyncSession) -> AsyncIterator[None]:
+    """Own the root transaction unless the caller opened an explicit UoW."""
+    transaction = session.get_transaction()
+    if transaction is None:
+        async with session.begin():
+            yield
+        return
+
+    origin = transaction.sync_transaction.origin
+    if origin is SessionTransactionOrigin.AUTOBEGIN:
+        # Authentication and other read dependencies trigger SQLAlchemy's
+        # implicit AUTOBEGIN. The command owns that root transaction and must
+        # finish it, otherwise session.close() rolls the successful write back.
+        try:
+            yield
+        except BaseException:
+            await session.rollback()
+            raise
+        else:
+            await session.commit()
+        return
+
+    async with session.begin_nested():
+        yield

--- a/services/command_transaction.py
+++ b/services/command_transaction.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import SessionTransactionOrigin
 
 @asynccontextmanager
 async def command_transaction(session: AsyncSession) -> AsyncIterator[None]:
-    """Own the root transaction unless the caller opened an explicit UoW."""
+    """Commit command-owned roots and isolate work inside caller transactions."""
     transaction = session.get_transaction()
     if transaction is None:
         async with session.begin():
@@ -19,15 +19,12 @@ async def command_transaction(session: AsyncSession) -> AsyncIterator[None]:
     origin = transaction.sync_transaction.origin
     if origin is SessionTransactionOrigin.AUTOBEGIN:
         # Authentication and other read dependencies trigger SQLAlchemy's
-        # implicit AUTOBEGIN. The command owns that root transaction and must
-        # finish it, otherwise session.close() rolls the successful write back.
-        try:
+        # implicit AUTOBEGIN. Isolate the command in a SAVEPOINT so a failed
+        # command does not roll back work that predates it on a reused session.
+        # A successful command still owns and commits the implicit root.
+        async with session.begin_nested():
             yield
-        except BaseException:
-            await session.rollback()
-            raise
-        else:
-            await session.commit()
+        await session.commit()
         return
 
     async with session.begin_nested():

--- a/tests/unit/test_command_transaction.py
+++ b/tests/unit/test_command_transaction.py
@@ -113,6 +113,45 @@ async def test_command_uses_savepoint_inside_explicit_uow(
 
 
 @pytest.mark.asyncio
+async def test_failed_autobegin_command_preserves_preexisting_root_work(
+    transaction_session_factory: Any,
+):
+    async with transaction_session_factory() as session:
+        await session.execute(
+            text(
+                """
+                INSERT INTO command_transaction_probe (value)
+                VALUES ('before')
+                """
+            )
+        )
+
+        with pytest.raises(RuntimeError, match="rollback command savepoint"):
+            async with command_transaction(session):
+                await session.execute(
+                    text(
+                        """
+                        INSERT INTO command_transaction_probe (value)
+                        VALUES ('nested')
+                        """
+                    )
+                )
+                raise RuntimeError("rollback command savepoint")
+
+        await session.execute(
+            text(
+                """
+                INSERT INTO command_transaction_probe (value)
+                VALUES ('after')
+                """
+            )
+        )
+        await session.commit()
+
+    assert await _stored_values(transaction_session_factory) == ["before", "after"]
+
+
+@pytest.mark.asyncio
 async def test_command_rolls_back_owned_autobegin_on_error(
     transaction_session_factory: Any,
 ):

--- a/tests/unit/test_command_transaction.py
+++ b/tests/unit/test_command_transaction.py
@@ -1,0 +1,134 @@
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from services.command_transaction import command_transaction
+
+
+@pytest.fixture
+async def transaction_session_factory(
+    tmp_path: Path,
+) -> AsyncIterator[Any]:
+    engine = create_async_engine(
+        f"sqlite+aiosqlite:///{tmp_path / 'command_transaction.db'}",
+        echo=False,
+    )
+    async with engine.begin() as connection:
+        await connection.execute(
+            text(
+                """
+                CREATE TABLE command_transaction_probe (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    value TEXT NOT NULL
+                )
+                """
+            )
+        )
+
+    factory = sessionmaker(
+        bind=engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+    yield factory
+    await engine.dispose()
+
+
+async def _stored_values(factory: Any) -> list[str]:
+    async with factory() as session:
+        result = await session.execute(
+            text(
+                """
+                SELECT value
+                FROM command_transaction_probe
+                ORDER BY id
+                """
+            )
+        )
+        return list(result.scalars().all())
+
+
+@pytest.mark.asyncio
+async def test_command_commits_after_read_only_autobegin(
+    transaction_session_factory: Any,
+):
+    async with transaction_session_factory() as session:
+        await session.execute(text("SELECT 1"))
+
+        async with command_transaction(session):
+            await session.execute(
+                text(
+                    """
+                    INSERT INTO command_transaction_probe (value)
+                    VALUES ('persisted')
+                    """
+                )
+            )
+
+    assert await _stored_values(transaction_session_factory) == ["persisted"]
+
+
+@pytest.mark.asyncio
+async def test_command_uses_savepoint_inside_explicit_uow(
+    transaction_session_factory: Any,
+):
+    async with transaction_session_factory() as session:
+        async with session.begin():
+            await session.execute(
+                text(
+                    """
+                    INSERT INTO command_transaction_probe (value)
+                    VALUES ('before')
+                    """
+                )
+            )
+
+            with pytest.raises(RuntimeError, match="rollback nested command"):
+                async with command_transaction(session):
+                    await session.execute(
+                        text(
+                            """
+                            INSERT INTO command_transaction_probe (value)
+                            VALUES ('nested')
+                            """
+                        )
+                    )
+                    raise RuntimeError("rollback nested command")
+
+            await session.execute(
+                text(
+                    """
+                    INSERT INTO command_transaction_probe (value)
+                    VALUES ('after')
+                    """
+                )
+            )
+
+    assert await _stored_values(transaction_session_factory) == ["before", "after"]
+
+
+@pytest.mark.asyncio
+async def test_command_rolls_back_owned_autobegin_on_error(
+    transaction_session_factory: Any,
+):
+    async with transaction_session_factory() as session:
+        await session.execute(text("SELECT 1"))
+
+        with pytest.raises(RuntimeError, match="rollback owned command"):
+            async with command_transaction(session):
+                await session.execute(
+                    text(
+                        """
+                        INSERT INTO command_transaction_probe (value)
+                        VALUES ('rolled-back')
+                        """
+                    )
+                )
+                raise RuntimeError("rollback owned command")
+
+    assert await _stored_values(transaction_session_factory) == []


### PR DESCRIPTION
## Problem

Manager order creation and updates can return successfully but disappear after the request finishes. The shared request session is first used by authentication/storefront dependencies, which opens an implicit SQLAlchemy `AUTOBEGIN` transaction.

`command_transaction()` previously treated every active transaction as an explicit caller-owned unit of work and opened only a SAVEPOINT. Releasing that SAVEPOINT did not commit the implicit root transaction, so request-session cleanup rolled the write back.

## Fix

- distinguish SQLAlchemy `AUTOBEGIN` from an explicitly opened caller UoW;
- isolate the command itself in a SAVEPOINT inside an implicit root transaction;
- after a successful command, release the SAVEPOINT and commit the implicit root;
- after a failed command, roll back only the command SAVEPOINT and leave root cleanup to the request/session lifecycle;
- retain ordinary `session.begin()` behavior when no transaction exists;
- retain SAVEPOINT behavior inside an explicit outer UoW.

This avoids both failure modes: successful Manager writes are durable, while an expected command validation error cannot erase work that existed before the command on a reused or externally managed session.

## Regression coverage

Focused SQLite async tests prove that:

- a write after a read-triggered `AUTOBEGIN` survives session close;
- a failed nested command rolls back only its SAVEPOINT inside an explicit outer UoW;
- a failed command preserves work already present in an implicit root transaction;
- a failed command does not persist its own write after session cleanup.

## CI follow-up

The first full run exposed eight tests that reused an externally managed transaction. The initial implementation called `session.rollback()` on command failure, which rolled back their entire fixture UoW. The revised SAVEPOINT boundary fixes that common root cause without changing the test fixture.

Full CI must pass before marking ready or merging.