### PR TITLE
Allow Patroni leader activation while peer is absent

### DIFF
--- a/scripts/ha/patroni_local_identity.py
+++ b/scripts/ha/patroni_local_identity.py
@@ -396,7 +396,7 @@ def reconcile_primary_systemd_units(
     if role == "standby":
         # ``systemctl stop`` deliberately does not clear a unit's failed latch.
         # A failed one-shot PITR service has no running owner, but the strict
-        # steady-state probe still requires ``inactive``.  Clear only the
+        # steady-state probe still requires ``inactive``. Clear only the
         # recorded failure after every stop attempt, then let the exact state
         # probe below prove that timers are disabled and every unit is inactive.
         for unit in unique_units:
@@ -609,7 +609,18 @@ def _validate_leader_lock(
     ):
         raise ValueError("Patroni /cluster member list is missing or invalid")
     names = [str(member.get("name") or "").strip() for member in raw_members]
-    if set(names) != EXPECTED_CLUSTER_NAMES or len(names) != len(EXPECTED_CLUSTER_NAMES):
+    reported_names = set(names)
+    # Patroni member keys are ephemeral. During a real node outage the elected
+    # primary may be the only reviewed member left in /cluster. Keep accepting
+    # only known, duplicate-free identities containing this local node; the
+    # fresh DCS observation, /leader proof, single-leader and timeline checks
+    # below still guard activation.
+    if (
+        not names
+        or len(names) != len(reported_names)
+        or expected_name not in reported_names
+        or not reported_names.issubset(EXPECTED_CLUSTER_NAMES)
+    ):
         raise ValueError(f"Patroni /cluster identities are unsafe: {sorted(names)}")
     leaders = [
         member

--- a/tests/unit/test_patroni_local_identity.py
+++ b/tests/unit/test_patroni_local_identity.py
@@ -284,6 +284,28 @@ def test_fetch_role_requires_strict_identity_and_leader_lock(
     )
 
 
+def test_primary_accepts_single_reviewed_local_dcs_member(monkeypatch):
+    status = _patroni_payload("leader")
+    cluster = {
+        "members": [
+            {
+                "name": "mvn-api",
+                "role": "leader",
+                "state": "running",
+                "timeline": 7,
+            }
+        ]
+    }
+    _mock_patroni(
+        monkeypatch,
+        status=status,
+        leader=dict(status),
+        cluster=cluster,
+    )
+
+    assert _fetch() == "primary"
+
+
 def test_fetch_role_rejects_unknown_running_role(monkeypatch):
     _mock_patroni(monkeypatch, status=_patroni_payload("mystery"))
     with pytest.raises(ValueError, match="unsupported Patroni role: mystery"):
@@ -362,6 +384,36 @@ def test_primary_requires_coherent_leader_endpoint_and_dcs_view(
         cluster["members"][1]["role"] = "leader"
     _mock_patroni(monkeypatch, status=status, leader=leader, cluster=cluster)
     with pytest.raises((ValueError, urllib.error.URLError), match=message):
+        _fetch()
+
+
+@pytest.mark.parametrize(
+    "members",
+    [
+        [],
+        [
+            {"name": "mvn-api", "role": "leader", "state": "running", "timeline": 7},
+            {"name": "mvn-api", "role": "replica", "state": "running", "timeline": 7},
+        ],
+        [
+            {"name": "mvn-api", "role": "leader", "state": "running", "timeline": 7},
+            {"name": "unexpected", "role": "replica", "state": "running", "timeline": 7},
+        ],
+        [
+            {"name": "zakup", "role": "leader", "state": "running", "timeline": 7},
+        ],
+    ],
+)
+def test_primary_rejects_unsafe_dcs_member_identities(monkeypatch, members):
+    status = _patroni_payload("leader")
+    _mock_patroni(
+        monkeypatch,
+        status=status,
+        leader=dict(status),
+        cluster={"members": members},
+    )
+
+    with pytest.raises(ValueError, match="identities are unsafe"):
         _fetch()
 
 


### PR DESCRIPTION
## Incident

During the 2026-08-05 provider outage, Patroni correctly promoted `mvn-api` to the DCS leader on timeline 19 after `zakup` disappeared. The host role agent nevertheless kept the API fenced as `standby` because its `/cluster` identity validator required both reviewed Patroni member keys to be present at all times.

That requirement turns a legitimate degraded failover state into an application outage: PostgreSQL is writable on the elected leader, but `/api/ready` remains 503 and Cloudflare has no healthy API origin.

## Fix

Allow `/cluster` to contain a non-empty, duplicate-free subset of the two reviewed member identities, provided it contains the local expected node.

All existing primary proofs remain mandatory:

- fresh DCS observation;
- local `/patroni` primary identity;
- local `/leader` endpoint agreement on system identifier and timeline;
- exactly one DCS leader;
- the DCS leader is the local running node;
- no pending restart, pause, unlocked cluster, or active DCS failsafe mode;
- no unknown or duplicate member identities.

## Coverage

Adds regression coverage for a single reviewed local leader and rejection coverage for empty, duplicate, unknown, and local-node-missing membership views.

## Operational note

An incident hotfix script was prepared with an external-fencing preflight, but it detected that `zakup` had become reachable again and exited before modifying the live host. No manual production source patch was applied. The permanent change is delivered only through this reviewed PR and the normal deployment pipeline.