### PR TITLE
Add controlled PITR host-asset rollout

### DIFF
--- a/.github/workflows/rollout-postgres-pitr-host-assets.yml
+++ b/.github/workflows/rollout-postgres-pitr-host-assets.yml
@@ -1,0 +1,132 @@
+name: Rollout PostgreSQL PITR Host Assets
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm_sha:
+        description: "Exact 40-character main SHA to install and attest"
+        type: string
+        required: true
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+concurrency:
+  group: production-postgres-pitr-host-assets
+  cancel-in-progress: false
+
+jobs:
+  rollout:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+
+    steps:
+      - name: Require Reviewed Main SHA
+        env:
+          CONFIRM_SHA: ${{ inputs.confirm_sha }}
+        run: |
+          set -euo pipefail
+          if [ "${GITHUB_REF}" != "refs/heads/main" ]; then
+            echo "::error::PITR host assets may be rolled out only from refs/heads/main"
+            exit 64
+          fi
+          if ! [[ "${CONFIRM_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::confirm_sha must be exactly 40 lowercase hexadecimal characters"
+            exit 64
+          fi
+          if [ "${CONFIRM_SHA}" != "${GITHUB_SHA}" ]; then
+            echo "::error::confirm_sha must equal the exact workflow main SHA"
+            exit 64
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Derive Stable Transaction ID
+        id: transaction
+        run: |
+          set -euo pipefail
+          transaction_id="$(
+            python3 - <<'PY'
+          import hashlib
+          import os
+
+          material = "\0".join(
+              (
+                  os.environ["GITHUB_REPOSITORY"],
+                  os.environ["GITHUB_RUN_ID"],
+                  os.environ["GITHUB_SHA"],
+                  "pitr-host-assets-v1",
+              )
+          )
+          print(hashlib.sha256(material.encode("utf-8")).hexdigest()[:32])
+          PY
+          )"
+          if ! [[ "${transaction_id}" =~ ^[0-9a-f]{32}$ ]]; then
+            echo "::error::derived PITR transaction ID is invalid"
+            exit 70
+          fi
+          echo "transaction_id=${transaction_id}" >> "${GITHUB_OUTPUT}"
+          echo "transaction_id=${transaction_id}" | tee pitr-host-assets-rollout.log
+
+      - name: Roll Out And Attest PITR Host Assets
+        env:
+          SSH_KEY: ${{ secrets.SSH_KEY }}
+          PITR_TRANSACTION_ID: ${{ steps.transaction.outputs.transaction_id }}
+        run: |
+          set -euo pipefail
+          umask 077
+          if [ -z "${SSH_KEY}" ]; then
+            echo "::error::Missing required SSH_KEY secret"
+            exit 1
+          fi
+          identity_file="$(mktemp)"
+          cleanup() {
+            rm -f "${identity_file}"
+          }
+          trap cleanup EXIT
+          printf '%s\n' "${SSH_KEY}" > "${identity_file}"
+          unset SSH_KEY
+          chmod 600 "${identity_file}"
+
+          python3 -I scripts/ha/rollout_postgres_pitr_host_assets.py \
+            --identity-file "${identity_file}" \
+            --transaction-id "${PITR_TRANSACTION_ID}" \
+            2>&1 | tee -a pitr-host-assets-rollout.log
+
+      - name: Write Summary
+        if: always()
+        run: |
+          {
+            echo "## PostgreSQL PITR Host-Asset Rollout"
+            echo "- main_sha: ${GITHUB_SHA}"
+            echo "- transaction_id: ${{ steps.transaction.outputs.transaction_id || 'unavailable' }}"
+            echo "- ordering: current Patroni standby, then current Patroni primary"
+            echo "- transport: repository-pinned SSH host identities"
+            echo "- mutation: existing PITR lock + per-project deploy lock"
+            echo "- recovery: rerun this workflow attempt to preserve the transaction ID"
+            echo "- log_artifact: pitr-host-assets-rollout-log-${{ github.run_id }}"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload PITR Host-Asset Rollout Log
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: pitr-host-assets-rollout-log-${{ github.run_id }}
+          path: pitr-host-assets-rollout.log
+          if-no-files-found: warn
+
+      - name: Notify HA failure
+        if: failure() && github.ref == 'refs/heads/main'
+        uses: ./.github/actions/notify-ha-failure
+        with:
+          bot-token: ${{ secrets.HA_ALERT_TELEGRAM_BOT_TOKEN }}
+          chat-id: ${{ secrets.HA_ALERT_TELEGRAM_CHAT_ID }}
+          thread-id: ${{ secrets.HA_ALERT_TELEGRAM_THREAD_ID }}
+          title: "MVN PostgreSQL PITR host-asset rollout failed"
+          details: "Artifact: pitr-host-assets-rollout-log-${{ github.run_id }}"

--- a/scripts/ha/pitr_host_asset_rollout.py
+++ b/scripts/ha/pitr_host_asset_rollout.py
@@ -1,0 +1,397 @@
+#!/usr/bin/env python3
+"""Fail-closed rollout of the reviewed PITR host-asset release."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from dataclasses import dataclass
+from typing import Callable, Mapping, Sequence
+
+try:
+    from scripts.ha.pitr_cluster_topology import (
+        ClusterTopology,
+        discover_cluster_topology,
+    )
+    from scripts.ha.pitr_pinned_ssh import PatroniNode, PinnedSshContext
+    from scripts.ha.pitr_remote_execution import (
+        prepare_host_release_bundles,
+        run_remote_maintenance_phase,
+        run_remote_release_action,
+    )
+    from scripts.ha.pitr_target_compose import validate_target_compose_bundles
+except ModuleNotFoundError:  # Direct execution from scripts/ha.
+    from pitr_cluster_topology import (  # type: ignore[no-redef]
+        ClusterTopology,
+        discover_cluster_topology,
+    )
+    from pitr_pinned_ssh import (  # type: ignore[no-redef]
+        PatroniNode,
+        PinnedSshContext,
+    )
+    from pitr_remote_execution import (  # type: ignore[no-redef]
+        prepare_host_release_bundles,
+        run_remote_maintenance_phase,
+        run_remote_release_action,
+    )
+    from pitr_target_compose import (  # type: ignore[no-redef]
+        validate_target_compose_bundles,
+    )
+
+
+Runner = Callable[[Sequence[str], str | None], subprocess.CompletedProcess[str]]
+TopologyDiscoverer = Callable[..., ClusterTopology]
+ReleaseBundleBuilder = Callable[[Sequence[PatroniNode]], dict[str, str]]
+ReleaseAction = Callable[..., str]
+VerifyAction = Callable[..., None]
+TargetComposeValidator = Callable[[Sequence[PatroniNode], Mapping[str, str]], str]
+
+TRANSACTION_ID_RE = re.compile(r"^[0-9a-f]{32}$")
+RELEASE_DIGEST_RE = re.compile(r"^[0-9a-f]{64}$")
+DEFAULT_BOOTSTRAP_HELPER = "/usr/local/sbin/mvn-postgres-pitr-bootstrap"
+SUPPORTED_INSPECT_STATES = {
+    "fresh",
+    "matching-active",
+    "matching-finalized",
+}
+RESUMABLE_INSPECT_STATES = {
+    "matching-active",
+    "matching-finalized",
+}
+
+
+@dataclass(frozen=True)
+class HostAssetRolloutResult:
+    transaction_id: str
+    primary_alias: str
+    standby_alias: str
+    system_identifier: str
+    timeline: int
+    compose_profile: str
+    release_digests: tuple[tuple[str, str], ...]
+
+
+@dataclass(frozen=True)
+class HostAssetRolloutDependencies:
+    discover: TopologyDiscoverer = discover_cluster_topology
+    bundles: ReleaseBundleBuilder = prepare_host_release_bundles
+    release: ReleaseAction = run_remote_release_action
+    verify: VerifyAction = run_remote_maintenance_phase
+    target_compose: TargetComposeValidator = validate_target_compose_bundles
+
+
+def validate_transaction_id(transaction_id: str) -> str:
+    if not TRANSACTION_ID_RE.fullmatch(transaction_id):
+        raise RuntimeError(
+            "PITR host-asset transaction ID must be 32 lowercase hexadecimal "
+            "characters"
+        )
+    return transaction_id
+
+
+def _release_digest(rendered_bundle: str) -> str:
+    try:
+        bundle = json.loads(rendered_bundle)
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError("pinned PITR release bundle is invalid") from exc
+    digest = bundle.get("release_sha256") if isinstance(bundle, dict) else None
+    if not isinstance(digest, str) or not RELEASE_DIGEST_RE.fullmatch(digest):
+        raise RuntimeError("pinned PITR release digest is invalid")
+    return digest
+
+
+class _HostAssetRollout:
+    def __init__(
+        self,
+        *,
+        context: PinnedSshContext,
+        transaction_id: str,
+        runner: Runner,
+        dependencies: HostAssetRolloutDependencies,
+        bootstrap_helper: str,
+    ) -> None:
+        if bootstrap_helper != DEFAULT_BOOTSTRAP_HELPER:
+            raise RuntimeError("unexpected bootstrap helper path")
+        self.context = context
+        self.transaction_id = validate_transaction_id(transaction_id)
+        self.runner = runner
+        self.dependencies = dependencies
+        self.bootstrap_helper = bootstrap_helper
+        self.baseline: ClusterTopology | None = None
+        self.roll_forward = False
+
+    def _discover(self) -> ClusterTopology:
+        return self.dependencies.discover(
+            context=self.context,
+            runner=self.runner,
+        )
+
+    def _guard_topology(self, *, stage: str) -> ClusterTopology:
+        current = self._discover()
+        baseline = self.baseline
+        if baseline is None:
+            self.baseline = current
+            return current
+        drift: list[str] = []
+        if current.system_identifier != baseline.system_identifier:
+            drift.append("system_identifier")
+        if current.timeline != baseline.timeline:
+            drift.append("timeline")
+        if current.primary.alias != baseline.primary.alias:
+            drift.append("primary")
+        if current.standby.alias != baseline.standby.alias:
+            drift.append("standby")
+        if drift:
+            raise RuntimeError(
+                f"topology drift at {stage}: " + ", ".join(drift)
+            )
+        return current
+
+    def _operate(
+        self,
+        *,
+        stage: str,
+        action: Callable[[], object],
+        mutating: bool = False,
+    ) -> object:
+        self._guard_topology(stage=f"before {stage}")
+        if mutating:
+            # A lost SSH response cannot prove that the remote executor made no
+            # durable progress. Every later failure must therefore be resumed
+            # with this exact transaction ID instead of rolling back blindly.
+            self.roll_forward = True
+        action_error: BaseException | None = None
+        result: object | None = None
+        try:
+            result = action()
+        except BaseException as exc:
+            action_error = exc
+        try:
+            self._guard_topology(stage=f"after {stage}")
+        except BaseException as topology_error:
+            if action_error is not None:
+                raise RuntimeError(
+                    f"{stage} failed: {action_error}; topology proof after the "
+                    f"attempted operation also failed: {topology_error}"
+                ) from topology_error
+            raise
+        if action_error is not None:
+            raise action_error
+        return result
+
+    def _release(
+        self,
+        *,
+        action: str,
+        node: PatroniNode,
+        release_bundle: str | None = None,
+    ) -> str:
+        return self.dependencies.release(
+            node=node,
+            context=self.context,
+            action=action,
+            txid=self.transaction_id,
+            release_bundle=release_bundle,
+            runner=self.runner,
+        )
+
+    def _verify(self, node: PatroniNode) -> None:
+        self.dependencies.verify(
+            node=node,
+            context=self.context,
+            bootstrap_helper=self.bootstrap_helper,
+            phase="verify",
+            transaction_id=self.transaction_id,
+            runner=self.runner,
+        )
+
+    def _result(
+        self,
+        *,
+        baseline: ClusterTopology,
+        profile: str,
+        bundles: Mapping[str, str],
+        ordered_nodes: Sequence[PatroniNode],
+    ) -> HostAssetRolloutResult:
+        return HostAssetRolloutResult(
+            transaction_id=self.transaction_id,
+            primary_alias=baseline.primary.alias,
+            standby_alias=baseline.standby.alias,
+            system_identifier=baseline.system_identifier,
+            timeline=baseline.timeline,
+            compose_profile=profile,
+            release_digests=tuple(
+                (node.alias, _release_digest(bundles[node.project_dir]))
+                for node in ordered_nodes
+            ),
+        )
+
+    def run(self) -> HostAssetRolloutResult:
+        baseline = self._guard_topology(stage="baseline")
+        ordered_nodes = (baseline.standby, baseline.primary)
+        bundles = self.dependencies.bundles(ordered_nodes)
+        expected_projects = {node.project_dir for node in ordered_nodes}
+        if set(bundles) != expected_projects:
+            raise RuntimeError(
+                "pinned PITR release bundle set does not match cluster nodes"
+            )
+        profile = self.dependencies.target_compose(ordered_nodes, bundles)
+
+        compatibility: dict[str, str] = {}
+        for node in ordered_nodes:
+            state = self._operate(
+                stage=f"bundle compatibility {node.alias}",
+                action=lambda node=node: self._release(
+                    action="inspect",
+                    node=node,
+                    release_bundle=bundles[node.project_dir],
+                ),
+            )
+            if not isinstance(state, str):
+                raise RuntimeError("release compatibility returned a non-string state")
+            compatibility[node.alias] = state
+
+        unsupported = {
+            state
+            for state in compatibility.values()
+            if state not in SUPPORTED_INSPECT_STATES
+        }
+        if unsupported:
+            if "matching-rolled-back" in unsupported:
+                raise RuntimeError(
+                    "this PITR host-asset transaction was durably rolled back; "
+                    "start a new workflow run with a new transaction ID"
+                )
+            if "preflight-fenced" in unsupported:
+                raise RuntimeError(
+                    "a full PITR migration preflight owns durable fenced state; "
+                    "resume or clean up that reviewed migration instead"
+                )
+            raise RuntimeError(
+                "release compatibility returned an unsupported state: "
+                + ", ".join(sorted(unsupported))
+            )
+
+        if any(
+            state in RESUMABLE_INSPECT_STATES
+            for state in compatibility.values()
+        ):
+            self.roll_forward = True
+
+        try:
+            if all(
+                state == "matching-finalized"
+                for state in compatibility.values()
+            ):
+                self._operate(
+                    stage=f"strict PITR verify {baseline.primary.alias}",
+                    action=lambda: self._verify(baseline.primary),
+                )
+                return self._result(
+                    baseline=baseline,
+                    profile=profile,
+                    bundles=bundles,
+                    ordered_nodes=ordered_nodes,
+                )
+
+            # Resume/reopen any durable transaction generation before touching a
+            # fresh peer. This keeps a retry moving toward one exact release.
+            apply_nodes = tuple(
+                sorted(
+                    ordered_nodes,
+                    key=lambda node: compatibility[node.alias] == "fresh",
+                )
+            )
+            expected_apply_results = {
+                "fresh": "applied",
+                "matching-active": "resumed",
+                "matching-finalized": "reopened",
+            }
+            for node in apply_nodes:
+                state = compatibility[node.alias]
+                result = self._operate(
+                    stage=f"bundle apply {node.alias}",
+                    action=lambda node=node: self._release(
+                        action="apply",
+                        node=node,
+                        release_bundle=bundles[node.project_dir],
+                    ),
+                    mutating=True,
+                )
+                expected_result = expected_apply_results[state]
+                if result != expected_result:
+                    raise RuntimeError(
+                        f"bundle apply {node.alias} returned {result!r}; "
+                        f"expected {expected_result!r}"
+                    )
+
+            # Finalize standby first. If the second finalize is interrupted, an
+            # exact same-transaction replay reopens the finalized peer and
+            # resumes the active peer before finalizing both again.
+            for node in ordered_nodes:
+                result = self._operate(
+                    stage=f"bundle finalize {node.alias}",
+                    action=lambda node=node: self._release(
+                        action="finalize",
+                        node=node,
+                    ),
+                    mutating=True,
+                )
+                if result not in {"finalized", "already-finalized"}:
+                    raise RuntimeError(
+                        f"bundle finalize {node.alias} returned {result!r}"
+                    )
+
+            for node in ordered_nodes:
+                state = self._operate(
+                    stage=f"finalized bundle proof {node.alias}",
+                    action=lambda node=node: self._release(
+                        action="inspect",
+                        node=node,
+                        release_bundle=bundles[node.project_dir],
+                    ),
+                )
+                if state != "matching-finalized":
+                    raise RuntimeError(
+                        f"{node.alias} did not retain the finalized PITR release"
+                    )
+
+            self._operate(
+                stage=f"strict PITR verify {baseline.primary.alias}",
+                action=lambda: self._verify(baseline.primary),
+            )
+        except BaseException as exc:
+            if self.roll_forward:
+                raise RuntimeError(
+                    "PITR host-asset rollout entered roll-forward state; do not "
+                    "copy files or delete manifests manually; rerun with the "
+                    f"same transaction ID {self.transaction_id}: {exc}"
+                ) from exc
+            raise
+
+        return self._result(
+            baseline=baseline,
+            profile=profile,
+            bundles=bundles,
+            ordered_nodes=ordered_nodes,
+        )
+
+
+def rollout_host_assets(
+    *,
+    context: PinnedSshContext,
+    transaction_id: str,
+    runner: Runner,
+    dependencies: HostAssetRolloutDependencies | None = None,
+    bootstrap_helper: str = DEFAULT_BOOTSTRAP_HELPER,
+) -> HostAssetRolloutResult:
+    """Install and attest one exact PITR host release on both Patroni nodes."""
+
+    return _HostAssetRollout(
+        context=context,
+        transaction_id=transaction_id,
+        runner=runner,
+        dependencies=dependencies or HostAssetRolloutDependencies(),
+        bootstrap_helper=bootstrap_helper,
+    ).run()

--- a/scripts/ha/rollout_postgres_pitr_host_assets.py
+++ b/scripts/ha/rollout_postgres_pitr_host_assets.py
@@ -12,6 +12,18 @@ import tempfile
 from pathlib import Path
 from typing import Sequence
 
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_repo_import_index = next(
+    (
+        index
+        for index, value in enumerate(sys.path)
+        if "site-packages" in value
+    ),
+    len(sys.path),
+)
+sys.path.insert(_repo_import_index, str(REPO_ROOT))
+
 try:
     from scripts.ha.pitr_host_asset_rollout import (
         rollout_host_assets,

--- a/scripts/ha/rollout_postgres_pitr_host_assets.py
+++ b/scripts/ha/rollout_postgres_pitr_host_assets.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Roll out the exact reviewed PITR host-asset release to both Patroni nodes."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import stat
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Sequence
+
+try:
+    from scripts.ha.pitr_host_asset_rollout import (
+        rollout_host_assets,
+        validate_transaction_id,
+    )
+    from scripts.ha.pitr_pinned_ssh import (
+        PATRONI_NODES,
+        create_context,
+        ssh_subprocess_environment,
+        validate_effective_config,
+    )
+except ModuleNotFoundError:  # Direct execution from scripts/ha.
+    from pitr_host_asset_rollout import (  # type: ignore[no-redef]
+        rollout_host_assets,
+        validate_transaction_id,
+    )
+    from pitr_pinned_ssh import (  # type: ignore[no-redef]
+        PATRONI_NODES,
+        create_context,
+        ssh_subprocess_environment,
+        validate_effective_config,
+    )
+
+
+def log(stage: str, message: str) -> None:
+    print(f"[pitr-host-assets][{stage}] {message}")
+
+
+def _run_subprocess(
+    args: Sequence[str],
+    stdin: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        list(args),
+        input=stdin,
+        text=True,
+        capture_output=True,
+        check=False,
+        env=ssh_subprocess_environment(),
+    )
+
+
+def _validate_owner_only_regular_file(path: Path, *, label: str) -> None:
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError as exc:
+        raise RuntimeError(f"{label} not found: {path}") from exc
+    if (
+        stat.S_ISLNK(metadata.st_mode)
+        or not stat.S_ISREG(metadata.st_mode)
+        or metadata.st_uid != os.geteuid()
+        or metadata.st_nlink != 1
+        or stat.S_IMODE(metadata.st_mode) & 0o077
+    ):
+        raise RuntimeError(
+            f"{label} must be an owner-only regular non-symlink file"
+        )
+
+
+def validate_identity_file(raw_path: str) -> Path:
+    if not raw_path.strip():
+        raise RuntimeError("--identity-file is required")
+    path = Path(raw_path).expanduser()
+    if not path.is_absolute():
+        raise RuntimeError("SSH identity file must use an absolute path")
+    _validate_owner_only_regular_file(path, label="SSH identity file")
+    return path
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--identity-file",
+        required=True,
+        help="Owner-only SSH key used with repository-pinned host identities.",
+    )
+    parser.add_argument(
+        "--transaction-id",
+        required=True,
+        help=(
+            "Stable 32-character lowercase hexadecimal rollout ID. Reuse the "
+            "same ID after any ambiguous failure."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        transaction_id = validate_transaction_id(args.transaction_id)
+        identity_file = validate_identity_file(args.identity_file)
+        with tempfile.TemporaryDirectory(
+            prefix="mvn-pitr-host-assets-"
+        ) as temporary:
+            directory = Path(temporary)
+            directory.chmod(0o700)
+            context = create_context(directory, identity_file)
+            for node in PATRONI_NODES:
+                validate_effective_config(node, context)
+
+            result = rollout_host_assets(
+                context=context,
+                transaction_id=transaction_id,
+                runner=_run_subprocess,
+            )
+
+        releases = ",".join(
+            f"{alias}:{digest}" for alias, digest in result.release_digests
+        )
+        log(
+            "ok",
+            "rollout passed "
+            f"transaction={result.transaction_id} "
+            f"primary={result.primary_alias} "
+            f"standby={result.standby_alias} "
+            f"timeline={result.timeline} "
+            f"profile={result.compose_profile} "
+            f"releases={releases}",
+        )
+        return 0
+    except RuntimeError as exc:
+        log("fail", str(exc))
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_pitr_host_asset_rollout.py
+++ b/tests/unit/test_pitr_host_asset_rollout.py
@@ -1,0 +1,294 @@
+from pathlib import Path
+
+import pytest
+
+from scripts.ha.pitr_cluster_topology import ClusterTopology
+from scripts.ha.pitr_host_asset_rollout import (
+    HostAssetRolloutDependencies,
+    rollout_host_assets,
+)
+from scripts.ha.pitr_pinned_ssh import PATRONI_NODES, PinnedSshContext
+
+
+TXID = "0123456789abcdef0123456789abcdef"
+
+
+def _context(tmp_path: Path) -> PinnedSshContext:
+    return PinnedSshContext(
+        identity_file=tmp_path / "identity",
+        known_hosts_file=tmp_path / "known-hosts",
+        config_file=tmp_path / "config",
+    )
+
+
+def _topology(
+    *,
+    timeline: int = 19,
+    primary_alias: str = "mvn-api",
+) -> ClusterTopology:
+    by_alias = {node.alias: node for node in PATRONI_NODES}
+    standby_alias = "zakup" if primary_alias == "mvn-api" else "mvn-api"
+    return ClusterTopology(
+        primary=by_alias[primary_alias],
+        standby=by_alias[standby_alias],
+        system_identifier="7657288033494519840",
+        timeline=timeline,
+    )
+
+
+def _bundle(node) -> str:
+    digest = "a" * 64 if node.alias == "mvn-api" else "b" * 64
+    return (
+        '{"files":[],"project_dir":"'
+        + node.project_dir
+        + '","release_sha256":"'
+        + digest
+        + '","version":1}'
+    )
+
+
+def _unused_runner(args, stdin):
+    raise AssertionError((args, stdin))
+
+
+class FakeOperations:
+    def __init__(self):
+        self.events = []
+        self.states = {"mvn-api": "fresh", "zakup": "fresh"}
+        self.topologies = []
+        self.discover_calls = 0
+        self.release_failure = None
+        self.verify_failure = False
+
+    def discover(self, *, context, runner):
+        self.discover_calls += 1
+        self.events.append(("topology",))
+        if self.topologies:
+            return self.topologies.pop(0)
+        return _topology()
+
+    def bundles(self, nodes):
+        return {node.project_dir: _bundle(node) for node in nodes}
+
+    def target_compose(self, nodes, bundles):
+        self.events.append(("target-compose", tuple(node.alias for node in nodes)))
+        assert set(bundles) == {node.project_dir for node in nodes}
+        return "dormant"
+
+    def release(
+        self,
+        *,
+        node,
+        context,
+        action,
+        txid,
+        release_bundle,
+        runner,
+    ):
+        self.events.append(("release", action, node.alias, txid))
+        if self.release_failure == (action, node.alias):
+            raise RuntimeError("simulated release failure")
+        if action == "inspect":
+            assert release_bundle == _bundle(node)
+            return self.states[node.alias]
+        if action == "apply":
+            assert release_bundle == _bundle(node)
+            state = self.states[node.alias]
+            result = {
+                "fresh": "applied",
+                "matching-active": "resumed",
+                "matching-finalized": "reopened",
+            }[state]
+            self.states[node.alias] = "matching-active"
+            return result
+        assert release_bundle is None
+        if action == "finalize":
+            already = self.states[node.alias] == "matching-finalized"
+            self.states[node.alias] = "matching-finalized"
+            return "already-finalized" if already else "finalized"
+        raise AssertionError(action)
+
+    def verify(
+        self,
+        *,
+        node,
+        context,
+        bootstrap_helper,
+        phase,
+        transaction_id,
+        runner,
+    ):
+        self.events.append(("verify", node.alias, phase, transaction_id))
+        if self.verify_failure:
+            raise RuntimeError("simulated strict verify failure")
+
+    def dependencies(self):
+        return HostAssetRolloutDependencies(
+            discover=self.discover,
+            bundles=self.bundles,
+            release=self.release,
+            verify=self.verify,
+            target_compose=self.target_compose,
+        )
+
+
+def _operations(events):
+    return [event for event in events if event[0] != "topology"]
+
+
+def test_fresh_rollout_uses_standby_first_and_finishes_with_strict_verify(
+    tmp_path,
+):
+    operations = FakeOperations()
+
+    result = rollout_host_assets(
+        context=_context(tmp_path),
+        transaction_id=TXID,
+        runner=_unused_runner,
+        dependencies=operations.dependencies(),
+    )
+
+    assert result.primary_alias == "mvn-api"
+    assert result.standby_alias == "zakup"
+    assert result.timeline == 19
+    assert result.compose_profile == "dormant"
+    assert result.release_digests == (
+        ("zakup", "b" * 64),
+        ("mvn-api", "a" * 64),
+    )
+    assert _operations(operations.events) == [
+        ("target-compose", ("zakup", "mvn-api")),
+        ("release", "inspect", "zakup", TXID),
+        ("release", "inspect", "mvn-api", TXID),
+        ("release", "apply", "zakup", TXID),
+        ("release", "apply", "mvn-api", TXID),
+        ("release", "finalize", "zakup", TXID),
+        ("release", "finalize", "mvn-api", TXID),
+        ("release", "inspect", "zakup", TXID),
+        ("release", "inspect", "mvn-api", TXID),
+        ("verify", "mvn-api", "verify", TXID),
+    ]
+
+
+def test_retry_resumes_durable_generations_before_touching_fresh_peer(tmp_path):
+    operations = FakeOperations()
+    operations.states["zakup"] = "fresh"
+    operations.states["mvn-api"] = "matching-active"
+
+    rollout_host_assets(
+        context=_context(tmp_path),
+        transaction_id=TXID,
+        runner=_unused_runner,
+        dependencies=operations.dependencies(),
+    )
+
+    apply_events = [
+        event
+        for event in operations.events
+        if event[:2] == ("release", "apply")
+    ]
+    assert apply_events == [
+        ("release", "apply", "mvn-api", TXID),
+        ("release", "apply", "zakup", TXID),
+    ]
+
+
+def test_fully_finalized_replay_is_idempotent_and_only_verifies(tmp_path):
+    operations = FakeOperations()
+    operations.states = {
+        "mvn-api": "matching-finalized",
+        "zakup": "matching-finalized",
+    }
+
+    rollout_host_assets(
+        context=_context(tmp_path),
+        transaction_id=TXID,
+        runner=_unused_runner,
+        dependencies=operations.dependencies(),
+    )
+
+    actions = [
+        event[1]
+        for event in operations.events
+        if event[0] == "release"
+    ]
+    assert actions == ["inspect", "inspect"]
+    assert ("verify", "mvn-api", "verify", TXID) in operations.events
+
+
+def test_ambiguous_apply_failure_requires_same_transaction_replay(tmp_path):
+    operations = FakeOperations()
+    operations.release_failure = ("apply", "zakup")
+
+    with pytest.raises(
+        RuntimeError,
+        match=f"same transaction ID {TXID}",
+    ):
+        rollout_host_assets(
+            context=_context(tmp_path),
+            transaction_id=TXID,
+            runner=_unused_runner,
+            dependencies=operations.dependencies(),
+        )
+
+    assert not any(
+        event[:2] == ("release", "finalize")
+        for event in operations.events
+    )
+
+
+@pytest.mark.parametrize(
+    ("state", "message"),
+    (
+        ("matching-rolled-back", "durably rolled back"),
+        ("preflight-fenced", "full PITR migration preflight"),
+    ),
+)
+def test_incompatible_durable_state_fails_before_mutation(
+    tmp_path,
+    state,
+    message,
+):
+    operations = FakeOperations()
+    operations.states["zakup"] = state
+
+    with pytest.raises(RuntimeError, match=message):
+        rollout_host_assets(
+            context=_context(tmp_path),
+            transaction_id=TXID,
+            runner=_unused_runner,
+            dependencies=operations.dependencies(),
+        )
+
+    assert not any(
+        event[0] == "release" and event[1] in {"apply", "finalize"}
+        for event in operations.events
+    )
+
+
+def test_topology_drift_after_first_mutation_fails_closed_for_same_tx(tmp_path):
+    operations = FakeOperations()
+    # baseline, two guards for each compatibility probe, before first apply,
+    # then a changed timeline after the attempted mutation.
+    operations.topologies = [
+        _topology(),
+        _topology(),
+        _topology(),
+        _topology(),
+        _topology(),
+        _topology(),
+        _topology(timeline=20),
+    ]
+
+    with pytest.raises(
+        RuntimeError,
+        match=f"same transaction ID {TXID}",
+    ) as error:
+        rollout_host_assets(
+            context=_context(tmp_path),
+            transaction_id=TXID,
+            runner=_unused_runner,
+            dependencies=operations.dependencies(),
+        )
+
+    assert "topology drift" in str(error.value)

--- a/tests/unit/test_pitr_host_asset_rollout.py
+++ b/tests/unit/test_pitr_host_asset_rollout.py
@@ -56,6 +56,7 @@ class FakeOperations:
         self.events = []
         self.states = {"mvn-api": "fresh", "zakup": "fresh"}
         self.topologies = []
+        self.default_topology = _topology()
         self.discover_calls = 0
         self.release_failure = None
         self.verify_failure = False
@@ -65,7 +66,7 @@ class FakeOperations:
         self.events.append(("topology",))
         if self.topologies:
             return self.topologies.pop(0)
-        return _topology()
+        return self.default_topology
 
     def bundles(self, nodes):
         return {node.project_dir: _bundle(node) for node in nodes}
@@ -168,6 +169,33 @@ def test_fresh_rollout_uses_standby_first_and_finishes_with_strict_verify(
         ("release", "inspect", "mvn-api", TXID),
         ("verify", "mvn-api", "verify", TXID),
     ]
+
+
+def test_rollout_order_follows_dynamic_patroni_roles_when_zakup_is_primary(
+    tmp_path,
+):
+    operations = FakeOperations()
+    operations.default_topology = _topology(primary_alias="zakup")
+
+    result = rollout_host_assets(
+        context=_context(tmp_path),
+        transaction_id=TXID,
+        runner=_unused_runner,
+        dependencies=operations.dependencies(),
+    )
+
+    assert result.primary_alias == "zakup"
+    assert result.standby_alias == "mvn-api"
+    apply_events = [
+        event
+        for event in operations.events
+        if event[:2] == ("release", "apply")
+    ]
+    assert apply_events == [
+        ("release", "apply", "mvn-api", TXID),
+        ("release", "apply", "zakup", TXID),
+    ]
+    assert ("verify", "zakup", "verify", TXID) in operations.events
 
 
 def test_retry_resumes_durable_generations_before_touching_fresh_peer(tmp_path):

--- a/tests/unit/test_pitr_host_asset_rollout_workflow.py
+++ b/tests/unit/test_pitr_host_asset_rollout_workflow.py
@@ -1,0 +1,72 @@
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _workflow() -> dict:
+    return yaml.load(
+        (
+            REPO_ROOT
+            / ".github/workflows/rollout-postgres-pitr-host-assets.yml"
+        ).read_text(encoding="utf-8"),
+        Loader=yaml.BaseLoader,
+    )
+
+
+def _step(workflow: dict, name: str) -> dict:
+    return next(
+        step
+        for step in workflow["jobs"]["rollout"]["steps"]
+        if step.get("name") == name
+    )
+
+
+def test_pitr_host_asset_rollout_is_manual_main_only_and_exact_sha_gated():
+    workflow = _workflow()
+    assert set(workflow["on"]) == {"workflow_dispatch"}
+    assert workflow["concurrency"]["cancel-in-progress"] == "false"
+    assert workflow["concurrency"]["group"] == (
+        "production-postgres-pitr-host-assets"
+    )
+
+    guard = _step(workflow, "Require Reviewed Main SHA")
+    assert "refs/heads/main" in guard["run"]
+    assert "CONFIRM_SHA" in guard["run"]
+    assert "GITHUB_SHA" in guard["run"]
+    assert guard["env"]["CONFIRM_SHA"] == "${{ inputs.confirm_sha }}"
+
+
+def test_pitr_host_asset_rollout_uses_pinned_checkout_and_stable_transaction():
+    workflow = _workflow()
+    checkout = _step(workflow, "Checkout")
+    transaction = _step(workflow, "Derive Stable Transaction ID")
+
+    assert checkout["uses"] == (
+        "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10"
+    )
+    assert checkout["with"]["ref"] == "${{ github.sha }}"
+    assert checkout["with"]["persist-credentials"] == "false"
+    assert "GITHUB_RUN_ID" in transaction["run"]
+    assert "GITHUB_SHA" in transaction["run"]
+    assert "GITHUB_RUN_ATTEMPT" not in transaction["run"]
+
+
+def test_pitr_host_asset_rollout_uses_pinned_ssh_controller_and_retains_log():
+    workflow = _workflow()
+    rollout = _step(workflow, "Roll Out And Attest PITR Host Assets")
+    artifact = _step(workflow, "Upload PITR Host-Asset Rollout Log")
+    notify = _step(workflow, "Notify HA failure")
+
+    assert rollout["env"]["SSH_KEY"] == "${{ secrets.SSH_KEY }}"
+    assert "ssh-keyscan" not in rollout["run"]
+    assert "rollout_postgres_pitr_host_assets.py" in rollout["run"]
+    assert "--transaction-id" in rollout["run"]
+    assert artifact["if"] == "always()"
+    assert artifact["uses"] == (
+        "actions/upload-artifact@"
+        "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
+    )
+    assert notify["if"] == "failure() && github.ref == 'refs/heads/main'"

--- a/tests/unit/test_pitr_host_asset_rollout_workflow.py
+++ b/tests/unit/test_pitr_host_asset_rollout_workflow.py
@@ -1,4 +1,6 @@
 from pathlib import Path
+import subprocess
+import sys
 
 import yaml
 
@@ -70,3 +72,24 @@ def test_pitr_host_asset_rollout_uses_pinned_ssh_controller_and_retains_log():
         "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
     )
     assert notify["if"] == "failure() && github.ref == 'refs/heads/main'"
+
+
+def test_pitr_host_asset_controller_starts_under_isolated_python():
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-I",
+            str(
+                REPO_ROOT
+                / "scripts/ha/rollout_postgres_pitr_host_assets.py"
+            ),
+            "--help",
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "--transaction-id" in result.stdout


### PR DESCRIPTION
## Problem

Commit `ca5d983` changed a protected PITR host asset (`restore_drill_latest_db.sh`). The ordinary API deploy correctly updated application containers but intentionally did not rewrite root-owned PITR tools or `/var/lib/mvn-postgres-pitr/release-manifest.json`. As a result, the live API, Patroni, replication, etcd, CDN and Cloudflare checks pass, while strict PITR verification fails with `finalized PITR release manifest contract is invalid`.

## Fix

Add a dedicated, manual production workflow for rolling out one exact PITR host-asset release to both Patroni nodes.

- Requires `refs/heads/main` and an exact 40-character confirmation SHA equal to the workflow SHA.
- Uses repository-pinned SSH host identities instead of `ssh-keyscan`.
- Resolves the current Patroni topology dynamically and processes the current standby before the current primary.
- Builds and validates one exact canonical asset bundle per physical node.
- Reuses the existing hardened PITR release executor, global PITR lock and per-project deploy lock.
- Applies files atomically, preserves snapshots and transaction journals, finalizes the root-owned release manifest on both nodes, and proves both finalized generations.
- Runs the strict installed PITR verification on the current primary before reporting success.
- Derives a stable transaction ID from repository, workflow run ID and exact SHA. Re-running the same workflow run therefore resumes an ambiguous partial rollout instead of inventing a new transaction.
- Starts the controller under the same Python isolated mode used by production workflows and explicitly pins the repository import root.

## Failure semantics

The controller is deliberately roll-forward after the first possible remote mutation. It never deletes manifests, copies files ad hoc, or guesses that an unanswered SSH call made no changes. A failure instructs the operator to rerun the same workflow run and transaction ID. Durable rolled-back or full-migration preflight states are rejected rather than crossed.

Topology is proved before and after every remote operation. Any change in primary, standby, timeline or system identifier stops the rollout.

## Operational scope

This workflow does **not**:

- restart or recreate PostgreSQL;
- run migrations or modify database data;
- change PITR credentials or archive destination;
- change Patroni roles, Cloudflare routing, API containers or communications-worker profile;
- run automatically after merge.

After merge, an operator must manually dispatch `Rollout PostgreSQL PITR Host Assets` with the exact current `main` SHA. After it succeeds, rerun `PostgreSQL PITR Check`, `API Restore Drill`, and `API HA Readiness Audit`.

## Validation

- 8 focused rollout orchestration tests pass locally, including both Patroni role assignments.
- 4 workflow/controller contract tests pass locally, including `python -I ... --help`.
- All new Python files parse successfully.
- Workflow YAML parses successfully.
- Every embedded shell block passes `bash -n`.
