### PR TITLE
Separate live HA failures from restore assurance

### DIFF
--- a/scripts/ha/report_ha_status.py
+++ b/scripts/ha/report_ha_status.py
@@ -44,6 +44,7 @@ Runner = Callable[[Sequence[str], str | None], subprocess.CompletedProcess[str]]
 class ExpectedWorkflow:
     name: str
     max_age_hours: float | None = None
+    assurance_only: bool = False
 
 
 @dataclass(frozen=True)
@@ -83,8 +84,8 @@ EXPECTED_WORKFLOWS = (
     ExpectedWorkflow("PostgreSQL Replication Check", max_age_hours=8),
     ExpectedWorkflow("Cloudflare LB Config Check", max_age_hours=8),
     ExpectedWorkflow("PostgreSQL PITR Check", max_age_hours=8),
-    ExpectedWorkflow("API Restore Drill", max_age_hours=36),
-    ExpectedWorkflow("PostgreSQL PITR Restore Drill", max_age_hours=36),
+    ExpectedWorkflow("API Restore Drill", max_age_hours=36, assurance_only=True),
+    ExpectedWorkflow("PostgreSQL PITR Restore Drill", max_age_hours=36, assurance_only=True),
 )
 
 
@@ -212,7 +213,17 @@ def evaluate_workflows(
             warnings.append(f"{workflow.name}: latest run is {run.status or 'unknown'} ({suffix})")
             continue
         if run.conclusion != "success":
-            failures.append(f"{workflow.name}: latest run concluded {run.conclusion or 'unknown'} ({suffix})")
+            message = (
+                f"{workflow.name}: latest run concluded {run.conclusion or 'unknown'} "
+                f"({suffix})"
+            )
+            if workflow.assurance_only:
+                warnings.append(
+                    f"{message}; restore assurance requires attention, "
+                    "but live service health is evaluated separately"
+                )
+            else:
+                failures.append(message)
             continue
 
         current_age = age_hours(run, now=now)
@@ -319,6 +330,12 @@ def next_steps_for(result: ReportResult) -> list[str]:
 
     if result.failures:
         add_once("inspect failed workflow URLs/artifacts before changing API routing or database roles")
+
+    if "restore assurance requires attention" in joined:
+        add_once(
+            "inspect the failed restore-drill URL/artifact; this is a recoverability "
+            "signal and does not by itself mean the live API is unavailable"
+        )
 
     if "Cloudflare LB Config Check" in joined:
         add_once(

--- a/scripts/ha/restore_drill_latest_db.sh
+++ b/scripts/ha/restore_drill_latest_db.sh
@@ -41,6 +41,20 @@ require_root_directory() {
     fail "logical restore-drill state directory is unsafe: ${path}"
 }
 
+ensure_postgres_image() {
+  if docker image inspect "${POSTGRES_IMAGE}" >/dev/null 2>&1; then
+    log "restore_image_status=cached image=${POSTGRES_IMAGE}"
+    return
+  fi
+
+  log "restore_image_status=pulling image=${POSTGRES_IMAGE}"
+  docker pull "${POSTGRES_IMAGE}" >/dev/null ||
+    fail "could not pull the pinned PostgreSQL restore image"
+  docker image inspect "${POSTGRES_IMAGE}" >/dev/null 2>&1 ||
+    fail "pinned PostgreSQL restore image is unavailable after pull"
+  log "restore_image_status=pulled image=${POSTGRES_IMAGE}"
+}
+
 (( EUID == 0 )) || fail "logical restore drill requires root"
 [[ "${PITR_OPERATION_ID}" =~ ^[0-9a-f]{32}$ ]] ||
   fail "PITR_OPERATION_ID must be a guarded 32-character lowercase hex ID"
@@ -70,6 +84,7 @@ esac
 require_root_directory "${DRILL_ROOT}"
 
 cd "${PROJECT_DIR}"
+ensure_postgres_image
 BACKEND_IMAGE="$(
   "${RUNTIME_CHECK_HELPER}" \
     --project-dir "${PROJECT_DIR}" \

--- a/tests/unit/test_ha_status_report.py
+++ b/tests/unit/test_ha_status_report.py
@@ -78,6 +78,32 @@ def test_evaluate_workflows_flags_missing_failed_and_stale_runs():
     assert any("workflow missing from recent run list: API HA Invariant Check" in warning for warning in result.warnings)
 
 
+def test_evaluate_workflows_treats_failed_restore_drill_as_assurance_attention():
+    now = datetime(2026, 7, 3, 12, 0, tzinfo=timezone.utc)
+    latest = {
+        "API Restore Drill": report_ha_status.parse_workflow_run(
+            _run("API Restore Drill", conclusion="failure")
+        ),
+    }
+
+    result = report_ha_status.evaluate_workflows(
+        latest,
+        expected=(
+            report_ha_status.ExpectedWorkflow(
+                "API Restore Drill",
+                max_age_hours=36,
+                assurance_only=True,
+            ),
+        ),
+        now=now,
+    )
+
+    assert result.status == "attention"
+    assert not result.failures
+    assert any("restore assurance requires attention" in warning for warning in result.warnings)
+    assert any("live service health is evaluated separately" in warning for warning in result.warnings)
+
+
 def test_latest_runs_prefers_latest_completed_run_over_current_in_progress():
     current = report_ha_status.parse_workflow_run(
         _run(
@@ -98,6 +124,20 @@ def test_latest_runs_prefers_latest_completed_run_over_current_in_progress():
 
 def test_default_expected_workflows_do_not_self_check_status_report():
     assert all(workflow.name != "API HA Status Report" for workflow in report_ha_status.EXPECTED_WORKFLOWS)
+
+
+def test_default_restore_drills_are_assurance_only():
+    restore_drills = {
+        workflow.name: workflow
+        for workflow in report_ha_status.EXPECTED_WORKFLOWS
+        if "Restore Drill" in workflow.name
+    }
+
+    assert set(restore_drills) == {
+        "API Restore Drill",
+        "PostgreSQL PITR Restore Drill",
+    }
+    assert all(workflow.assurance_only for workflow in restore_drills.values())
 
 
 def test_external_prereq_failures_are_blockers_until_require_strict(monkeypatch):
@@ -182,6 +222,24 @@ def test_next_steps_prioritize_failed_workflows_and_live_skip():
 
     assert steps[0] == "inspect failed workflow URLs/artifacts before changing API routing or database roles"
     assert any("rerun without --skip-live" in step for step in steps)
+
+
+def test_next_steps_explain_restore_assurance_without_implying_outage():
+    result = report_ha_status.ReportResult(
+        ok=["active/passive direct-origin invariant passed"],
+        warnings=[
+            "API Restore Drill: latest run concluded failure; "
+            "restore assurance requires attention, but live service health is evaluated separately"
+        ],
+        blockers=[],
+        failures=[],
+    )
+
+    steps = report_ha_status.next_steps_for(result)
+
+    assert any("recoverability signal" in step for step in steps)
+    assert any("does not by itself mean the live API is unavailable" in step for step in steps)
+    assert not any("changing API routing or database roles" in step for step in steps)
 
 
 def test_next_steps_explain_failed_cloudflare_lb_config_check():

--- a/tests/unit/test_restore_drill_cleanup.py
+++ b/tests/unit/test_restore_drill_cleanup.py
@@ -99,6 +99,19 @@ def test_logical_drill_uses_root_state_and_isolated_generated_credentials():
     assert 'docker kill "${container}"' in text
 
 
+def test_logical_drill_pulls_only_the_exact_pinned_postgres_image_when_missing():
+    text = DRILL_SCRIPT.read_text(encoding="utf-8")
+
+    assert 'POSTGRES_IMAGE="postgres:15.18-alpine@sha256:' in text
+    assert 'docker image inspect "${POSTGRES_IMAGE}"' in text
+    assert 'docker pull "${POSTGRES_IMAGE}"' in text
+    assert 'restore_image_status=cached image=${POSTGRES_IMAGE}' in text
+    assert 'restore_image_status=pulled image=${POSTGRES_IMAGE}' in text
+    assert 'docker run --pull never -d' in text
+    assert text.index("ensure_postgres_image") < text.index("BACKEND_IMAGE=")
+    assert text.index('docker pull "${POSTGRES_IMAGE}"') < text.index("docker run --pull never -d")
+
+
 def test_logical_drill_bounds_download_expansion_and_attests_runtime():
     text = DRILL_SCRIPT.read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Problem

`API HA Status Report` treated every failed workflow as proof that the live service was unhealthy. A historical `API Restore Drill` failure therefore triggered the generic Telegram alert `MVN API HA status report failed` every two hours, even while deploy, readiness, replication, Cloudflare routing and the direct active/passive invariant were green.

The restore drill failure itself was real but narrower: the selected host did not have the exact pinned PostgreSQL image locally, while the drill deliberately starts its disposable container with `--pull never`.

## Fix

### Operator signal

- Mark logical and PITR restore drills as recoverability-assurance workflows.
- Keep failed or stale drills visible in the rollup as `attention` warnings with their exact workflow URL.
- Do not fail the generic HA Status Report solely because an assurance drill is red.
- Keep core deploy, readiness, invariant, replication, PITR freshness, Cloudflare and live-origin failures as hard failures.
- Add an explicit next step explaining that a restore-drill warning does not by itself mean the live API is unavailable.

The restore workflows retain their own precise failure status and Telegram notification, so the signal is not hidden or downgraded at its source.

### Restore drill

- Check whether the exact digest-pinned PostgreSQL image is cached.
- Pull that exact immutable reference only when absent.
- Verify it is locally inspectable after the pull.
- Keep `docker run --pull never` for the actual isolated drill, preserving deterministic execution.

## Coverage

- Core workflow failures remain hard failures.
- Restore-drill failures produce `attention`, not a generic live-outage result.
- Both restore workflows are explicitly classified as assurance-only.
- Operator next steps distinguish recoverability from availability.
- The logical restore drill is pinned, pulls only the exact reference when missing, verifies it, and still starts with `--pull never`.

## Incident context

On 2026-08-06 the live HA proof surfaces were green, but the rollup repeatedly alerted on the previous day's restore drill. This change removes that duplicate false-outage signal while fixing the drill's actual missing-image cause.