### PR TITLE
Make HA readiness role-neutral under Patroni

### DIFF
--- a/scripts/ha/check_api_ha_readiness.sh
+++ b/scripts/ha/check_api_ha_readiness.sh
@@ -29,8 +29,11 @@ API_NODE_COMPOSE_FILE="${API_NODE_COMPOSE_FILE:-${PRIMARY_COMPOSE_FILE}}"
 RESERVE_NODE_COMPOSE_FILE="${RESERVE_NODE_COMPOSE_FILE:-${STANDBY_COMPOSE_FILE}}"
 API_NODE_ORIGIN="${API_NODE_ORIGIN:-185.250.45.54}"
 RESERVE_NODE_ORIGIN="${RESERVE_NODE_ORIGIN:-193.47.42.213}"
-CONFIGURED_PRIMARY_ORIGIN="${PRIMARY_ORIGIN}"
-CONFIGURED_STANDBY_ORIGIN="${STANDBY_ORIGIN}"
+
+# Cloudflare pool order is stable configuration, not the current Patroni role.
+# Keep backward-compatible defaults from the legacy physical primary variables.
+CLOUDFLARE_PRIMARY_ORIGIN="${CLOUDFLARE_PRIMARY_ORIGIN:-${PRIMARY_ORIGIN}}"
+CLOUDFLARE_STANDBY_ORIGIN="${CLOUDFLARE_STANDBY_ORIGIN:-${STANDBY_ORIGIN}}"
 
 EXPECTED_CDN_BASE="${EXPECTED_CDN_BASE:-https://cdn.mvn.by}"
 MIN_DB_CDN_URLS="${MIN_DB_CDN_URLS:-3}"
@@ -182,8 +185,8 @@ run_cloudflare_lb() {
   fi
 
   CF_LB_HOSTNAME="${CF_LB_HOSTNAME:-${API_HOST}}" \
-    CF_LB_PRIMARY_ORIGIN="${CF_LB_PRIMARY_ORIGIN:-${CONFIGURED_PRIMARY_ORIGIN}}" \
-    CF_LB_STANDBY_ORIGIN="${CF_LB_STANDBY_ORIGIN:-${CONFIGURED_STANDBY_ORIGIN}}" \
+    CF_LB_PRIMARY_ORIGIN="${CF_LB_PRIMARY_ORIGIN:-${CLOUDFLARE_PRIMARY_ORIGIN}}" \
+    CF_LB_STANDBY_ORIGIN="${CF_LB_STANDBY_ORIGIN:-${CLOUDFLARE_STANDBY_ORIGIN}}" \
     CF_LB_HOST_HEADER="${CF_LB_HOST_HEADER:-${API_HOST}}" \
     CF_LB_MONITOR_PATH="${CF_LB_MONITOR_PATH:-/api/ready}" \
     CF_LB_MONITOR_METHOD="${CF_LB_MONITOR_METHOD:-GET}" \
@@ -233,11 +236,6 @@ case "${API_DB_HA_MODE}" in
         exit 1
         ;;
     esac
-    if [[ "${CONFIGURED_PRIMARY_ORIGIN}" != "${PRIMARY_ORIGIN}" ||
-          "${CONFIGURED_STANDBY_ORIGIN}" != "${STANDBY_ORIGIN}" ]]; then
-      log fail "configured API role origins disagree with the proven Patroni topology"
-      exit 1
-    fi
     ;;
   physical)
     patroni_primary_label=physical
@@ -248,7 +246,7 @@ case "${API_DB_HA_MODE}" in
     ;;
 esac
 
-log info "strict=${HA_READINESS_STRICT} ha_mode=${API_DB_HA_MODE} primary_label=${patroni_primary_label} primary=${PRIMARY_ORIGIN} standby=${STANDBY_ORIGIN} primary_ssh=${PRIMARY_SSH} standby_ssh=${STANDBY_SSH}"
+log info "strict=${HA_READINESS_STRICT} ha_mode=${API_DB_HA_MODE} primary_label=${patroni_primary_label} primary=${PRIMARY_ORIGIN} standby=${STANDBY_ORIGIN} primary_ssh=${PRIMARY_SSH} standby_ssh=${STANDBY_SSH} cloudflare_primary=${CLOUDFLARE_PRIMARY_ORIGIN} cloudflare_standby=${CLOUDFLARE_STANDBY_ORIGIN}"
 
 if is_true "${CHECK_ACTIVE_PASSIVE}"; then
   run_required "active_passive_invariant" run_active_passive

--- a/tests/unit/test_ha_readiness_workflow.py
+++ b/tests/unit/test_ha_readiness_workflow.py
@@ -59,7 +59,7 @@ def test_ha_readiness_workflow_wires_core_and_soft_blocker_inputs():
     assert artifact_step["with"]["path"] == "api-ha-readiness.log"
 
 
-def test_ha_readiness_resolves_patroni_primary_and_uses_role_aware_monitor():
+def test_ha_readiness_resolves_patroni_primary_and_keeps_lb_order_separate():
     script = (REPO_ROOT / "scripts/ha/check_api_ha_readiness.sh").read_text(
         encoding="utf-8"
     )
@@ -69,34 +69,29 @@ def test_ha_readiness_resolves_patroni_primary_and_uses_role_aware_monitor():
     assert "run_postgres_pitr_workflow.py --phase verify" in script
     assert 'PITR_WORKFLOW_IDENTITY_FILE' in script
     assert 'API_DB_HA_MODE="${API_DB_HA_MODE:-physical}"' in script
-    assert 'CONFIGURED_PRIMARY_ORIGIN="${PRIMARY_ORIGIN}"' in script
+    assert 'CLOUDFLARE_PRIMARY_ORIGIN="${CLOUDFLARE_PRIMARY_ORIGIN:-${PRIMARY_ORIGIN}}"' in script
     assert 'PRIMARY_SSH="${RESERVE_NODE_SSH}"' in script
     assert 'PRIMARY_COMPOSE_FILE="${RESERVE_NODE_COMPOSE_FILE}"' in script
-    assert "configured API role origins disagree" in script
+    assert "configured API role origins disagree" not in script
+    assert "cloudflare_primary=${CLOUDFLARE_PRIMARY_ORIGIN}" in script
 
 
 @pytest.mark.parametrize(
-    ("primary_label", "configured_primary", "configured_standby", "expected_log"),
+    ("primary_label", "expected_log"),
     (
         (
             "api",
-            "1.1.1.1",
-            "2.2.2.2",
             "primary=1.1.1.1 standby=2.2.2.2 primary_ssh=api-node standby_ssh=reserve-node",
         ),
         (
             "reserve",
-            "2.2.2.2",
-            "1.1.1.1",
             "primary=2.2.2.2 standby=1.1.1.1 primary_ssh=reserve-node standby_ssh=api-node",
         ),
     ),
 )
-def test_ha_readiness_maps_proven_patroni_role_from_physical_nodes(
+def test_ha_readiness_maps_patroni_roles_without_relabeling_cloudflare_pools(
     tmp_path,
     primary_label,
-    configured_primary,
-    configured_standby,
     expected_log,
 ):
     fake_bin = tmp_path / "bin"
@@ -117,8 +112,10 @@ def test_ha_readiness_maps_proven_patroni_role_from_physical_nodes(
             "RESERVE_NODE_COMPOSE_FILE": "docker-compose.patroni.yml",
             "API_NODE_ORIGIN": "1.1.1.1",
             "RESERVE_NODE_ORIGIN": "2.2.2.2",
-            "PRIMARY_ORIGIN": configured_primary,
-            "STANDBY_ORIGIN": configured_standby,
+            "PRIMARY_ORIGIN": "1.1.1.1",
+            "STANDBY_ORIGIN": "2.2.2.2",
+            "CLOUDFLARE_PRIMARY_ORIGIN": "1.1.1.1",
+            "CLOUDFLARE_STANDBY_ORIGIN": "2.2.2.2",
             "CHECK_ACTIVE_PASSIVE": "false",
             "CHECK_POSTGRES_REPLICATION": "false",
             "CHECK_MEDIA_CDN_DB": "false",
@@ -137,6 +134,7 @@ def test_ha_readiness_maps_proven_patroni_role_from_physical_nodes(
 
     assert result.returncode == 0, result.stdout + result.stderr
     assert expected_log in result.stdout
+    assert "cloudflare_primary=1.1.1.1 cloudflare_standby=2.2.2.2" in result.stdout
 
 
 def test_ha_invariant_workflow_skips_public_cloudflare_challenge_from_runner():


### PR DESCRIPTION
## Problem

After a normal Patroni failover, `API HA Readiness Audit` resolved the new primary correctly, then failed because legacy static `API_PRIMARY_ORIGIN` / `API_STANDBY_ORIGIN` values still described the previous role assignment.

That couples two different concepts:

- physical node identity and Cloudflare pool order, which are stable configuration;
- current PostgreSQL/API primary and standby roles, which Patroni is expected to move automatically.

With equivalent HA nodes, a healthy role swap must not require rewriting GitHub variables.

## Fix

- Keep stable Cloudflare pool order in separate internal variables.
- Resolve runtime primary/standby exclusively from Patroni in Patroni mode.
- Remove the failure that required static origin labels to match the current Patroni topology.
- Continue using the dynamically resolved role for active/passive checks, replication, media inspection, PITR, and runtime ownership.
- Log both the dynamic roles and stable Cloudflare pool order so they cannot be mistaken for each other.

## Safety

This does not weaken topology proof. `check_patroni_production.py --resolve-primary` still must prove exactly one valid Patroni primary before role-aware checks run. Cloudflare configuration is still audited separately against its configured pool order.

## Coverage

Adds regression coverage for both role assignments while the static Cloudflare pool order remains unchanged. The targeted tests and `bash -n` pass locally.

## Incident context

On 2026-08-05, `mvn-api` became the healthy primary on timeline 19 and `zakup` rejoined as the synchronous streaming replica. The readiness audit remained red solely because the legacy static role labels had not been swapped.