### PR TITLE
Complete storefront-scoped TenantOffer public catalog

### DIFF
--- a/alembic/versions/f2a3b4c5d6e7_add_order_product_catalog_snapshot.py
+++ b/alembic/versions/f2a3b4c5d6e7_add_order_product_catalog_snapshot.py
@@ -19,10 +19,10 @@ depends_on: str | Sequence[str] | None = None
 
 def upgrade() -> None:
     # Nullable expansion keeps historical lines honest: only newly captured
-    # storefront snapshots can claim a title and currency fixed at checkout.
+    # links can claim a title and currency fixed at creation time.
     op.add_column(
         "order_product_link",
-        sa.Column("title_snapshot", sa.String(length=500), nullable=True),
+        sa.Column("title_snapshot", sa.Text(), nullable=True),
     )
     op.add_column(
         "order_product_link",

--- a/alembic/versions/f2a3b4c5d6e7_add_order_product_catalog_snapshot.py
+++ b/alembic/versions/f2a3b4c5d6e7_add_order_product_catalog_snapshot.py
@@ -1,0 +1,35 @@
+"""Add immutable public catalog title and currency snapshots.
+
+Revision ID: f2a3b4c5d6e7
+Revises: ab02c3d4e5f6
+Create Date: 2026-08-01
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "f2a3b4c5d6e7"
+down_revision: str | Sequence[str] | None = "ab02c3d4e5f6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Nullable expansion keeps historical lines honest: only newly captured
+    # storefront snapshots can claim a title and currency fixed at checkout.
+    op.add_column(
+        "order_product_link",
+        sa.Column("title_snapshot", sa.String(length=500), nullable=True),
+    )
+    op.add_column(
+        "order_product_link",
+        sa.Column("currency_snapshot", sa.String(length=3), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("order_product_link", "currency_snapshot")
+    op.drop_column("order_product_link", "title_snapshot")

--- a/api_contracts/public_catalog.py
+++ b/api_contracts/public_catalog.py
@@ -1,0 +1,40 @@
+"""Explicit response contracts for public catalog helper endpoints."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from schemas import ProductKind, PublicStockState
+
+
+class PublicProductSearchItemResponse(BaseModel):
+    """Small public projection; internal sourcing and margin data is excluded."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: int
+    title: str
+    slug: str | None = None
+    price: int
+    old_price: int | None = None
+    product_kind: ProductKind = "unknown"
+    is_inverter: bool
+    power_cooling: float | None = None
+    main_image: str | None = None
+    card_image: str | None = None
+    full_image: str | None = None
+    specs: dict[str, Any] = Field(default_factory=dict)
+    vitebsk_qty: int = 0
+    minsk_qty: int = 0
+    availability_status: str | None = None
+    public_stock_state: PublicStockState | None = None
+    delivery_min_days: int | None = None
+    delivery_max_days: int | None = None
+
+
+class PublicProductSearchResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    items: list[PublicProductSearchItemResponse] = Field(default_factory=list)

--- a/core/tenant_scope.py
+++ b/core/tenant_scope.py
@@ -112,4 +112,9 @@ async def get_public_tenant_scope(
         tenant_id=context.tenant_id,
         storefront_id=context.storefront_id,
         is_system=context.tenant_is_system,
+        is_canonical_storefront=(
+            context.tenant_is_system
+            and context.tenant_slug == "mvn"
+            and context.storefront_slug == "main"
+        ),
     )

--- a/crud/canonical_public_catalog.py
+++ b/crud/canonical_public_catalog.py
@@ -119,13 +119,19 @@ class CanonicalPublicCatalogDAO:
             search_query=search_query,
         )
         if sort == "price_asc":
-            statement = statement.order_by(Product.price.asc())
+            statement = statement.order_by(Product.price.asc(), Product.id.asc())
         elif sort == "price_desc":
-            statement = statement.order_by(Product.price.desc())
+            statement = statement.order_by(Product.price.desc(), Product.id.desc())
         elif sort == "area_asc":
-            statement = statement.order_by(ProductDAO.area_expr(session).asc())
+            statement = statement.order_by(
+                ProductDAO.area_expr(session).asc(),
+                Product.id.asc(),
+            )
         elif sort == "area_desc":
-            statement = statement.order_by(ProductDAO.area_expr(session).desc())
+            statement = statement.order_by(
+                ProductDAO.area_expr(session).desc(),
+                Product.id.desc(),
+            )
         elif sort == "newest":
             statement = statement.order_by(
                 Product.created_at.desc(),

--- a/crud/canonical_public_catalog.py
+++ b/crud/canonical_public_catalog.py
@@ -1,0 +1,158 @@
+"""Canonical storefront reads constrained to public catalog taxonomy."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from sqlalchemy import func
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+from sqlmodel import select
+
+from crud.product import ProductDAO
+from crud.public_taxonomy import PublicTaxonomyDAO
+from models import Product, Tag
+
+
+class CanonicalPublicCatalogDAO:
+    @staticmethod
+    def _select_products(*, load_image_variants: bool):
+        return select(Product).options(
+            selectinload(Product.brand),
+            ProductDAO._series_option(),
+            selectinload(Product.tags).selectinload(Tag.group),
+            ProductDAO._gallery_images_option(
+                load_image_variants=load_image_variants
+            ),
+            selectinload(Product.attachments),
+        )
+
+    @staticmethod
+    def _apply_filters(
+        session: AsyncSession,
+        statement,
+        *,
+        area_min: Optional[int] = None,
+        area_max: Optional[int] = None,
+        min_price: Optional[int] = None,
+        max_price: Optional[int] = None,
+        is_inverter: Optional[bool] = None,
+        heating_min: Optional[int] = None,
+        has_wifi: Optional[bool] = None,
+        has_fresh_air: Optional[bool] = None,
+        color: Optional[str] = None,
+        indoor_types: Optional[list[str]] = None,
+        brand_slugs: Optional[list[str]] = None,
+        faceted_tag_ids: Optional[dict[int, list[int]]] = None,
+        search_query: Optional[str] = None,
+    ):
+        statement = ProductDAO._apply_common_filters(
+            session,
+            statement,
+            area_min=area_min,
+            area_max=area_max,
+            min_price=min_price,
+            max_price=max_price,
+            is_inverter=is_inverter,
+            heating_min=heating_min,
+            has_wifi=has_wifi,
+            has_fresh_air=has_fresh_air,
+            color=color,
+            indoor_types=indoor_types,
+            tag_slugs=None,
+            brand_slugs=None,
+            is_published=True,
+        )
+        statement = PublicTaxonomyDAO.apply_published_brand_filter(
+            statement,
+            brand_slugs,
+        )
+        statement = PublicTaxonomyDAO.apply_search_filter(
+            session,
+            statement,
+            search_query,
+        )
+        return PublicTaxonomyDAO.apply_faceted_filters(
+            statement,
+            faceted_tag_ids,
+        )
+
+    @staticmethod
+    async def get_filtered(
+        session: AsyncSession,
+        *,
+        area_min: Optional[int] = None,
+        area_max: Optional[int] = None,
+        min_price: Optional[int] = None,
+        max_price: Optional[int] = None,
+        is_inverter: Optional[bool] = None,
+        heating_min: Optional[int] = None,
+        has_wifi: Optional[bool] = None,
+        has_fresh_air: Optional[bool] = None,
+        color: Optional[str] = None,
+        indoor_types: Optional[list[str]] = None,
+        brand_slugs: Optional[list[str]] = None,
+        faceted_tag_ids: Optional[dict[int, list[int]]] = None,
+        search_query: Optional[str] = None,
+        sort: str = "recommended",
+        page: int = 1,
+        limit: int = 20,
+        load_image_variants: bool = False,
+    ) -> list[Product]:
+        statement = CanonicalPublicCatalogDAO._apply_filters(
+            session,
+            CanonicalPublicCatalogDAO._select_products(
+                load_image_variants=load_image_variants
+            ),
+            area_min=area_min,
+            area_max=area_max,
+            min_price=min_price,
+            max_price=max_price,
+            is_inverter=is_inverter,
+            heating_min=heating_min,
+            has_wifi=has_wifi,
+            has_fresh_air=has_fresh_air,
+            color=color,
+            indoor_types=indoor_types,
+            brand_slugs=brand_slugs,
+            faceted_tag_ids=faceted_tag_ids,
+            search_query=search_query,
+        )
+        if sort == "price_asc":
+            statement = statement.order_by(Product.price.asc())
+        elif sort == "price_desc":
+            statement = statement.order_by(Product.price.desc())
+        elif sort == "area_asc":
+            statement = statement.order_by(ProductDAO.area_expr(session).asc())
+        elif sort == "area_desc":
+            statement = statement.order_by(ProductDAO.area_expr(session).desc())
+        elif sort == "newest":
+            statement = statement.order_by(
+                Product.created_at.desc(),
+                Product.id.desc(),
+            )
+        else:
+            statement = statement.order_by(
+                ProductDAO._catalog_recommendation_score_expr(
+                    session,
+                    area_max=area_max,
+                ).desc(),
+                ProductDAO._catalog_brand_priority_expr().asc(),
+                Product.created_at.desc(),
+                Product.id.desc(),
+            )
+        statement = statement.offset((page - 1) * limit).limit(limit)
+        result = await session.execute(statement)
+        return list(result.scalars().all())
+
+    @staticmethod
+    async def count_filtered(
+        session: AsyncSession,
+        **filters,
+    ) -> int:
+        statement = CanonicalPublicCatalogDAO._apply_filters(
+            session,
+            select(func.count(Product.id)),
+            **filters,
+        )
+        return int((await session.execute(statement)).scalar_one() or 0)

--- a/crud/public_catalog.py
+++ b/crud/public_catalog.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import selectinload
 from sqlmodel import select
 
 from crud.product import ProductDAO
+from crud.public_taxonomy import PublicTaxonomyDAO
 from models import (
     Brand,
     FeatureSeriesLink,
@@ -125,8 +126,12 @@ class PublicCatalogDAO:
             has_fresh_air=has_fresh_air,
             color=color,
             indoor_types=indoor_types,
-            brand_slugs=brand_slugs,
+            brand_slugs=None,
             is_published=True,
+        )
+        stmt = PublicTaxonomyDAO.apply_published_brand_filter(
+            stmt,
+            brand_slugs,
         )
         if min_price is not None:
             stmt = stmt.where(TenantOffer.price >= min_price)
@@ -138,9 +143,12 @@ class PublicCatalogDAO:
             stmt = stmt.where(Product.series_id.in_(series_ids))
         if product_kinds:
             stmt = stmt.where(Product.product_kind.in_(product_kinds))
-        if search_query:
-            stmt = ProductDAO._apply_smart_search_filter(session, stmt, search_query)
-        stmt = ProductDAO._apply_faceted_filters(stmt, faceted_tag_ids)
+        stmt = PublicTaxonomyDAO.apply_search_filter(
+            session,
+            stmt,
+            search_query,
+        )
+        stmt = PublicTaxonomyDAO.apply_faceted_filters(stmt, faceted_tag_ids)
 
         if sort == "price_asc":
             stmt = stmt.order_by(TenantOffer.price.asc(), Product.id.asc())
@@ -204,16 +212,23 @@ class PublicCatalogDAO:
             has_fresh_air=has_fresh_air,
             color=color,
             indoor_types=indoor_types,
-            brand_slugs=brand_slugs,
+            brand_slugs=None,
             is_published=True,
+        )
+        stmt = PublicTaxonomyDAO.apply_published_brand_filter(
+            stmt,
+            brand_slugs,
         )
         if min_price is not None:
             stmt = stmt.where(TenantOffer.price >= min_price)
         if max_price is not None:
             stmt = stmt.where(TenantOffer.price <= max_price)
-        if search_query:
-            stmt = ProductDAO._apply_smart_search_filter(session, stmt, search_query)
-        stmt = ProductDAO._apply_faceted_filters(stmt, faceted_tag_ids)
+        stmt = PublicTaxonomyDAO.apply_search_filter(
+            session,
+            stmt,
+            search_query,
+        )
+        stmt = PublicTaxonomyDAO.apply_faceted_filters(stmt, faceted_tag_ids)
         return int((await session.execute(stmt)).scalar_one() or 0)
 
     @staticmethod
@@ -283,7 +298,9 @@ class PublicCatalogDAO:
                 int(tag.id)
                 for tag in (product.tags or [])
                 if tag.id is not None
+                and tag.is_public is True
                 and tag.group is not None
+                and tag.group.is_public is True
                 and tag.group.slug == "series"
             ]
             if not series_tag_ids:
@@ -450,6 +467,7 @@ class PublicCatalogDAO:
             .join(TenantOffer, TenantOffer.product_id == Product.id)
             .where(
                 Tag.is_public.is_(True),
+                TagGroup.is_public.is_(True),
                 (TagGroup.slug == "expert-badge")
                 | (TagGroup.is_expert_badge.is_(True)),
                 Product.is_published.is_(True),

--- a/crud/public_catalog.py
+++ b/crud/public_catalog.py
@@ -24,6 +24,7 @@ from models import (
 )
 from models.supplier import ProductLocalStock
 from models.tenancy import TenantScope
+from services.public_taxonomy_service import PublicTaxonomyService
 
 
 PublicCatalogRow = tuple[Product, int, int | None]
@@ -291,8 +292,9 @@ class PublicCatalogDAO:
             load_image_variants=load_image_variants,
         ).where(Product.id != product.id)
 
-        if product.series_id:
-            stmt = stmt.where(Product.series_id == product.series_id)
+        series = PublicTaxonomyService.public_series(product)
+        if series is not None and series.id is not None:
+            stmt = stmt.where(Product.series_id == series.id)
         else:
             series_tag_ids = [
                 int(tag.id)

--- a/crud/public_catalog.py
+++ b/crud/public_catalog.py
@@ -1,0 +1,497 @@
+"""Strict storefront-scoped reads for the shared product catalog."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from sqlalchemy import func
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+from sqlmodel import select
+
+from crud.product import ProductDAO
+from models import (
+    Brand,
+    FeatureSeriesLink,
+    Product,
+    ProductImage,
+    ProductSeries,
+    ProductTagLink,
+    Tag,
+    TagGroup,
+    TenantOffer,
+)
+from models.supplier import ProductLocalStock
+from models.tenancy import TenantScope
+
+
+PublicCatalogRow = tuple[Product, int, int | None]
+
+
+class PublicCatalogDAO:
+    """Read active offers without falling back to shared Product prices."""
+
+    @staticmethod
+    def visible_offer_conditions(tenant_scope: TenantScope):
+        return (
+            TenantOffer.tenant_id == tenant_scope.tenant_id,
+            TenantOffer.storefront_id == tenant_scope.storefront_id,
+            TenantOffer.status == "active",
+            TenantOffer.is_published.is_(True),
+        )
+
+    @staticmethod
+    def _product_options(*, load_image_variants: bool = False):
+        gallery_option = selectinload(Product.gallery_images)
+        if load_image_variants:
+            gallery_option = gallery_option.selectinload(ProductImage.variants)
+        return (
+            selectinload(Product.brand),
+            selectinload(Product.series)
+            .selectinload(ProductSeries.feature_links)
+            .selectinload(FeatureSeriesLink.feature),
+            selectinload(Product.tags).selectinload(Tag.group),
+            gallery_option,
+            selectinload(Product.attachments),
+        )
+
+    @staticmethod
+    def _select_products(
+        tenant_scope: TenantScope,
+        *,
+        load_image_variants: bool = False,
+    ):
+        return (
+            select(Product, TenantOffer.price, TenantOffer.old_price)
+            .join(TenantOffer, TenantOffer.product_id == Product.id)
+            .where(
+                Product.is_published.is_(True),
+                *PublicCatalogDAO.visible_offer_conditions(tenant_scope),
+            )
+            .options(
+                *PublicCatalogDAO._product_options(
+                    load_image_variants=load_image_variants
+                )
+            )
+        )
+
+    @staticmethod
+    def _rows(result) -> list[PublicCatalogRow]:
+        return [
+            (product, int(price), int(old_price) if old_price is not None else None)
+            for product, price, old_price in result.all()
+        ]
+
+    @staticmethod
+    async def get_filtered(
+        session: AsyncSession,
+        *,
+        tenant_scope: TenantScope,
+        area_min: Optional[int] = None,
+        area_max: Optional[int] = None,
+        min_price: Optional[int] = None,
+        max_price: Optional[int] = None,
+        is_inverter: Optional[bool] = None,
+        heating_min: Optional[int] = None,
+        has_wifi: Optional[bool] = None,
+        has_fresh_air: Optional[bool] = None,
+        color: Optional[str] = None,
+        indoor_types: Optional[list[str]] = None,
+        brand_slugs: Optional[list[str]] = None,
+        brand_ids: Optional[list[int]] = None,
+        series_ids: Optional[list[int]] = None,
+        product_kinds: Optional[list[str]] = None,
+        faceted_tag_ids: Optional[dict[int, list[int]]] = None,
+        search_query: Optional[str] = None,
+        sort: str = "recommended",
+        page: int = 1,
+        limit: int = 20,
+        load_image_variants: bool = False,
+    ) -> list[PublicCatalogRow]:
+        stmt = PublicCatalogDAO._select_products(
+            tenant_scope,
+            load_image_variants=load_image_variants,
+        )
+        stmt = ProductDAO._apply_common_filters(
+            session,
+            stmt,
+            area_min=area_min,
+            area_max=area_max,
+            min_price=None,
+            max_price=None,
+            is_inverter=is_inverter,
+            heating_min=heating_min,
+            has_wifi=has_wifi,
+            has_fresh_air=has_fresh_air,
+            color=color,
+            indoor_types=indoor_types,
+            brand_slugs=brand_slugs,
+            is_published=True,
+        )
+        if min_price is not None:
+            stmt = stmt.where(TenantOffer.price >= min_price)
+        if max_price is not None:
+            stmt = stmt.where(TenantOffer.price <= max_price)
+        if brand_ids:
+            stmt = stmt.where(Product.brand_id.in_(brand_ids))
+        if series_ids:
+            stmt = stmt.where(Product.series_id.in_(series_ids))
+        if product_kinds:
+            stmt = stmt.where(Product.product_kind.in_(product_kinds))
+        if search_query:
+            stmt = ProductDAO._apply_smart_search_filter(session, stmt, search_query)
+        stmt = ProductDAO._apply_faceted_filters(stmt, faceted_tag_ids)
+
+        if sort == "price_asc":
+            stmt = stmt.order_by(TenantOffer.price.asc(), Product.id.asc())
+        elif sort == "price_desc":
+            stmt = stmt.order_by(TenantOffer.price.desc(), Product.id.desc())
+        elif sort == "area_asc":
+            stmt = stmt.order_by(ProductDAO.area_expr(session).asc(), Product.id.asc())
+        elif sort == "area_desc":
+            stmt = stmt.order_by(ProductDAO.area_expr(session).desc(), Product.id.desc())
+        elif sort == "newest":
+            stmt = stmt.order_by(Product.created_at.desc(), Product.id.desc())
+        else:
+            stmt = stmt.order_by(
+                ProductDAO._catalog_recommendation_score_expr(
+                    session,
+                    area_max=area_max,
+                ).desc(),
+                ProductDAO._catalog_brand_priority_expr().asc(),
+                Product.created_at.desc(),
+                Product.id.desc(),
+            )
+
+        stmt = stmt.offset((page - 1) * limit).limit(limit)
+        return PublicCatalogDAO._rows(await session.execute(stmt))
+
+    @staticmethod
+    async def count_filtered(
+        session: AsyncSession,
+        *,
+        tenant_scope: TenantScope,
+        area_min: Optional[int] = None,
+        area_max: Optional[int] = None,
+        min_price: Optional[int] = None,
+        max_price: Optional[int] = None,
+        is_inverter: Optional[bool] = None,
+        heating_min: Optional[int] = None,
+        has_wifi: Optional[bool] = None,
+        has_fresh_air: Optional[bool] = None,
+        color: Optional[str] = None,
+        indoor_types: Optional[list[str]] = None,
+        brand_slugs: Optional[list[str]] = None,
+        faceted_tag_ids: Optional[dict[int, list[int]]] = None,
+        search_query: Optional[str] = None,
+    ) -> int:
+        stmt = (
+            select(func.count(Product.id))
+            .select_from(Product)
+            .join(TenantOffer, TenantOffer.product_id == Product.id)
+            .where(*PublicCatalogDAO.visible_offer_conditions(tenant_scope))
+        )
+        stmt = ProductDAO._apply_common_filters(
+            session,
+            stmt,
+            area_min=area_min,
+            area_max=area_max,
+            min_price=None,
+            max_price=None,
+            is_inverter=is_inverter,
+            heating_min=heating_min,
+            has_wifi=has_wifi,
+            has_fresh_air=has_fresh_air,
+            color=color,
+            indoor_types=indoor_types,
+            brand_slugs=brand_slugs,
+            is_published=True,
+        )
+        if min_price is not None:
+            stmt = stmt.where(TenantOffer.price >= min_price)
+        if max_price is not None:
+            stmt = stmt.where(TenantOffer.price <= max_price)
+        if search_query:
+            stmt = ProductDAO._apply_smart_search_filter(session, stmt, search_query)
+        stmt = ProductDAO._apply_faceted_filters(stmt, faceted_tag_ids)
+        return int((await session.execute(stmt)).scalar_one() or 0)
+
+    @staticmethod
+    async def get_by_identifier(
+        session: AsyncSession,
+        *,
+        tenant_scope: TenantScope,
+        identifier: str,
+    ) -> PublicCatalogRow | None:
+        async def fetch(condition) -> PublicCatalogRow | None:
+            result = await session.execute(
+                PublicCatalogDAO._select_products(
+                    tenant_scope,
+                    load_image_variants=True,
+                ).where(condition)
+            )
+            row = result.one_or_none()
+            if row is None:
+                return None
+            product, price, old_price = row
+            return (
+                product,
+                int(price),
+                int(old_price) if old_price is not None else None,
+            )
+
+        if identifier.isdigit():
+            by_id = await fetch(Product.id == int(identifier))
+            if by_id is not None:
+                return by_id
+        return await fetch(Product.slug == identifier)
+
+    @staticmethod
+    async def get_by_ids(
+        session: AsyncSession,
+        *,
+        tenant_scope: TenantScope,
+        product_ids: list[int],
+        load_image_variants: bool = False,
+    ) -> list[PublicCatalogRow]:
+        if not product_ids:
+            return []
+        stmt = PublicCatalogDAO._select_products(
+            tenant_scope,
+            load_image_variants=load_image_variants,
+        ).where(Product.id.in_(product_ids))
+        return PublicCatalogDAO._rows(await session.execute(stmt))
+
+    @staticmethod
+    async def get_series_siblings(
+        session: AsyncSession,
+        *,
+        tenant_scope: TenantScope,
+        product: Product,
+        load_image_variants: bool = False,
+    ) -> list[PublicCatalogRow]:
+        """Select sibling candidates inside the storefront offer boundary."""
+        stmt = PublicCatalogDAO._select_products(
+            tenant_scope,
+            load_image_variants=load_image_variants,
+        ).where(Product.id != product.id)
+
+        if product.series_id:
+            stmt = stmt.where(Product.series_id == product.series_id)
+        else:
+            series_tag_ids = [
+                int(tag.id)
+                for tag in (product.tags or [])
+                if tag.id is not None
+                and tag.group is not None
+                and tag.group.slug == "series"
+            ]
+            if not series_tag_ids:
+                return []
+            series_product_ids = (
+                select(ProductTagLink.product_id)
+                .where(ProductTagLink.tag_id.in_(series_tag_ids))
+                .distinct()
+                .subquery()
+            )
+            stmt = stmt.join(
+                series_product_ids,
+                Product.id == series_product_ids.c.product_id,
+            )
+
+        return PublicCatalogDAO._rows(await session.execute(stmt))
+
+    @staticmethod
+    async def get_all(
+        session: AsyncSession,
+        *,
+        tenant_scope: TenantScope,
+        load_image_variants: bool = False,
+    ) -> list[PublicCatalogRow]:
+        stmt = PublicCatalogDAO._select_products(
+            tenant_scope,
+            load_image_variants=load_image_variants,
+        ).order_by(Product.id.asc())
+        return PublicCatalogDAO._rows(await session.execute(stmt))
+
+    @staticmethod
+    async def get_by_series_id(
+        session: AsyncSession,
+        *,
+        tenant_scope: TenantScope,
+        series_id: int,
+        load_image_variants: bool = False,
+    ) -> list[PublicCatalogRow]:
+        stmt = (
+            PublicCatalogDAO._select_products(
+                tenant_scope,
+                load_image_variants=load_image_variants,
+            )
+            .where(Product.series_id == series_id)
+            .order_by(Product.title.asc(), Product.id.asc())
+        )
+        return PublicCatalogDAO._rows(await session.execute(stmt))
+
+    @staticmethod
+    async def get_vitebsk_featured(
+        session: AsyncSession,
+        *,
+        tenant_scope: TenantScope,
+        limit: int,
+    ) -> list[PublicCatalogRow]:
+        stmt = (
+            PublicCatalogDAO._select_products(
+                tenant_scope,
+                load_image_variants=True,
+            )
+            .join(ProductLocalStock, Product.id == ProductLocalStock.product_id)
+            .where(
+                ProductLocalStock.warehouse_code == "vitebsk",
+                ProductLocalStock.qty > 0,
+            )
+            .order_by(Product.created_at.desc(), Product.id.desc())
+            .limit(limit)
+        )
+        return PublicCatalogDAO._rows(await session.execute(stmt))
+
+    @staticmethod
+    async def get_filter_stats(
+        session: AsyncSession,
+        *,
+        tenant_scope: TenantScope,
+    ) -> tuple[int | None, int | None, float | None, float | None, list[Brand]]:
+        offer_conditions = PublicCatalogDAO.visible_offer_conditions(tenant_scope)
+        price_area = (
+            await session.execute(
+                select(
+                    func.min(TenantOffer.price),
+                    func.max(TenantOffer.price),
+                    func.min(ProductDAO.area_expr(session)),
+                    func.max(ProductDAO.area_expr(session)),
+                )
+                .select_from(Product)
+                .join(TenantOffer, TenantOffer.product_id == Product.id)
+                .where(Product.is_published.is_(True), *offer_conditions)
+            )
+        ).one()
+        brands = list(
+            (
+                await session.execute(
+                    select(Brand)
+                    .join(Product, Product.brand_id == Brand.id)
+                    .join(TenantOffer, TenantOffer.product_id == Product.id)
+                    .where(
+                        Brand.is_published.is_(True),
+                        Product.is_published.is_(True),
+                        *offer_conditions,
+                    )
+                    .group_by(Brand.id)
+                    .order_by(Brand.sort_order, Brand.title)
+                )
+            ).scalars().all()
+        )
+        return (*price_area, brands)
+
+    @staticmethod
+    async def get_public_specs(
+        session: AsyncSession,
+        *,
+        tenant_scope: TenantScope,
+    ) -> list[dict | None]:
+        result = await session.execute(
+            select(Product.specs)
+            .join(TenantOffer, TenantOffer.product_id == Product.id)
+            .where(
+                Product.is_published.is_(True),
+                *PublicCatalogDAO.visible_offer_conditions(tenant_scope),
+            )
+        )
+        return list(result.scalars().all())
+
+    @staticmethod
+    async def list_brand_counts(
+        session: AsyncSession,
+        *,
+        tenant_scope: TenantScope,
+        brand_slug: str | None = None,
+    ) -> list[tuple[Brand, int]]:
+        stmt = (
+            select(Brand, func.count(Product.id).label("products_count"))
+            .join(Product, Product.brand_id == Brand.id)
+            .join(TenantOffer, TenantOffer.product_id == Product.id)
+            .where(
+                Brand.is_published.is_(True),
+                Product.is_published.is_(True),
+                *PublicCatalogDAO.visible_offer_conditions(tenant_scope),
+            )
+            .group_by(Brand.id)
+            .having(func.count(Product.id) > 0)
+        )
+        if brand_slug is not None:
+            stmt = stmt.where(Brand.slug == brand_slug)
+        else:
+            stmt = stmt.order_by(Brand.sort_order.asc(), Brand.title.asc())
+        return [
+            (brand, int(products_count))
+            for brand, products_count in (await session.execute(stmt)).all()
+        ]
+
+    @staticmethod
+    async def list_expert_tags(
+        session: AsyncSession,
+        *,
+        tenant_scope: TenantScope,
+    ) -> list[Tag]:
+        result = await session.execute(
+            select(Tag)
+            .join(TagGroup, Tag.group_id == TagGroup.id)
+            .join(ProductTagLink, ProductTagLink.tag_id == Tag.id)
+            .join(Product, Product.id == ProductTagLink.product_id)
+            .join(TenantOffer, TenantOffer.product_id == Product.id)
+            .where(
+                Tag.is_public.is_(True),
+                (TagGroup.slug == "expert-badge")
+                | (TagGroup.is_expert_badge.is_(True)),
+                Product.is_published.is_(True),
+                *PublicCatalogDAO.visible_offer_conditions(tenant_scope),
+            )
+            .group_by(Tag.id)
+            .order_by(Tag.sort_order, Tag.title)
+        )
+        return list(result.scalars().all())
+
+    @staticmethod
+    async def list_related_series(
+        session: AsyncSession,
+        *,
+        tenant_scope: TenantScope,
+        brand_id: int,
+        current_series_id: int,
+        limit: int,
+    ) -> list[tuple[ProductSeries, int]]:
+        stmt = (
+            select(
+                ProductSeries,
+                func.count(Product.id).label("products_count"),
+            )
+            .join(Product, Product.series_id == ProductSeries.id)
+            .join(TenantOffer, TenantOffer.product_id == Product.id)
+            .where(
+                ProductSeries.brand_id == brand_id,
+                ProductSeries.id != current_series_id,
+                ProductSeries.is_published.is_(True),
+                Product.is_published.is_(True),
+                *PublicCatalogDAO.visible_offer_conditions(tenant_scope),
+            )
+            .group_by(ProductSeries.id)
+            .order_by(
+                ProductSeries.sort_order.asc(),
+                ProductSeries.title.asc(),
+                ProductSeries.id.asc(),
+            )
+            .limit(limit)
+        )
+        return [
+            (series, int(products_count))
+            for series, products_count in (await session.execute(stmt)).all()
+        ]

--- a/crud/public_catalog_checkout.py
+++ b/crud/public_catalog_checkout.py
@@ -2,57 +2,115 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
+from sqlalchemy import and_
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
 from crud.public_catalog import PublicCatalogDAO
-from models import Product, TenantOffer
+from models import Product, Storefront, TenantOffer
 from models.tenancy import TenantScope
+
+
+@dataclass(frozen=True)
+class LockedPublicCatalogProduct:
+    product_id: int
+    title: str
+    unit_price: int
+    currency: str
 
 
 class PublicCatalogCheckoutDAO:
     @staticmethod
-    async def get_shared_prices_by_ids(
-        session: AsyncSession,
-        *,
-        product_ids: set[int],
-    ) -> dict[int, int]:
-        if not product_ids:
-            return {}
-        rows = (
-            await session.execute(
-                select(Product.id, Product.price)
-                .where(
-                    Product.id.in_(product_ids),
-                    Product.is_published.is_(True),
-                )
-                .order_by(Product.id.asc())
-                .with_for_update(read=True, of=Product)
-            )
-        ).all()
-        return {int(product_id): int(price) for product_id, price in rows}
-
-    @staticmethod
-    async def get_offer_prices_by_ids(
+    async def get_shared_snapshots_by_ids(
         session: AsyncSession,
         *,
         tenant_scope: TenantScope,
         product_ids: set[int],
-    ) -> dict[int, int]:
+    ) -> dict[int, LockedPublicCatalogProduct]:
         if not product_ids:
             return {}
         rows = (
             await session.execute(
-                select(Product.id, TenantOffer.price)
+                select(
+                    Product.id,
+                    Product.title,
+                    Product.price,
+                    Storefront.currency,
+                )
                 .select_from(Product)
-                .join(TenantOffer, TenantOffer.product_id == Product.id)
+                .join(
+                    Storefront,
+                    and_(
+                        Storefront.id == tenant_scope.storefront_id,
+                        Storefront.tenant_id == tenant_scope.tenant_id,
+                    ),
+                )
                 .where(
                     Product.id.in_(product_ids),
                     Product.is_published.is_(True),
+                    Storefront.status == "active",
+                )
+                .order_by(Product.id.asc())
+                .with_for_update(read=True, of=(Product, Storefront))
+            )
+        ).all()
+        return {
+            int(product_id): LockedPublicCatalogProduct(
+                product_id=int(product_id),
+                title=str(title),
+                unit_price=int(price),
+                currency=str(currency),
+            )
+            for product_id, title, price, currency in rows
+        }
+
+    @staticmethod
+    async def get_offer_snapshots_by_ids(
+        session: AsyncSession,
+        *,
+        tenant_scope: TenantScope,
+        product_ids: set[int],
+    ) -> dict[int, LockedPublicCatalogProduct]:
+        if not product_ids:
+            return {}
+        rows = (
+            await session.execute(
+                select(
+                    Product.id,
+                    Product.title,
+                    TenantOffer.price,
+                    Storefront.currency,
+                )
+                .select_from(Product)
+                .join(TenantOffer, TenantOffer.product_id == Product.id)
+                .join(
+                    Storefront,
+                    and_(
+                        Storefront.id == tenant_scope.storefront_id,
+                        Storefront.tenant_id == tenant_scope.tenant_id,
+                    ),
+                )
+                .where(
+                    Product.id.in_(product_ids),
+                    Product.is_published.is_(True),
+                    Storefront.status == "active",
                     *PublicCatalogDAO.visible_offer_conditions(tenant_scope),
                 )
                 .order_by(Product.id.asc())
-                .with_for_update(read=True, of=(Product, TenantOffer))
+                .with_for_update(
+                    read=True,
+                    of=(Product, TenantOffer, Storefront),
+                )
             )
         ).all()
-        return {int(product_id): int(price) for product_id, price in rows}
+        return {
+            int(product_id): LockedPublicCatalogProduct(
+                product_id=int(product_id),
+                title=str(title),
+                unit_price=int(price),
+                currency=str(currency),
+            )
+            for product_id, title, price, currency in rows
+        }

--- a/crud/public_catalog_checkout.py
+++ b/crud/public_catalog_checkout.py
@@ -1,0 +1,58 @@
+"""Locked price snapshots for public checkout."""
+
+from __future__ import annotations
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from crud.public_catalog import PublicCatalogDAO
+from models import Product, TenantOffer
+from models.tenancy import TenantScope
+
+
+class PublicCatalogCheckoutDAO:
+    @staticmethod
+    async def get_shared_prices_by_ids(
+        session: AsyncSession,
+        *,
+        product_ids: set[int],
+    ) -> dict[int, int]:
+        if not product_ids:
+            return {}
+        rows = (
+            await session.execute(
+                select(Product.id, Product.price)
+                .where(
+                    Product.id.in_(product_ids),
+                    Product.is_published.is_(True),
+                )
+                .order_by(Product.id.asc())
+                .with_for_update(read=True, of=Product)
+            )
+        ).all()
+        return {int(product_id): int(price) for product_id, price in rows}
+
+    @staticmethod
+    async def get_offer_prices_by_ids(
+        session: AsyncSession,
+        *,
+        tenant_scope: TenantScope,
+        product_ids: set[int],
+    ) -> dict[int, int]:
+        if not product_ids:
+            return {}
+        rows = (
+            await session.execute(
+                select(Product.id, TenantOffer.price)
+                .select_from(Product)
+                .join(TenantOffer, TenantOffer.product_id == Product.id)
+                .where(
+                    Product.id.in_(product_ids),
+                    Product.is_published.is_(True),
+                    *PublicCatalogDAO.visible_offer_conditions(tenant_scope),
+                )
+                .order_by(Product.id.asc())
+                .with_for_update(read=True, of=(Product, TenantOffer))
+            )
+        ).all()
+        return {int(product_id): int(price) for product_id, price in rows}

--- a/crud/public_taxonomy.py
+++ b/crud/public_taxonomy.py
@@ -1,0 +1,181 @@
+"""Public-only taxonomy predicates for storefront catalog queries."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from sqlalchemy import exists, or_
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from models import Brand, Product, ProductTagLink, Tag, TagGroup
+from models.product_constants import BTU_MAPPING
+
+
+PUBLIC_FILTER_GROUP_SLUGS = {
+    "brand",
+    "series",
+    "expert-badge",
+    "type",
+    "category",
+}
+
+
+def _normalized_slugs(values: Iterable[str] | None) -> list[str]:
+    return list(
+        dict.fromkeys(
+            str(value).strip().lower()
+            for value in (values or [])
+            if value and str(value).strip()
+        )
+    )
+
+
+class PublicTaxonomyDAO:
+    """Build queries that can only observe public tags and tag groups."""
+
+    @staticmethod
+    def public_tag_conditions():
+        return (
+            Tag.is_public.is_(True),
+            TagGroup.is_public.is_(True),
+        )
+
+    @staticmethod
+    async def resolve_filter_ids(
+        session: AsyncSession,
+        *,
+        tag_slugs: Iterable[str] | None,
+        brand_slugs: Iterable[str] | None,
+    ) -> tuple[dict[int, list[int]] | None, list[str]]:
+        requested_tag_slugs = _normalized_slugs(tag_slugs)
+        resolved_brand_slugs = _normalized_slugs(brand_slugs)
+        if not requested_tag_slugs:
+            return None, resolved_brand_slugs
+
+        tag_rows = (
+            await session.execute(
+                select(Tag.id, Tag.group_id, Tag.slug, TagGroup.slug)
+                .join(TagGroup, Tag.group_id == TagGroup.id)
+                .where(
+                    Tag.slug.in_(requested_tag_slugs),
+                    TagGroup.slug.in_(sorted(PUBLIC_FILTER_GROUP_SLUGS)),
+                    *PublicTaxonomyDAO.public_tag_conditions(),
+                )
+            )
+        ).all()
+
+        public_brand_tag_slugs = {
+            str(tag_slug)
+            for _, _, tag_slug, group_slug in tag_rows
+            if group_slug == "brand" and tag_slug
+        }
+        legacy_brand_slugs: set[str] = set()
+        if public_brand_tag_slugs:
+            legacy_brand_slugs = {
+                str(slug)
+                for slug in (
+                    await session.execute(
+                        select(Brand.slug).where(
+                            Brand.slug.in_(public_brand_tag_slugs),
+                            Brand.is_published.is_(True),
+                        )
+                    )
+                ).scalars().all()
+                if slug
+            }
+            resolved_brand_slugs.extend(sorted(legacy_brand_slugs))
+
+        grouped: dict[int, list[int]] = {}
+        for tag_id, group_id, _, group_slug in tag_rows:
+            if group_id is None or tag_id is None or group_slug == "brand":
+                continue
+            grouped.setdefault(int(group_id), []).append(int(tag_id))
+
+        return grouped or None, list(dict.fromkeys(resolved_brand_slugs))
+
+    @staticmethod
+    def apply_published_brand_filter(statement, brand_slugs: Iterable[str] | None):
+        normalized = _normalized_slugs(brand_slugs)
+        if not normalized:
+            return statement
+        published_brand_ids = select(Brand.id).where(
+            Brand.slug.in_(normalized),
+            Brand.is_published.is_(True),
+        )
+        return statement.where(Product.brand_id.in_(published_brand_ids))
+
+    @staticmethod
+    def apply_faceted_filters(
+        statement,
+        faceted_tag_ids: dict[int, list[int]] | None,
+    ):
+        for tag_ids in (faceted_tag_ids or {}).values():
+            normalized_ids = sorted({int(tag_id) for tag_id in tag_ids})
+            if not normalized_ids:
+                continue
+            matching_products = (
+                select(ProductTagLink.product_id)
+                .join(Tag, ProductTagLink.tag_id == Tag.id)
+                .join(TagGroup, Tag.group_id == TagGroup.id)
+                .where(
+                    Tag.id.in_(normalized_ids),
+                    *PublicTaxonomyDAO.public_tag_conditions(),
+                )
+            )
+            statement = statement.where(Product.id.in_(matching_products))
+        return statement
+
+    @staticmethod
+    def apply_search_filter(
+        session: AsyncSession,
+        statement,
+        query: str | None,
+    ):
+        normalized_query = str(query or "").strip()
+        if not normalized_query:
+            return statement
+
+        from crud.product import ProductDAO
+
+        tokens = normalized_query.split()
+        text_tokens = [token for token in tokens if not token.isdigit()]
+        number_tokens = [token for token in tokens if token.isdigit()]
+
+        for word in text_tokens:
+            public_tag_title_match = exists(
+                select(ProductTagLink.product_id)
+                .join(Tag, ProductTagLink.tag_id == Tag.id)
+                .join(TagGroup, Tag.group_id == TagGroup.id)
+                .where(
+                    ProductTagLink.product_id == Product.id,
+                    Tag.title.ilike(f"%{word}%"),
+                    *PublicTaxonomyDAO.public_tag_conditions(),
+                )
+            )
+            statement = statement.where(
+                or_(
+                    Product.title.ilike(f"%{word}%"),
+                    public_tag_title_match,
+                )
+            )
+
+        for number in number_tokens:
+            if number in BTU_MAPPING:
+                ranges = BTU_MAPPING[number]
+                number_filter = or_(
+                    ProductDAO.area_expr(session).between(
+                        ranges["area"][0],
+                        ranges["area"][1],
+                    ),
+                    Product.power_cooling.between(
+                        ranges["power"][0],
+                        ranges["power"][1],
+                    ),
+                    Product.title.ilike(f"%{number}%"),
+                )
+            else:
+                number_filter = Product.title.ilike(f"%{number}%")
+            statement = statement.where(number_filter)
+
+        return statement

--- a/docs/tenant-offer-contract.md
+++ b/docs/tenant-offer-contract.md
@@ -42,15 +42,28 @@ username snapshot; legacy system-admin commands may have only the snapshot.
 - status is `active` or `disabled`;
 - audit records carry the same tenant/storefront consistency constraint.
 
-## Deliberate release boundary
+## Public catalog projection
 
-This foundation does not change public catalog output. Until the next release,
-public product endpoints continue using the existing MVN price and visibility.
-The public cutover must join active, published offers inside the catalog SQL
-query before filtering, sorting and pagination. Applying prices after
-pagination would produce incorrect result sets and is prohibited.
+The canonical `mvn/main` storefront intentionally keeps the historical shared
+`Product.price` behaviour, but it can expose only published products. Every
+other trusted storefront is deny-by-default and reads only a globally
+published Product with an exact `(tenant_id, storefront_id)` offer where
+`status=active` and `is_published=true`.
 
-For non-default storefronts the future public projection will be
-deny-by-default: a product without an active, published offer is not visible.
-The canonical `mvn/main` compatibility policy must be made explicit and tested
-before that projection is enabled.
+Offer price is joined in SQL before price filtering, sorting, counting and
+pagination. It is not overlaid after a shared catalog page has been selected.
+The same boundary applies to product detail, siblings, series navigation,
+featured products, brand counts, series pages, merchandising collections,
+filter metadata, spec keys and the legacy public search endpoint.
+
+Website checkout resolves and share-locks the same storefront price again on
+the server, in deterministic product order, before creating any order rows. A
+missing or disabled offer returns `409 product_not_available`; a valid order
+stores the storefront unit price in `OrderProductLink.price` and records the
+pricing source in the order technical snapshot. Browser-supplied prices remain
+non-authoritative.
+
+`POST /api/v1/leads/product-availability` applies the same visibility check
+before looking up or creating an Order and before resolving notification
+recipients. A foreign, disabled or missing offer returns the same neutral `404`
+as a missing Product and has no persistence or notification side effects.

--- a/docs/tenant-offer-contract.md
+++ b/docs/tenant-offer-contract.md
@@ -56,12 +56,21 @@ The same boundary applies to product detail, siblings, series navigation,
 featured products, brand counts, series pages, merchandising collections,
 filter metadata, spec keys and the legacy public search endpoint.
 
+Public product payloads serialize a tag only when both `Tag.is_public=true`
+and its `TagGroup.is_public=true`. Catalog tag filters and tag-title search use
+the same predicate. Hidden tag slugs are ignored exactly like unknown legacy
+slugs; a legacy brand slug is recognized only through a public brand tag and a
+published `Brand`. These rules are identical for the canonical and secondary
+storefront projections.
+
 Website checkout resolves and share-locks the same storefront price again on
 the server, in deterministic product order, before creating any order rows. A
 missing or disabled offer returns `409 product_not_available`; a valid order
 stores the storefront unit price in `OrderProductLink.price` and records the
-pricing source in the order technical snapshot. Browser-supplied prices remain
-non-authoritative.
+pricing source in the order technical snapshot. Link creation receives the
+locked price through a dedicated immutable command, so the generic order
+orchestrator does not resolve or fall back from storefront pricing.
+Browser-supplied prices remain non-authoritative.
 
 `POST /api/v1/leads/product-availability` applies the same visibility check
 before looking up or creating an Order and before resolving notification

--- a/manager_frontend/src/client/index.ts
+++ b/manager_frontend/src/client/index.ts
@@ -469,6 +469,8 @@ export type { PublicOrderPricingErrorResponse } from './models/PublicOrderPricin
 export type { PublicProductCollectionItemResponse } from './models/PublicProductCollectionItemResponse';
 export type { PublicProductCollectionPlacementResponse } from './models/PublicProductCollectionPlacementResponse';
 export type { PublicProductCollectionResponse } from './models/PublicProductCollectionResponse';
+export type { PublicProductSearchItemResponse } from './models/PublicProductSearchItemResponse';
+export type { PublicProductSearchResponse } from './models/PublicProductSearchResponse';
 export type { PublicRelatedSeriesResponse } from './models/PublicRelatedSeriesResponse';
 export type { PublicSeriesPageResponse } from './models/PublicSeriesPageResponse';
 export type { PublicStorefrontContextResponse } from './models/PublicStorefrontContextResponse';

--- a/manager_frontend/src/client/models/ManagerOrderTransferProductLine.ts
+++ b/manager_frontend/src/client/models/ManagerOrderTransferProductLine.ts
@@ -7,6 +7,8 @@ import type { OrderProductLogisticsComponent } from './OrderProductLogisticsComp
 export type ManagerOrderTransferProductLine = {
     source_id?: (number | null);
     product: ManagerOrderTransferProductRef;
+    title_snapshot?: (string | null);
+    currency_snapshot?: (string | null);
     quantity: number;
     price: number;
     cost?: number;

--- a/manager_frontend/src/client/models/OrderProductLineResponse.ts
+++ b/manager_frontend/src/client/models/OrderProductLineResponse.ts
@@ -9,6 +9,8 @@ export type OrderProductLineResponse = {
     proposal_id?: (number | null);
     product_id?: (number | null);
     product_title: string;
+    title_snapshot?: (string | null);
+    currency_snapshot?: (string | null);
     quantity: number;
     price: number;
     cost: number;

--- a/manager_frontend/src/client/models/PublicProductSearchItemResponse.ts
+++ b/manager_frontend/src/client/models/PublicProductSearchItemResponse.ts
@@ -1,0 +1,28 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * Small public projection; internal sourcing and margin data is excluded.
+ */
+export type PublicProductSearchItemResponse = {
+    id: number;
+    title: string;
+    slug?: (string | null);
+    price: number;
+    old_price?: (number | null);
+    product_kind?: 'unknown' | 'complete_split_system' | 'indoor_unit' | 'outdoor_unit' | 'panel' | 'accessory' | 'consumable' | 'other';
+    is_inverter: boolean;
+    power_cooling?: (number | null);
+    main_image?: (string | null);
+    card_image?: (string | null);
+    full_image?: (string | null);
+    specs?: Record<string, any>;
+    vitebsk_qty?: number;
+    minsk_qty?: number;
+    availability_status?: (string | null);
+    public_stock_state?: ('local_stock' | 'supplier_stock' | 'available_to_order' | 'out_of_stock' | null);
+    delivery_min_days?: (number | null);
+    delivery_max_days?: (number | null);
+};
+

--- a/manager_frontend/src/client/models/PublicProductSearchResponse.ts
+++ b/manager_frontend/src/client/models/PublicProductSearchResponse.ts
@@ -1,0 +1,9 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { PublicProductSearchItemResponse } from './PublicProductSearchItemResponse';
+export type PublicProductSearchResponse = {
+    items?: Array<PublicProductSearchItemResponse>;
+};
+

--- a/manager_frontend/src/client/services/ApiService.ts
+++ b/manager_frontend/src/client/services/ApiService.ts
@@ -21,6 +21,7 @@ import type { PublicBrandResponse } from '../models/PublicBrandResponse';
 import type { PublicContactLeadPayload } from '../models/PublicContactLeadPayload';
 import type { PublicContactLeadResponse } from '../models/PublicContactLeadResponse';
 import type { PublicProductCollectionPlacementResponse } from '../models/PublicProductCollectionPlacementResponse';
+import type { PublicProductSearchResponse } from '../models/PublicProductSearchResponse';
 import type { PublicSeriesPageResponse } from '../models/PublicSeriesPageResponse';
 import type { PublicStorefrontContextResponse } from '../models/PublicStorefrontContextResponse';
 import type { RepairDiagnosticLeadResponse } from '../models/RepairDiagnosticLeadResponse';
@@ -36,13 +37,13 @@ export class ApiService {
      * Search products with fuzzy matching.
      * @param q
      * @param isInverter
-     * @returns any Successful Response
+     * @returns PublicProductSearchResponse Successful Response
      * @throws ApiError
      */
     public static searchProductsApiProductsSearchGet(
         q?: string,
         isInverter?: boolean,
-    ): CancelablePromise<any> {
+    ): CancelablePromise<PublicProductSearchResponse> {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/api/products/search',

--- a/models/order.py
+++ b/models/order.py
@@ -275,7 +275,7 @@ class OrderProductLink(SQLModel, table=True):
     price: int = Field(default=0)
     title_snapshot: Optional[str] = Field(
         default=None,
-        sa_column=Column(String(500), nullable=True),
+        sa_column=Column(Text, nullable=True),
     )
     currency_snapshot: Optional[str] = Field(
         default=None,

--- a/models/order.py
+++ b/models/order.py
@@ -273,6 +273,14 @@ class OrderProductLink(SQLModel, table=True):
     quantity: int = Field(default=1)
 
     price: int = Field(default=0)
+    title_snapshot: Optional[str] = Field(
+        default=None,
+        sa_column=Column(String(500), nullable=True),
+    )
+    currency_snapshot: Optional[str] = Field(
+        default=None,
+        sa_column=Column(String(3), nullable=True),
+    )
     cost: int = Field(default=0)
 
     is_installation_included: bool = Field(default=False)

--- a/models/tenancy.py
+++ b/models/tenancy.py
@@ -21,6 +21,9 @@ class TenantScope:
     # Transitional legacy rows belong only to the canonical system tenant.
     # New tenants must never be allowed to claim nullable MVN-era ownership.
     is_system: bool = False
+    # Public resolvers set this explicitly. ``None`` keeps compatibility for
+    # internal callers that only know the persisted IDs.
+    is_canonical_storefront: bool | None = None
 
 
 class Tenant(SQLModel, table=True):

--- a/openapi.json
+++ b/openapi.json
@@ -40615,6 +40615,28 @@
           "product": {
             "$ref": "#/components/schemas/ManagerOrderTransferProductRef"
           },
+          "title_snapshot": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title Snapshot"
+          },
+          "currency_snapshot": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Currency Snapshot"
+          },
           "quantity": {
             "type": "integer",
             "title": "Quantity"
@@ -47223,6 +47245,28 @@
           "product_title": {
             "type": "string",
             "title": "Product Title"
+          },
+          "title_snapshot": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title Snapshot"
+          },
+          "currency_snapshot": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Currency Snapshot"
           },
           "quantity": {
             "type": "integer",

--- a/openapi.json
+++ b/openapi.json
@@ -1923,7 +1923,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/PublicProductSearchResponse"
+                }
               }
             }
           },
@@ -51977,6 +51979,196 @@
           "updated_at"
         ],
         "title": "PublicProductCollectionResponse"
+      },
+      "PublicProductSearchItemResponse": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "slug": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Slug"
+          },
+          "price": {
+            "type": "integer",
+            "title": "Price"
+          },
+          "old_price": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Old Price"
+          },
+          "product_kind": {
+            "type": "string",
+            "enum": [
+              "unknown",
+              "complete_split_system",
+              "indoor_unit",
+              "outdoor_unit",
+              "panel",
+              "accessory",
+              "consumable",
+              "other"
+            ],
+            "title": "Product Kind",
+            "default": "unknown"
+          },
+          "is_inverter": {
+            "type": "boolean",
+            "title": "Is Inverter"
+          },
+          "power_cooling": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Power Cooling"
+          },
+          "main_image": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Main Image"
+          },
+          "card_image": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Card Image"
+          },
+          "full_image": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Full Image"
+          },
+          "specs": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Specs"
+          },
+          "vitebsk_qty": {
+            "type": "integer",
+            "title": "Vitebsk Qty",
+            "default": 0
+          },
+          "minsk_qty": {
+            "type": "integer",
+            "title": "Minsk Qty",
+            "default": 0
+          },
+          "availability_status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Availability Status"
+          },
+          "public_stock_state": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "local_stock",
+                  "supplier_stock",
+                  "available_to_order",
+                  "out_of_stock"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Public Stock State"
+          },
+          "delivery_min_days": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Delivery Min Days"
+          },
+          "delivery_max_days": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Delivery Max Days"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "id",
+          "title",
+          "price",
+          "is_inverter"
+        ],
+        "title": "PublicProductSearchItemResponse",
+        "description": "Small public projection; internal sourcing and margin data is excluded."
+      },
+      "PublicProductSearchResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/PublicProductSearchItemResponse"
+            },
+            "type": "array",
+            "title": "Items"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "title": "PublicProductSearchResponse"
       },
       "PublicRelatedSeriesResponse": {
         "properties": {

--- a/routers/api_admin.py
+++ b/routers/api_admin.py
@@ -5,24 +5,33 @@ from fastapi.responses import JSONResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 from typing import List
 
+from api_contracts.public_catalog import PublicProductSearchResponse
 from core.database import get_session
 from core.security import get_current_username
+from core.tenant_scope import get_public_tenant_scope
+from models.tenancy import TenantScope
 from services.admin_api_service import AdminApiService
-from services.product_service import ProductService
+from services.public_catalog_service import PublicCatalogService
 from services.readiness_service import ReadinessService
 
 router = APIRouter(tags=["api"])
 
 
-@router.get("/products/search")
+@router.get("/products/search", response_model=PublicProductSearchResponse)
 async def search_products(
     q: str = None,
     is_inverter: bool = None,
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_public_tenant_scope),
 ):
     """Search products with fuzzy matching."""
-    products = await ProductService.search(session, query=q, is_inverter=is_inverter)
-    return {"items": products}
+    products = await PublicCatalogService.search(
+        session,
+        tenant_scope=tenant_scope,
+        query=q,
+        is_inverter=is_inverter,
+    )
+    return PublicProductSearchResponse(items=products)
 
 
 @router.get("/admin/tags/filterable")

--- a/routers/api_content.py
+++ b/routers/api_content.py
@@ -5,7 +5,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from typing import List
 
 from core.database import get_session
-from core.tenant_scope import verify_public_storefront_request
+from core.tenant_scope import get_public_tenant_scope, verify_public_storefront_request
+from models.tenancy import TenantScope
 from schemas import (
     ArticleResponse,
     PublicBrandDetailResponse,
@@ -46,9 +47,15 @@ async def get_services(session: AsyncSession = Depends(get_session)):
 
 
 @router.get("/v1/content/brands", response_model=List[PublicBrandResponse], operation_id="get_public_brands")
-async def get_public_brands(session: AsyncSession = Depends(get_session)):
+async def get_public_brands(
+    session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_public_tenant_scope),
+):
     """Get published brands that have at least one published product."""
-    return await ContentApiService.get_public_brands(session)
+    return await ContentApiService.get_public_brands(
+        session,
+        tenant_scope=tenant_scope,
+    )
 
 
 @router.get(
@@ -56,9 +63,17 @@ async def get_public_brands(session: AsyncSession = Depends(get_session)):
     response_model=PublicBrandDetailResponse,
     operation_id="get_public_brand",
 )
-async def get_public_brand(slug: str, session: AsyncSession = Depends(get_session)):
+async def get_public_brand(
+    slug: str,
+    session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_public_tenant_scope),
+):
     """Get a published brand by slug if it has published products."""
-    brand = await ContentApiService.get_public_brand_by_slug(session, slug)
+    brand = await ContentApiService.get_public_brand_by_slug(
+        session,
+        slug,
+        tenant_scope=tenant_scope,
+    )
     if not brand:
         raise HTTPException(status_code=404, detail=f"Brand with slug '{slug}' not found")
     return brand
@@ -73,12 +88,14 @@ async def get_public_brand_series(
     brand_slug: str,
     series_slug: str,
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_public_tenant_scope),
 ):
     """Get one published series and its public product cards."""
     payload = await PublicSeriesPageService.get_by_slugs(
         session,
         brand_slug=brand_slug,
         series_slug=series_slug,
+        tenant_scope=tenant_scope,
     )
     if payload is None:
         raise HTTPException(

--- a/routers/api_product_collections.py
+++ b/routers/api_product_collections.py
@@ -3,7 +3,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from api_contracts.product_collections import PublicProductCollectionPlacementResponse
 from core.database import get_session
-from core.tenant_scope import verify_public_storefront_request
+from core.tenant_scope import get_public_tenant_scope, verify_public_storefront_request
+from models.tenancy import TenantScope
 from services.product_collection_resolver import ProductCollectionResolver
 
 
@@ -22,9 +23,11 @@ async def get_public_product_collection_placement(
     surface_key: str = Path(min_length=1, max_length=80),
     slot_key: str = Path(min_length=1, max_length=80),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_public_tenant_scope),
 ):
     return await ProductCollectionResolver.resolve_placement(
         session,
         surface_key=surface_key.lower(),
         slot_key=slot_key.lower(),
+        tenant_scope=tenant_scope,
     )

--- a/routers/api_products.py
+++ b/routers/api_products.py
@@ -7,7 +7,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from core.database import get_session
 from core.security import get_current_username
-from core.tenant_scope import verify_public_storefront_request
+from core.tenant_scope import get_public_tenant_scope, verify_public_storefront_request
+from models.tenancy import TenantScope
 from schemas import (
     CatalogResponse,
     FiltersConfigResponse,
@@ -18,10 +19,10 @@ from schemas import (
     SpecRegistryResponse,
 )
 from services.description_generator import DescriptionGeneratorService
-from services.catalog import CatalogService
 from services.product_response_mapper import map_product_to_response
 from services.product_service import ProductService
 from services.feature_resolver_service import FeatureResolverService
+from services.public_catalog_service import PublicCatalogService
 
 router = APIRouter(tags=["api"])
 _PUBLIC_STOREFRONT_DEPENDENCIES = [Depends(verify_public_storefront_request)]
@@ -33,8 +34,14 @@ _PUBLIC_STOREFRONT_DEPENDENCIES = [Depends(verify_public_storefront_request)]
     operation_id="get_public_spec_keys",
     dependencies=_PUBLIC_STOREFRONT_DEPENDENCIES,
 )
-async def get_public_spec_keys(session: AsyncSession = Depends(get_session)):
-    payload = await ProductService.get_public_spec_keys(session)
+async def get_public_spec_keys(
+    session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_public_tenant_scope),
+):
+    payload = await PublicCatalogService.get_public_spec_keys(
+        session,
+        tenant_scope=tenant_scope,
+    )
     return SpecsKeysResponse(**payload)
 
 
@@ -55,8 +62,14 @@ async def get_public_spec_registry():
     operation_id="get_filters_config",
     dependencies=_PUBLIC_STOREFRONT_DEPENDENCIES,
 )
-async def get_filters_config(session: AsyncSession = Depends(get_session)):
-    return await ProductService.get_filters_config(session)
+async def get_filters_config(
+    session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_public_tenant_scope),
+):
+    return await PublicCatalogService.get_filters_config(
+        session,
+        tenant_scope=tenant_scope,
+    )
 
 
 @router.post("/products/{product_id}/generate-description")
@@ -105,14 +118,16 @@ async def get_catalog(
     is_inverter: Optional[bool] = None,
     q: Optional[str] = Query(None, description="Smart search query"),
     session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_public_tenant_scope),
 ):
     try:
         ProductService.validate_public_pagination(page, limit)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
-    payload = await ProductService.get_catalog_page(
+    payload = await PublicCatalogService.get_catalog_page(
         session,
+        tenant_scope=tenant_scope,
         page=page,
         limit=limit,
         sort=sort,
@@ -130,16 +145,18 @@ async def get_catalog(
         is_inverter=is_inverter,
         search=q,
     )
-    supply_metrics = await ProductService.get_supply_metrics_map(session, payload["items"])
-    await FeatureResolverService.resolve_for_products(session, payload["items"])
+    products = [projection.product for projection in payload["items"]]
+    supply_metrics = await ProductService.get_supply_metrics_map(session, products)
+    await FeatureResolverService.resolve_for_products(session, products)
 
     return CatalogResponse(
         items=[
             map_product_to_response(
-                product,
-                supply_metrics=supply_metrics.get(product.id),
+                projection.product,
+                supply_metrics=supply_metrics.get(projection.product.id),
+                pricing=projection.pricing,
             )
-            for product in payload["items"]
+            for projection in payload["items"]
         ],
         meta=Meta(**payload["meta"]),
     )
@@ -151,16 +168,25 @@ async def get_catalog(
     operation_id="get_vitebsk_featured_products",
     dependencies=_PUBLIC_STOREFRONT_DEPENDENCIES,
 )
-async def get_vitebsk_featured_products(session: AsyncSession = Depends(get_session)):
-    products = await CatalogService.get_vitebsk_featured_products(session, limit=6)
+async def get_vitebsk_featured_products(
+    session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_public_tenant_scope),
+):
+    projections = await PublicCatalogService.get_vitebsk_featured_products(
+        session,
+        tenant_scope=tenant_scope,
+        limit=6,
+    )
+    products = [projection.product for projection in projections]
     supply_metrics = await ProductService.get_supply_metrics_map(session, products)
     await FeatureResolverService.resolve_for_products(session, products)
     return [
         map_product_to_response(
-            product,
-            supply_metrics=supply_metrics.get(product.id),
+            projection.product,
+            supply_metrics=supply_metrics.get(projection.product.id),
+            pricing=projection.pricing,
         )
-        for product in products
+        for projection in projections
     ]
 
 
@@ -170,8 +196,14 @@ async def get_vitebsk_featured_products(session: AsyncSession = Depends(get_sess
     operation_id="get_product_series_navigation",
     dependencies=_PUBLIC_STOREFRONT_DEPENDENCIES,
 )
-async def get_product_series_navigation(session: AsyncSession = Depends(get_session)):
-    return await ProductService.get_series_navigation(session)
+async def get_product_series_navigation(
+    session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_public_tenant_scope),
+):
+    return await PublicCatalogService.get_series_navigation(
+        session,
+        tenant_scope=tenant_scope,
+    )
 
 
 @router.get(
@@ -180,15 +212,30 @@ async def get_product_series_navigation(session: AsyncSession = Depends(get_sess
     operation_id="get_product",
     dependencies=_PUBLIC_STOREFRONT_DEPENDENCIES,
 )
-async def get_product_by_identifier(identifier: str, session: AsyncSession = Depends(get_session)):
-    product = await ProductService.get_public_product_by_identifier(session, identifier)
-    if not product:
+async def get_product_by_identifier(
+    identifier: str,
+    session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_public_tenant_scope),
+):
+    page = await PublicCatalogService.get_product_page(
+        session,
+        tenant_scope=tenant_scope,
+        identifier=identifier,
+    )
+    if not page:
         raise HTTPException(status_code=404, detail=f"Product with identifier '{identifier}' not found")
-    siblings = await ProductService.get_series_siblings(session, product, limit=8)
+    product = page.product.product
+    siblings = [projection.product for projection in page.siblings]
     supply_metrics = await ProductService.get_supply_metrics_map(session, [product])
     await FeatureResolverService.resolve_for_products(session, [product])
     return map_product_to_response(
         product,
         series_siblings=siblings,
         supply_metrics=supply_metrics.get(product.id),
+        pricing=page.product.pricing,
+        sibling_pricing={
+            int(projection.product.id): projection.pricing
+            for projection in page.siblings
+            if projection.product.id is not None
+        },
     )

--- a/schemas_manager_order_transfer.py
+++ b/schemas_manager_order_transfer.py
@@ -49,6 +49,8 @@ class ManagerOrderTransferServiceRef(BaseModel):
 class ManagerOrderTransferProductLine(BaseModel):
     source_id: Optional[int] = None
     product: ManagerOrderTransferProductRef
+    title_snapshot: Optional[str] = None
+    currency_snapshot: Optional[str] = None
     quantity: int
     price: int
     cost: int = 0

--- a/schemas_manager_orders.py
+++ b/schemas_manager_orders.py
@@ -137,6 +137,8 @@ class OrderProductLineResponse(BaseModel):
     proposal_id: Optional[int] = None
     product_id: Optional[int] = None
     product_title: str
+    title_snapshot: Optional[str] = None
+    currency_snapshot: Optional[str] = None
     quantity: int
     price: int
     cost: int

--- a/services/communications/contracts.py
+++ b/services/communications/contracts.py
@@ -78,7 +78,10 @@ class PublicOrderCreatedPayloadV1(_ContractV1):
     customer: PublicOrderCustomerSnapshotV1
     comment: str | None = Field(default=None, max_length=2000)
     total_amount: Decimal = Field(ge=0, max_digits=14, decimal_places=2)
-    currency: Literal["BYN"] = "BYN"
+    currency: Annotated[
+        str,
+        Field(min_length=3, max_length=3, pattern=r"^[A-Z]{3}$"),
+    ] = "BYN"
     product_lines: list[PublicOrderProductLineSnapshotV1] = Field(
         default_factory=list,
         max_length=20,

--- a/services/communications/tenant_website_event_service.py
+++ b/services/communications/tenant_website_event_service.py
@@ -5,7 +5,15 @@ from __future__ import annotations
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
-from models import Customer, Lead, Order, OrderProductLink, OrderServiceLink, Product
+from models import (
+    Customer,
+    Lead,
+    Order,
+    OrderProductLink,
+    OrderServiceLink,
+    Product,
+    Storefront,
+)
 from schemas import OrderPayload
 from services.communications.contracts import (
     PublicOrderCustomerSnapshotV1,
@@ -65,6 +73,12 @@ class TenantWebsiteEventService:
         customer = await session.get(Customer, int(order.customer_id or 0))
         if customer is None or int(customer.tenant_id or 0) != tenant_scope.tenant_id:
             raise ValueError("Tenant website checkout customer scope is invalid")
+        storefront = await session.get(Storefront, tenant_scope.storefront_id)
+        if (
+            storefront is None
+            or int(storefront.tenant_id or 0) != tenant_scope.tenant_id
+        ):
+            raise ValueError("Tenant website checkout storefront scope is invalid")
 
         product_rows = (
             await session.execute(
@@ -101,6 +115,7 @@ class TenantWebsiteEventService:
             ),
             comment=request.comment,
             total_amount=order.total_amount,
+            currency=str(storefront.currency).strip().upper(),
             product_lines=[
                 PublicOrderProductLineSnapshotV1(
                     product_id=link.product_id,

--- a/services/content_api_service.py
+++ b/services/content_api_service.py
@@ -8,8 +8,11 @@ from sqlalchemy import func
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
+from crud.public_catalog import PublicCatalogDAO
 from models import Brand, Feature, FeatureBrandLink, GlobalConfig, Product, Service
+from models.tenancy import TenantScope
 from services.feature_scope_policy import FeatureScopePolicy
+from services.public_catalog_visibility_service import PublicCatalogVisibilityService
 
 
 class ContentApiService:
@@ -157,34 +160,63 @@ class ContentApiService:
         return [ContentApiService._serialize_service(service) for service in result.scalars().all()]
 
     @staticmethod
-    async def get_public_brands(session: AsyncSession) -> List[Dict[str, Any]]:
-        stmt = (
-            select(Brand, func.count(Product.id).label("products_count"))
-            .join(Product, Product.brand_id == Brand.id)
-            .where(Brand.is_published == True)
-            .where(Product.is_published == True)
-            .group_by(Brand.id)
-            .having(func.count(Product.id) > 0)
-            .order_by(Brand.sort_order.asc(), Brand.title.asc())
-        )
-        result = await session.execute(stmt)
+    async def get_public_brands(
+        session: AsyncSession,
+        *,
+        tenant_scope: TenantScope | None = None,
+    ) -> List[Dict[str, Any]]:
+        if tenant_scope is not None and not await PublicCatalogVisibilityService.is_canonical_scope(
+            session,
+            tenant_scope,
+        ):
+            rows = await PublicCatalogDAO.list_brand_counts(
+                session,
+                tenant_scope=tenant_scope,
+            )
+        else:
+            stmt = (
+                select(Brand, func.count(Product.id).label("products_count"))
+                .join(Product, Product.brand_id == Brand.id)
+                .where(Brand.is_published == True)
+                .where(Product.is_published == True)
+                .group_by(Brand.id)
+                .having(func.count(Product.id) > 0)
+                .order_by(Brand.sort_order.asc(), Brand.title.asc())
+            )
+            rows = list((await session.execute(stmt)).all())
         return [
             ContentApiService._serialize_brand(brand, products_count=products_count)
-            for brand, products_count in result.all()
+            for brand, products_count in rows
         ]
 
     @staticmethod
-    async def get_public_brand_by_slug(session: AsyncSession, slug: str) -> Dict[str, Any] | None:
-        stmt = (
-            select(Brand, func.count(Product.id).label("products_count"))
-            .join(Product, Product.brand_id == Brand.id)
-            .where(Brand.is_published == True)
-            .where(Brand.slug == slug)
-            .where(Product.is_published == True)
-            .group_by(Brand.id)
-            .having(func.count(Product.id) > 0)
-        )
-        row = (await session.execute(stmt)).one_or_none()
+    async def get_public_brand_by_slug(
+        session: AsyncSession,
+        slug: str,
+        *,
+        tenant_scope: TenantScope | None = None,
+    ) -> Dict[str, Any] | None:
+        if tenant_scope is not None and not await PublicCatalogVisibilityService.is_canonical_scope(
+            session,
+            tenant_scope,
+        ):
+            rows = await PublicCatalogDAO.list_brand_counts(
+                session,
+                tenant_scope=tenant_scope,
+                brand_slug=slug,
+            )
+            row = rows[0] if rows else None
+        else:
+            stmt = (
+                select(Brand, func.count(Product.id).label("products_count"))
+                .join(Product, Product.brand_id == Brand.id)
+                .where(Brand.is_published == True)
+                .where(Brand.slug == slug)
+                .where(Product.is_published == True)
+                .group_by(Brand.id)
+                .having(func.count(Product.id) > 0)
+            )
+            row = (await session.execute(stmt)).one_or_none()
         if row is None:
             return None
         brand, products_count = row

--- a/services/order_product_link_command.py
+++ b/services/order_product_link_command.py
@@ -1,0 +1,82 @@
+"""Focused command for immutable order-product price/link snapshots."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any, Mapping
+
+from models import OrderProductLink, Product
+
+
+@dataclass(frozen=True)
+class OrderProductLinkMutation:
+    link: OrderProductLink
+    product_total: int
+
+
+class OrderProductLinkCommand:
+    """Construct a link from either shared or pre-locked storefront prices."""
+
+    def __init__(self, unit_prices: Mapping[int, int] | None = None) -> None:
+        self._unit_prices = (
+            None
+            if unit_prices is None
+            else MappingProxyType(
+                {
+                    int(product_id): int(unit_price)
+                    for product_id, unit_price in unit_prices.items()
+                }
+            )
+        )
+
+    @classmethod
+    def shared_catalog(cls) -> "OrderProductLinkCommand":
+        return cls()
+
+    @classmethod
+    def storefront_snapshot(
+        cls,
+        unit_prices: Mapping[int, int],
+    ) -> "OrderProductLinkCommand":
+        return cls(unit_prices)
+
+    @property
+    def unit_prices(self) -> Mapping[int, int] | None:
+        return self._unit_prices
+
+    def build(
+        self,
+        *,
+        order_id: int,
+        proposal_id: int,
+        product: Product,
+        item: Mapping[str, Any],
+        product_cost: int,
+    ) -> OrderProductLinkMutation:
+        product_id = int(product.id)
+        unit_price = (
+            int(product.price)
+            if self._unit_prices is None
+            else int(self._unit_prices[product_id])
+        )
+        quantity = item["quantity"]
+        with_installation = bool(item.get("with_installation", False))
+        installation_price = int(item.get("installation_price", 0))
+        link = OrderProductLink(
+            order_id=order_id,
+            proposal_id=proposal_id,
+            product_id=product_id,
+            quantity=quantity,
+            price=unit_price,
+            cost=product_cost,
+            is_installation_included=with_installation,
+            installation_price=installation_price if with_installation else 0,
+            installation_details=(
+                item.get("installation_meta") if with_installation else None
+            ),
+        )
+        return OrderProductLinkMutation(
+            link=link,
+            product_total=unit_price * quantity,
+        )

--- a/services/order_product_link_command.py
+++ b/services/order_product_link_command.py
@@ -15,20 +15,73 @@ class OrderProductLinkMutation:
     product_total: int
 
 
-class OrderProductLinkCommand:
-    """Construct a link from either shared or pre-locked storefront prices."""
+@dataclass(frozen=True)
+class OrderProductCatalogSnapshot:
+    product_id: int
+    title: str
+    unit_price: int
+    currency: str
+    pricing_source: str
 
-    def __init__(self, unit_prices: Mapping[int, int] | None = None) -> None:
-        self._unit_prices = (
+    def __post_init__(self) -> None:
+        product_id = int(self.product_id)
+        title = " ".join(str(self.title or "").split())
+        unit_price = int(self.unit_price)
+        currency = str(self.currency or "").strip().upper()
+        pricing_source = str(self.pricing_source or "").strip()
+        if product_id <= 0:
+            raise ValueError("product_id must be positive")
+        if not title:
+            raise ValueError("title snapshot is required")
+        if unit_price < 0:
+            raise ValueError("unit price snapshot must be non-negative")
+        if len(currency) != 3 or not currency.isalpha():
+            raise ValueError("currency snapshot must be a three-letter code")
+        if pricing_source not in {"shared_product", "tenant_offer"}:
+            raise ValueError("unsupported pricing snapshot source")
+        object.__setattr__(self, "product_id", product_id)
+        object.__setattr__(self, "title", title)
+        object.__setattr__(self, "unit_price", unit_price)
+        object.__setattr__(self, "currency", currency)
+        object.__setattr__(self, "pricing_source", pricing_source)
+
+    def as_technical_meta(self) -> dict[str, int | str]:
+        return {
+            "product_id": self.product_id,
+            "title_snapshot": self.title,
+            "unit_price": self.unit_price,
+            "currency_snapshot": self.currency,
+            "source": self.pricing_source,
+        }
+
+
+class OrderProductLinkCommand:
+    """Construct links from shared products or locked storefront snapshots."""
+
+    def __init__(
+        self,
+        snapshots: Mapping[int, OrderProductCatalogSnapshot] | None = None,
+        *,
+        shared_currency: str = "BYN",
+    ) -> None:
+        self._snapshots = (
             None
-            if unit_prices is None
+            if snapshots is None
             else MappingProxyType(
                 {
-                    int(product_id): int(unit_price)
-                    for product_id, unit_price in unit_prices.items()
+                    int(product_id): snapshot
+                    for product_id, snapshot in snapshots.items()
                 }
             )
         )
+        if self._snapshots is not None:
+            for product_id, snapshot in self._snapshots.items():
+                if product_id != snapshot.product_id:
+                    raise ValueError("snapshot key must match product_id")
+        normalized_currency = str(shared_currency or "").strip().upper()
+        if len(normalized_currency) != 3 or not normalized_currency.isalpha():
+            raise ValueError("shared currency must be a three-letter code")
+        self._shared_currency = normalized_currency
 
     @classmethod
     def shared_catalog(cls) -> "OrderProductLinkCommand":
@@ -37,13 +90,24 @@ class OrderProductLinkCommand:
     @classmethod
     def storefront_snapshot(
         cls,
-        unit_prices: Mapping[int, int],
+        snapshots: Mapping[int, OrderProductCatalogSnapshot],
     ) -> "OrderProductLinkCommand":
-        return cls(unit_prices)
+        return cls(snapshots)
 
     @property
     def unit_prices(self) -> Mapping[int, int] | None:
-        return self._unit_prices
+        if self._snapshots is None:
+            return None
+        return MappingProxyType(
+            {
+                product_id: snapshot.unit_price
+                for product_id, snapshot in self._snapshots.items()
+            }
+        )
+
+    @property
+    def snapshots(self) -> Mapping[int, OrderProductCatalogSnapshot] | None:
+        return self._snapshots
 
     def build(
         self,
@@ -55,11 +119,17 @@ class OrderProductLinkCommand:
         product_cost: int,
     ) -> OrderProductLinkMutation:
         product_id = int(product.id)
-        unit_price = (
-            int(product.price)
-            if self._unit_prices is None
-            else int(self._unit_prices[product_id])
-        )
+        if self._snapshots is None:
+            snapshot = OrderProductCatalogSnapshot(
+                product_id=product_id,
+                title=product.title,
+                unit_price=int(product.price),
+                currency=self._shared_currency,
+                pricing_source="shared_product",
+            )
+        else:
+            snapshot = self._snapshots[product_id]
+        unit_price = snapshot.unit_price
         quantity = item["quantity"]
         with_installation = bool(item.get("with_installation", False))
         installation_price = int(item.get("installation_price", 0))
@@ -69,6 +139,8 @@ class OrderProductLinkCommand:
             product_id=product_id,
             quantity=quantity,
             price=unit_price,
+            title_snapshot=snapshot.title,
+            currency_snapshot=snapshot.currency,
             cost=product_cost,
             is_installation_included=with_installation,
             installation_price=installation_price if with_installation else 0,

--- a/services/order_product_link_command.py
+++ b/services/order_product_link_command.py
@@ -25,13 +25,13 @@ class OrderProductCatalogSnapshot:
 
     def __post_init__(self) -> None:
         product_id = int(self.product_id)
-        title = " ".join(str(self.title or "").split())
+        title = self.title
         unit_price = int(self.unit_price)
         currency = str(self.currency or "").strip().upper()
         pricing_source = str(self.pricing_source or "").strip()
         if product_id <= 0:
             raise ValueError("product_id must be positive")
-        if not title:
+        if not isinstance(title, str) or len(title) == 0:
             raise ValueError("title snapshot is required")
         if unit_price < 0:
             raise ValueError("unit price snapshot must be non-negative")

--- a/services/order_product_transfer_service.py
+++ b/services/order_product_transfer_service.py
@@ -1,0 +1,188 @@
+"""Focused product-line mapping for portable Manager order transfers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from sqlalchemy import func
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from models import OrderProductLink, Product
+from schemas import (
+    ManagerOrderTransferProductLine,
+    ManagerOrderTransferProductRef,
+)
+from services.order_service import OrderService
+
+
+@dataclass(frozen=True)
+class ResolvedTransferProduct:
+    product: Product | None
+    status: str
+    reason: str | None = None
+
+
+class OrderProductTransferService:
+    """Own product matching and immutable line snapshot round-trips."""
+
+    @staticmethod
+    def _optional_clean(value: Any) -> str | None:
+        cleaned = " ".join(str(value or "").split())
+        return cleaned or None
+
+    @staticmethod
+    def product_ref(link: OrderProductLink) -> ManagerOrderTransferProductRef:
+        product = link.product
+        return ManagerOrderTransferProductRef(
+            source_id=product.id if product else link.product_id,
+            # This is the mutable catalog reference used for display/matching.
+            # The immutable order title remains a separate nullable field.
+            title=(
+                product.title
+                if product
+                else (
+                    getattr(link, "title_snapshot", None)
+                    or f"Товар #{link.product_id}"
+                )
+            ),
+            slug=product.slug if product else None,
+            source_url=product.source_url if product else None,
+        )
+
+    @staticmethod
+    def snapshot_line(
+        link: OrderProductLink,
+    ) -> ManagerOrderTransferProductLine:
+        return ManagerOrderTransferProductLine(
+            source_id=link.id,
+            product=OrderProductTransferService.product_ref(link),
+            title_snapshot=getattr(link, "title_snapshot", None),
+            currency_snapshot=getattr(link, "currency_snapshot", None),
+            quantity=int(link.quantity or 1),
+            price=int(link.price or 0),
+            cost=int(link.cost or 0),
+            is_installation_included=bool(link.is_installation_included),
+            installation_price=int(link.installation_price or 0),
+            installation_details=link.installation_details,
+            logistics_components=(
+                OrderService._serialize_order_logistics_components(
+                    link.logistics_components
+                )
+            ),
+        )
+
+    @staticmethod
+    async def resolve_product(
+        session: AsyncSession,
+        product_ref: ManagerOrderTransferProductRef,
+    ) -> ResolvedTransferProduct:
+        slug = OrderProductTransferService._optional_clean(product_ref.slug)
+        if slug:
+            result = await session.execute(
+                select(Product).where(Product.slug == slug).limit(1)
+            )
+            product = result.scalars().first()
+            if product:
+                return ResolvedTransferProduct(
+                    product=product,
+                    status="matched",
+                    reason="slug",
+                )
+
+        source_url = OrderProductTransferService._optional_clean(
+            product_ref.source_url
+        )
+        if source_url:
+            result = await session.execute(
+                select(Product)
+                .where(Product.source_url == source_url)
+                .limit(1)
+            )
+            product = result.scalars().first()
+            if product:
+                return ResolvedTransferProduct(
+                    product=product,
+                    status="matched",
+                    reason="source_url",
+                )
+
+        title = OrderProductTransferService._optional_clean(product_ref.title)
+        if title:
+            result = await session.execute(
+                select(Product)
+                .where(func.lower(Product.title) == title.lower())
+                .limit(2)
+            )
+            products = list(result.scalars().all())
+            if len(products) == 1:
+                return ResolvedTransferProduct(
+                    product=products[0],
+                    status="matched",
+                    reason="title",
+                )
+            if len(products) > 1:
+                return ResolvedTransferProduct(
+                    product=None,
+                    status="missing",
+                    reason="ambiguous_title",
+                )
+
+        return ResolvedTransferProduct(
+            product=None,
+            status="missing",
+            reason="not_found",
+        )
+
+    @staticmethod
+    def preview_match(
+        *,
+        source_order_id: int | None,
+        product_line: ManagerOrderTransferProductLine,
+        resolved: ResolvedTransferProduct,
+    ) -> dict[str, Any]:
+        return {
+            "source_order_id": source_order_id,
+            "product_title": product_line.product.title,
+            "product_slug": product_line.product.slug,
+            "matched_product_id": (
+                resolved.product.id if resolved.product else None
+            ),
+            "matched_product_title": (
+                resolved.product.title if resolved.product else None
+            ),
+            "status": resolved.status,
+            "reason": resolved.reason,
+        }
+
+    @staticmethod
+    def build_import_link(
+        *,
+        order_id: int,
+        proposal_id: int,
+        product_line: ManagerOrderTransferProductLine,
+        product: Product,
+    ) -> OrderProductLink:
+        return OrderProductLink(
+            order_id=order_id,
+            proposal_id=proposal_id,
+            product_id=int(product.id),
+            quantity=int(product_line.quantity or 1),
+            price=int(product_line.price or 0),
+            # Preserve the exported historical fact exactly. The mutable
+            # product reference above must never fabricate a legacy snapshot.
+            title_snapshot=product_line.title_snapshot,
+            currency_snapshot=product_line.currency_snapshot,
+            cost=int(product_line.cost or 0),
+            is_installation_included=bool(
+                product_line.is_installation_included
+            ),
+            installation_price=int(product_line.installation_price or 0),
+            installation_details=product_line.installation_details,
+            logistics_components=[
+                item.model_dump() if hasattr(item, "model_dump") else dict(item)
+                for item in (product_line.logistics_components or [])
+            ]
+            or None,
+        )

--- a/services/order_projection_service.py
+++ b/services/order_projection_service.py
@@ -145,13 +145,18 @@ class OrderProjectionService:
 
     @staticmethod
     def _map_product_line(link: OrderProductLink) -> Dict[str, Any]:
-        product_title = link.product.title if link.product else f"Товар #{link.product_id}"
+        product_title = (
+            getattr(link, "title_snapshot", None)
+            or (link.product.title if link.product else f"Товар #{link.product_id}")
+        )
         line_total = link.price * link.quantity
         return {
             "id": link.id,
             "proposal_id": link.proposal_id,
             "product_id": link.product_id,
             "product_title": product_title,
+            "title_snapshot": getattr(link, "title_snapshot", None),
+            "currency_snapshot": getattr(link, "currency_snapshot", None),
             "quantity": link.quantity,
             "price": link.price,
             "cost": link.cost,

--- a/services/order_service.py
+++ b/services/order_service.py
@@ -17,6 +17,7 @@ from services.product_area import area_from_specs
 from services.order_proposal_lifecycle import (
     PROPOSAL_STATUS_SENT,
 )
+from services.order_product_link_command import OrderProductLinkCommand
 from services.tenant_scope_service import (
     TenantScope,
     tenant_scope_clause,
@@ -952,7 +953,7 @@ class OrderService:
         customer_bank_name: Optional[str] = None,
         customer_id: Optional[int] = None,
         order_technical_meta: Optional[Dict[str, Any]] = None,
-        product_price_overrides: Optional[Dict[int, int]] = None,
+        product_link_command: Optional[OrderProductLinkCommand] = None,
         commit: bool = True,
     ) -> Order:
         """
@@ -1092,6 +1093,7 @@ class OrderService:
         added_items = []
         installation_services = []  # Collect installation services to add after products
         product_cost_cache: Dict[int, int] = {}
+        link_command = product_link_command or OrderProductLinkCommand.shared_catalog()
         
         for item in items:
             product_id = item.get("product_id")
@@ -1104,12 +1106,6 @@ class OrderService:
                 product = await ProductDAO.get_by_id(session, product_id)
 
             if product:
-                if product_price_overrides is None:
-                    storefront_unit_price = int(product.price)
-                else:
-                    storefront_unit_price = int(
-                        product_price_overrides[int(product.id)]
-                    )
                 # Extract installation fields (Phase: Snapshot Pricing Refactor)
                 with_installation = item.get("with_installation", False)
                 installation_price = int(item.get("installation_price", 0))
@@ -1119,23 +1115,17 @@ class OrderService:
                     product_cost_cache,
                 )
                 
-                link = OrderProductLink(
+                link_mutation = link_command.build(
                     order_id=order.id,
                     proposal_id=proposal.id,
-                    product_id=product.id,
-                    quantity=item["quantity"],
-                    price=storefront_unit_price,
-                    cost=product_cost,
-                    # Save snapshot for history
-                    is_installation_included=with_installation,
-                    installation_price=installation_price if with_installation else 0,
-                    installation_details=item.get("installation_meta") if with_installation else None
+                    product=product,
+                    item=item,
+                    product_cost=product_cost,
                 )
-                session.add(link)
+                session.add(link_mutation.link)
                 
                 # Calculate product total
-                product_total = storefront_unit_price * item["quantity"]
-                total_amount += product_total
+                total_amount += link_mutation.product_total
                 
                 # If installation requested, add to total
                 if with_installation and installation_price > 0:

--- a/services/order_service.py
+++ b/services/order_service.py
@@ -952,6 +952,7 @@ class OrderService:
         customer_bank_name: Optional[str] = None,
         customer_id: Optional[int] = None,
         order_technical_meta: Optional[Dict[str, Any]] = None,
+        product_price_overrides: Optional[Dict[int, int]] = None,
         commit: bool = True,
     ) -> Order:
         """
@@ -1103,6 +1104,12 @@ class OrderService:
                 product = await ProductDAO.get_by_id(session, product_id)
 
             if product:
+                if product_price_overrides is None:
+                    storefront_unit_price = int(product.price)
+                else:
+                    storefront_unit_price = int(
+                        product_price_overrides[int(product.id)]
+                    )
                 # Extract installation fields (Phase: Snapshot Pricing Refactor)
                 with_installation = item.get("with_installation", False)
                 installation_price = int(item.get("installation_price", 0))
@@ -1117,7 +1124,7 @@ class OrderService:
                     proposal_id=proposal.id,
                     product_id=product.id,
                     quantity=item["quantity"],
-                    price=product.price,
+                    price=storefront_unit_price,
                     cost=product_cost,
                     # Save snapshot for history
                     is_installation_included=with_installation,
@@ -1127,7 +1134,7 @@ class OrderService:
                 session.add(link)
                 
                 # Calculate product total
-                product_total = product.price * item["quantity"]
+                product_total = storefront_unit_price * item["quantity"]
                 total_amount += product_total
                 
                 # If installation requested, add to total

--- a/services/order_transfer_service.py
+++ b/services/order_transfer_service.py
@@ -132,7 +132,10 @@ class OrderTransferService:
         product = link.product
         return ManagerOrderTransferProductRef(
             source_id=product.id if product else link.product_id,
-            title=product.title if product else f"Товар #{link.product_id}",
+            title=(
+                getattr(link, "title_snapshot", None)
+                or (product.title if product else f"Товар #{link.product_id}")
+            ),
             slug=product.slug if product else None,
             source_url=product.source_url if product else None,
         )
@@ -153,6 +156,8 @@ class OrderTransferService:
         return ManagerOrderTransferProductLine(
             source_id=link.id,
             product=OrderTransferService._product_ref(link),
+            title_snapshot=getattr(link, "title_snapshot", None),
+            currency_snapshot=getattr(link, "currency_snapshot", None),
             quantity=int(link.quantity or 1),
             price=int(link.price or 0),
             cost=int(link.cost or 0),
@@ -683,6 +688,11 @@ class OrderTransferService:
                             product_id=int(resolved.product.id),
                             quantity=int(product_line.quantity or 1),
                             price=int(product_line.price or 0),
+                            title_snapshot=(
+                                product_line.title_snapshot
+                                or product_line.product.title
+                            ),
+                            currency_snapshot=product_line.currency_snapshot,
                             cost=int(product_line.cost or 0),
                             is_installation_included=bool(product_line.is_installation_included),
                             installation_price=int(product_line.installation_price or 0),

--- a/services/order_transfer_service.py
+++ b/services/order_transfer_service.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Optional
 
@@ -26,7 +25,6 @@ from models import (
     Payment,
     PaymentCurrency,
     PaymentType,
-    Product,
     Service,
 )
 from models.common import EquipmentStatus
@@ -40,26 +38,18 @@ from schemas import (
     ManagerOrderTransferOrder,
     ManagerOrderTransferPackage,
     ManagerOrderTransferPayment,
-    ManagerOrderTransferProductLine,
-    ManagerOrderTransferProductRef,
     ManagerOrderTransferProposal,
     ManagerOrderTransferServiceLine,
     ManagerOrderTransferServiceRef,
     ManagerOrderTransferWorkStage,
 )
+from services.order_product_transfer_service import OrderProductTransferService
 from services.order_service import OrderService
 from services.tenant_entity_access_service import TenantEntityAccessService
 from services.tenant_scope_service import (
     TenantScope,
     tenant_scope_clause,
 )
-
-
-@dataclass
-class _ResolvedProduct:
-    product: Optional[Product]
-    status: str
-    reason: Optional[str] = None
 
 
 class OrderTransferService:
@@ -128,19 +118,6 @@ class OrderTransferService:
         )
 
     @staticmethod
-    def _product_ref(link: OrderProductLink) -> ManagerOrderTransferProductRef:
-        product = link.product
-        return ManagerOrderTransferProductRef(
-            source_id=product.id if product else link.product_id,
-            title=(
-                getattr(link, "title_snapshot", None)
-                or (product.title if product else f"Товар #{link.product_id}")
-            ),
-            slug=product.slug if product else None,
-            source_url=product.source_url if product else None,
-        )
-
-    @staticmethod
     def _service_ref(link: OrderServiceLink) -> Optional[ManagerOrderTransferServiceRef]:
         if not link.service and not link.service_id:
             return None
@@ -149,22 +126,6 @@ class OrderTransferService:
             source_id=service.id if service else link.service_id,
             title=service.title if service else (link.title or f"Услуга #{link.service_id}"),
             slug=service.slug if service else None,
-        )
-
-    @staticmethod
-    def _product_line_snapshot(link: OrderProductLink) -> ManagerOrderTransferProductLine:
-        return ManagerOrderTransferProductLine(
-            source_id=link.id,
-            product=OrderTransferService._product_ref(link),
-            title_snapshot=getattr(link, "title_snapshot", None),
-            currency_snapshot=getattr(link, "currency_snapshot", None),
-            quantity=int(link.quantity or 1),
-            price=int(link.price or 0),
-            cost=int(link.cost or 0),
-            is_installation_included=bool(link.is_installation_included),
-            installation_price=int(link.installation_price or 0),
-            installation_details=link.installation_details,
-            logistics_components=OrderService._serialize_order_logistics_components(link.logistics_components),
         )
 
     @staticmethod
@@ -189,7 +150,10 @@ class OrderTransferService:
             is_selected=bool(proposal.is_selected),
             is_archived=bool(proposal.is_archived),
             sort_order=int(proposal.sort_order or 0),
-            product_lines=[OrderTransferService._product_line_snapshot(link) for link in product_lines],
+            product_lines=[
+                OrderProductTransferService.snapshot_line(link)
+                for link in product_lines
+            ],
             service_lines=[OrderTransferService._service_line_snapshot(link) for link in service_lines],
         )
 
@@ -384,37 +348,6 @@ class OrderTransferService:
         return None, "will_create"
 
     @staticmethod
-    async def _find_product(session: AsyncSession, product_ref: ManagerOrderTransferProductRef) -> _ResolvedProduct:
-        slug = OrderTransferService._optional_clean(product_ref.slug)
-        if slug:
-            result = await session.execute(select(Product).where(Product.slug == slug).limit(1))
-            product = result.scalars().first()
-            if product:
-                return _ResolvedProduct(product=product, status="matched", reason="slug")
-
-        source_url = OrderTransferService._optional_clean(product_ref.source_url)
-        if source_url:
-            result = await session.execute(select(Product).where(Product.source_url == source_url).limit(1))
-            product = result.scalars().first()
-            if product:
-                return _ResolvedProduct(product=product, status="matched", reason="source_url")
-
-        title = OrderTransferService._optional_clean(product_ref.title)
-        if title:
-            result = await session.execute(
-                select(Product)
-                .where(func.lower(Product.title) == title.lower())
-                .limit(2)
-            )
-            products = list(result.scalars().all())
-            if len(products) == 1:
-                return _ResolvedProduct(product=products[0], status="matched", reason="title")
-            if len(products) > 1:
-                return _ResolvedProduct(product=None, status="missing", reason="ambiguous_title")
-
-        return _ResolvedProduct(product=None, status="missing", reason="not_found")
-
-    @staticmethod
     async def _find_service(session: AsyncSession, service_ref: Optional[ManagerOrderTransferServiceRef]) -> Optional[Service]:
         if not service_ref:
             return None
@@ -467,19 +400,18 @@ class OrderTransferService:
             for proposal in order_data.proposals:
                 for product_line in proposal.product_lines:
                     products_total += 1
-                    resolved = await OrderTransferService._find_product(session, product_line.product)
+                    resolved = await OrderProductTransferService.resolve_product(
+                        session,
+                        product_line.product,
+                    )
                     if resolved.product:
                         products_matched += 1
                     product_matches.append(
-                        {
-                            "source_order_id": order_data.source_id,
-                            "product_title": product_line.product.title,
-                            "product_slug": product_line.product.slug,
-                            "matched_product_id": resolved.product.id if resolved.product else None,
-                            "matched_product_title": resolved.product.title if resolved.product else None,
-                            "status": resolved.status,
-                            "reason": resolved.reason,
-                        }
+                        OrderProductTransferService.preview_match(
+                            source_order_id=order_data.source_id,
+                            product_line=product_line,
+                            resolved=resolved,
+                        )
                     )
 
         products_missing = products_total - products_matched
@@ -678,29 +610,18 @@ class OrderTransferService:
                 await session.flush()
 
                 for product_line in proposal_data.product_lines:
-                    resolved = await OrderTransferService._find_product(session, product_line.product)
+                    resolved = await OrderProductTransferService.resolve_product(
+                        session,
+                        product_line.product,
+                    )
                     if not resolved.product:
                         raise ValueError(f"Product not found: {product_line.product.title}")
                     session.add(
-                        OrderProductLink(
+                        OrderProductTransferService.build_import_link(
                             order_id=int(order.id),
                             proposal_id=int(proposal.id),
-                            product_id=int(resolved.product.id),
-                            quantity=int(product_line.quantity or 1),
-                            price=int(product_line.price or 0),
-                            title_snapshot=(
-                                product_line.title_snapshot
-                                or product_line.product.title
-                            ),
-                            currency_snapshot=product_line.currency_snapshot,
-                            cost=int(product_line.cost or 0),
-                            is_installation_included=bool(product_line.is_installation_included),
-                            installation_price=int(product_line.installation_price or 0),
-                            installation_details=product_line.installation_details,
-                            logistics_components=[
-                                item.model_dump() if hasattr(item, "model_dump") else dict(item)
-                                for item in (product_line.logistics_components or [])
-                            ] or None,
+                            product_line=product_line,
+                            product=resolved.product,
                         )
                     )
 

--- a/services/product_collection_eligibility.py
+++ b/services/product_collection_eligibility.py
@@ -26,6 +26,7 @@ class ProductCollectionEligibility:
         surface_key: str,
         slot_key: str,
         supply_metrics: dict[str, Any],
+        price_override: int | None = None,
     ) -> ProductEligibilityResult:
         failures: list[tuple[str, str]] = []
         if not product.is_published:
@@ -43,7 +44,8 @@ class ProductCollectionEligibility:
                     "Для главной разрешены только готовые бытовые сплит-системы.",
                 )
             )
-        if int(product.price or 0) <= 0:
+        public_price = product.price if price_override is None else price_override
+        if int(public_price or 0) <= 0:
             failures.append(("missing_price", "Не задана корректная публичная цена."))
         if (surface_key, slot_key) != YANDEX_BUSINESS_PLACEMENT:
             if not str(product.main_image or "").strip():

--- a/services/product_collection_resolver.py
+++ b/services/product_collection_resolver.py
@@ -6,12 +6,15 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from crud.product import ProductDAO
 from crud.product_collection import ProductCollectionDAO
+from crud.public_catalog import PublicCatalogDAO
 from models import ProductCollection
+from models.tenancy import TenantScope
 from services.feature_resolver_service import FeatureResolverService
 from services.product_collection_eligibility import ProductCollectionEligibility
 from services.product_collection_rule_matcher import ProductCollectionRuleMatcher
 from services.product_read_service import ProductReadService
 from services.product_response_mapper import map_product_to_response
+from services.public_catalog_visibility_service import PublicCatalogVisibilityService
 
 
 def utc_now() -> datetime:
@@ -40,6 +43,8 @@ class ProductCollectionResolver:
         enforce_publication: bool,
         selection_source: str = "manual",
         visited_collection_ids: set[int] | None = None,
+        tenant_scope: TenantScope | None = None,
+        use_offer_projection: bool | None = None,
     ) -> dict:
         now = utc_now()
         if enforce_publication and (
@@ -58,6 +63,15 @@ class ProductCollectionResolver:
             return ProductCollectionResolver._empty_result(collection)
         visited.add(collection_id)
 
+        if use_offer_projection is None:
+            use_offer_projection = bool(
+                tenant_scope is not None
+                and not await PublicCatalogVisibilityService.is_canonical_scope(
+                    session,
+                    tenant_scope,
+                )
+            )
+
         item_rows = await ProductCollectionDAO.list_items(session, collection_id)
         manual_rows = (
             item_rows
@@ -67,12 +81,32 @@ class ProductCollectionResolver:
             else []
         )
         product_ids = [int(item.product_id) for item in manual_rows]
-        products = await ProductDAO.get_by_ids(
-            session,
-            product_ids,
-            load_image_variants=True,
-        )
-        product_map = {int(product.id): product for product in products}
+        if use_offer_projection and tenant_scope is not None:
+            scoped_rows = await PublicCatalogDAO.get_by_ids(
+                session,
+                tenant_scope=tenant_scope,
+                product_ids=product_ids,
+                load_image_variants=True,
+            )
+            projections = [
+                PublicCatalogVisibilityService.project_row(row)
+                for row in scoped_rows
+            ]
+        else:
+            products = await ProductDAO.get_by_ids(
+                session,
+                product_ids,
+                load_image_variants=True,
+            )
+            projections = [
+                PublicCatalogVisibilityService.project_product(product)
+                for product in products
+            ]
+        product_map = {
+            int(projection.product.id): projection
+            for projection in projections
+        }
+        products = [projection.product for projection in projections]
         if products:
             await FeatureResolverService.resolve_for_products(session, products)
         supply_metrics = await ProductReadService.get_supply_metrics_map(session, products)
@@ -80,8 +114,8 @@ class ProductCollectionResolver:
         selected: list[dict] = []
         excluded: list[dict] = []
         for item in manual_rows:
-            product = product_map.get(int(item.product_id))
-            if product is None:
+            projection = product_map.get(int(item.product_id))
+            if projection is None:
                 excluded.append(
                     {
                         "product_id": int(item.product_id),
@@ -92,12 +126,14 @@ class ProductCollectionResolver:
                     }
                 )
                 continue
+            product = projection.product
             metrics = supply_metrics.get(int(product.id), {})
             eligibility = ProductCollectionEligibility.evaluate(
                 product,
                 surface_key=surface_key,
                 slot_key=slot_key,
                 supply_metrics=metrics,
+                price_override=projection.price,
             )
             if not eligibility.is_eligible:
                 excluded.append(
@@ -117,6 +153,7 @@ class ProductCollectionResolver:
                     "product": map_product_to_response(
                         product,
                         supply_metrics=metrics,
+                        pricing=projection.pricing,
                     ),
                 }
             )
@@ -129,22 +166,43 @@ class ProductCollectionResolver:
             and len(selected) < collection.max_items
             and any(value not in (None, [], "") for value in rule_config.values())
         ):
-            automatic_products = await ProductDAO.get_filtered(
-                session,
-                area_min=rule_config.get("min_area_m2"),
-                area_max=rule_config.get("max_area_m2"),
-                min_price=rule_config.get("min_price"),
-                max_price=rule_config.get("max_price"),
-                is_inverter=rule_config.get("is_inverter"),
-                brand_ids=rule_config.get("brand_ids"),
-                series_ids=rule_config.get("series_ids"),
-                product_kinds=rule_config.get("product_kinds"),
-                is_published=True,
-                sort=collection.sort_mode,
-                page=1,
-                limit=500,
-                load_image_variants=True,
-            )
+            query = {
+                "area_min": rule_config.get("min_area_m2"),
+                "area_max": rule_config.get("max_area_m2"),
+                "min_price": rule_config.get("min_price"),
+                "max_price": rule_config.get("max_price"),
+                "is_inverter": rule_config.get("is_inverter"),
+                "brand_ids": rule_config.get("brand_ids"),
+                "series_ids": rule_config.get("series_ids"),
+                "product_kinds": rule_config.get("product_kinds"),
+                "sort": collection.sort_mode,
+                "page": 1,
+                "limit": 500,
+                "load_image_variants": True,
+            }
+            if use_offer_projection and tenant_scope is not None:
+                automatic_rows = await PublicCatalogDAO.get_filtered(
+                    session,
+                    tenant_scope=tenant_scope,
+                    **query,
+                )
+                automatic_projections = [
+                    PublicCatalogVisibilityService.project_row(row)
+                    for row in automatic_rows
+                ]
+            else:
+                automatic_products = await ProductDAO.get_filtered(
+                    session,
+                    is_published=True,
+                    **query,
+                )
+                automatic_projections = [
+                    PublicCatalogVisibilityService.project_product(product)
+                    for product in automatic_products
+                ]
+            automatic_products = [
+                projection.product for projection in automatic_projections
+            ]
             await FeatureResolverService.resolve_for_products(session, automatic_products)
             automatic_metrics = await ProductReadService.get_supply_metrics_map(
                 session,
@@ -154,7 +212,8 @@ class ProductCollectionResolver:
                 int(item["product"].id)
                 for item in selected
             }
-            for candidate_position, product in enumerate(automatic_products):
+            for candidate_position, projection in enumerate(automatic_projections):
+                product = projection.product
                 product_id = int(product.id)
                 if product_id in selected_ids:
                     continue
@@ -163,6 +222,7 @@ class ProductCollectionResolver:
                     product,
                     rule_config=rule_config,
                     supply_metrics=metrics,
+                    price_override=projection.price,
                 ):
                     continue
                 eligibility = ProductCollectionEligibility.evaluate(
@@ -170,6 +230,7 @@ class ProductCollectionResolver:
                     surface_key=surface_key,
                     slot_key=slot_key,
                     supply_metrics=metrics,
+                    price_override=projection.price,
                 )
                 if not eligibility.is_eligible:
                     if len(excluded) < 50:
@@ -194,6 +255,7 @@ class ProductCollectionResolver:
                         "product": map_product_to_response(
                             product,
                             supply_metrics=metrics,
+                            pricing=projection.pricing,
                         ),
                     }
                 )
@@ -216,6 +278,8 @@ class ProductCollectionResolver:
                     enforce_publication=enforce_publication,
                     selection_source="fallback",
                     visited_collection_ids=visited,
+                    tenant_scope=tenant_scope,
+                    use_offer_projection=use_offer_projection,
                 )
                 if not fallback_result["below_min_items"]:
                     return {
@@ -253,7 +317,15 @@ class ProductCollectionResolver:
         *,
         surface_key: str,
         slot_key: str,
+        tenant_scope: TenantScope | None = None,
     ) -> dict:
+        use_offer_projection = bool(
+            tenant_scope is not None
+            and not await PublicCatalogVisibilityService.is_canonical_scope(
+                session,
+                tenant_scope,
+            )
+        )
         rows = await ProductCollectionDAO.list_placements(
             session,
             surface_key=surface_key,
@@ -271,6 +343,8 @@ class ProductCollectionResolver:
                 surface_key=surface_key,
                 slot_key=slot_key,
                 enforce_publication=True,
+                tenant_scope=tenant_scope,
+                use_offer_projection=use_offer_projection,
             )
             if resolved["below_min_items"]:
                 continue

--- a/services/product_collection_rule_matcher.py
+++ b/services/product_collection_rule_matcher.py
@@ -41,13 +41,14 @@ class ProductCollectionRuleMatcher:
         *,
         rule_config: dict[str, Any],
         supply_metrics: dict[str, Any],
+        price_override: int | None = None,
     ) -> bool:
         specs = product.specs or {}
         product_kinds = set(rule_config.get("product_kinds") or [])
         if product_kinds and product.product_kind not in product_kinds:
             return False
 
-        price = int(product.price or 0)
+        price = int(product.price if price_override is None else price_override)
         if rule_config.get("min_price") is not None and price < int(rule_config["min_price"]):
             return False
         if rule_config.get("max_price") is not None and price > int(rule_config["max_price"]):

--- a/services/product_filter_service.py
+++ b/services/product_filter_service.py
@@ -63,6 +63,7 @@ class ProductFilterService:
             select(Tag)
             .join(TagGroup, Tag.group_id == TagGroup.id)
             .where(Tag.is_public == True)
+            .where(TagGroup.is_public == True)
             .where((TagGroup.slug == "expert-badge") | (TagGroup.is_expert_badge == True))
             .order_by(Tag.sort_order, Tag.title)
         )

--- a/services/product_read_service.py
+++ b/services/product_read_service.py
@@ -5,8 +5,10 @@ from typing import Any, Dict, Iterable, List, Optional
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
+from crud.canonical_public_catalog import CanonicalPublicCatalogDAO
 from crud.product import ProductDAO
-from models import Brand, Product
+from crud.public_taxonomy import PublicTaxonomyDAO
+from models import Product
 from services.product_dict_mapper import map_product_to_dict
 from services.product_filter_service import ProductFilterService
 from services.product_series_service import ProductSeriesService
@@ -74,21 +76,15 @@ class ProductReadService(ProductFilterService, ProductSeriesService):
         is_inverter: Optional[bool] = None,
         search: Optional[str] = None,
     ) -> Dict[str, Any]:
-        faceted_tag_ids = None
-        resolved_brand_slugs = list(brand_slugs or [])
-        facet_slugs = tag_slugs or []
-        if tag_slugs:
-            brand_rows = (
-                await session.execute(select(Brand.slug).where(Brand.slug.in_(tag_slugs)))
-            ).scalars().all()
-            legacy_brand_slugs = [slug for slug in brand_rows if slug]
-            resolved_brand_slugs.extend(legacy_brand_slugs)
-            brand_slug_set = set(legacy_brand_slugs)
-            facet_slugs = [slug for slug in tag_slugs if slug not in brand_slug_set]
-            faceted_tag_ids = await ProductReadService.resolve_slugs_to_grouped_ids(session, facet_slugs)
-        resolved_brand_slugs = list(dict.fromkeys(resolved_brand_slugs))
+        faceted_tag_ids, resolved_brand_slugs = (
+            await PublicTaxonomyDAO.resolve_filter_ids(
+                session,
+                tag_slugs=tag_slugs,
+                brand_slugs=brand_slugs,
+            )
+        )
 
-        items = await ProductDAO.get_filtered(
+        items = await CanonicalPublicCatalogDAO.get_filtered(
             session,
             area_min=area_min,
             area_max=area_max,
@@ -100,17 +96,15 @@ class ProductReadService(ProductFilterService, ProductSeriesService):
             color=color,
             indoor_types=indoor_types,
             is_inverter=is_inverter,
-            tag_slugs=None,
             brand_slugs=resolved_brand_slugs,
             faceted_tag_ids=faceted_tag_ids,
             sort=sort,
             page=page,
             limit=limit,
-            is_published=True,
             search_query=search,
             load_image_variants=True,
         )
-        total = await ProductDAO.count_filtered(
+        total = await CanonicalPublicCatalogDAO.count_filtered(
             session,
             area_min=area_min,
             area_max=area_max,
@@ -122,10 +116,8 @@ class ProductReadService(ProductFilterService, ProductSeriesService):
             color=color,
             indoor_types=indoor_types,
             is_inverter=is_inverter,
-            tag_slugs=None,
             brand_slugs=resolved_brand_slugs,
             faceted_tag_ids=faceted_tag_ids,
-            is_published=True,
             search_query=search,
         )
 

--- a/services/product_response_mapper.py
+++ b/services/product_response_mapper.py
@@ -20,6 +20,7 @@ from services.product_image_processing_contract import (
 )
 from services.product_series_payloads import build_product_series_response
 from services.product_serialization import parse_legacy_images, sanitize_specs
+from services.public_taxonomy_service import PublicTaxonomyService
 
 
 def _is_same_image_url(left: Optional[str], right: Optional[str]) -> bool:
@@ -153,7 +154,7 @@ def map_product_to_response(
 ) -> ProductResponse:
     tags_payload = []
     if product.tags:
-        for tag in product.tags:
+        for tag in PublicTaxonomyService.visible_tags(product.tags):
             group = None
             if tag.group:
                 group = TagGroupResponse(

--- a/services/product_response_mapper.py
+++ b/services/product_response_mapper.py
@@ -217,7 +217,8 @@ def map_product_to_response(
             )
         )
 
-    series = product.series if product.series_id else None
+    public_brand = PublicTaxonomyService.public_brand(product)
+    series = PublicTaxonomyService.public_series(product)
     series_payload = build_product_series_response(series)
 
     manuals_payload = []
@@ -267,12 +268,12 @@ def map_product_to_response(
         delivery_max_days=delivery_max_days,
         brand=(
             ProductBrandResponse(
-                id=product.brand.id,
-                title=product.brand.title,
-                slug=product.brand.slug,
-                logo_url=product.brand.logo_url,
+                id=public_brand.id,
+                title=public_brand.title,
+                slug=public_brand.slug,
+                logo_url=public_brand.logo_url,
             )
-            if product.brand
+            if public_brand
             else None
         ),
         series=series_payload,

--- a/services/product_response_mapper.py
+++ b/services/product_response_mapper.py
@@ -1,6 +1,6 @@
 """Helpers to map Product domain models into public API DTOs."""
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Mapping, Optional
 
 from core.input_validation import validate_public_manual_url
 from models import Product
@@ -148,6 +148,8 @@ def map_product_to_response(
     product: Product,
     series_siblings: Optional[List[Product]] = None,
     supply_metrics: Optional[Dict[str, Any]] = None,
+    pricing: tuple[int, int | None] | None = None,
+    sibling_pricing: Mapping[int, tuple[int, int | None]] | None = None,
 ) -> ProductResponse:
     tags_payload = []
     if product.tags:
@@ -193,19 +195,26 @@ def map_product_to_response(
                 )
             )
 
-    siblings_payload = [
-        ProductSiblingResponse(
-            id=item.id,
-            title=item.title,
-            slug=item.slug,
-            price=item.price,
-            old_price=item.old_price,
-            specs=sanitize_specs(item.specs),
-            is_inverter=item.is_inverter,
-            main_image=item.main_image,
+    siblings_payload = []
+    for item in series_siblings or []:
+        item_pricing = (sibling_pricing or {}).get(int(item.id or 0))
+        item_price, item_old_price = (
+            item_pricing
+            if item_pricing is not None
+            else (item.price, item.old_price)
         )
-        for item in (series_siblings or [])
-    ]
+        siblings_payload.append(
+            ProductSiblingResponse(
+                id=item.id,
+                title=item.title,
+                slug=item.slug,
+                price=item_price,
+                old_price=item_old_price,
+                specs=sanitize_specs(item.specs),
+                is_inverter=item.is_inverter,
+                main_image=item.main_image,
+            )
+        )
 
     series = product.series if product.series_id else None
     series_payload = build_product_series_response(series)
@@ -233,12 +242,14 @@ def map_product_to_response(
         availability_status
     )
 
+    public_price, public_old_price = pricing or (product.price, product.old_price)
+
     return ProductResponse(
         id=product.id,
         title=product.title,
         slug=product.slug,
-        price=product.price,
-        old_price=product.old_price,
+        price=public_price,
+        old_price=public_old_price,
         product_kind=product.product_kind,
         is_inverter=product.is_inverter,
         power_cooling=product.power_cooling,

--- a/services/product_series_service.py
+++ b/services/product_series_service.py
@@ -16,6 +16,7 @@ from schemas import (
 from services.product_series_payloads import build_product_series_response
 from services.product_area import area_from_specs
 from services.product_serialization import sanitize_specs
+from services.public_taxonomy_service import PublicTaxonomyService
 
 
 class ProductSeriesService:
@@ -28,11 +29,13 @@ class ProductSeriesService:
             else:
                 reference_brand_ids = {
                     tag.id for tag in (reference.tags or [])
-                    if tag.group and tag.group.slug == "brand"
+                    if PublicTaxonomyService.is_public_tag(tag)
+                    and tag.group.slug == "brand"
                 }
                 item_brand_ids = {
                     tag.id for tag in (item.tags or [])
-                    if tag.group and tag.group.slug == "brand"
+                    if PublicTaxonomyService.is_public_tag(tag)
+                    and tag.group.slug == "brand"
                 }
                 same_brand = 0 if (reference_brand_ids and item_brand_ids.intersection(reference_brand_ids)) else 1
 
@@ -82,7 +85,9 @@ class ProductSeriesService:
         keys = [
             f"tag:{tag.id}"
             for tag in (product.tags or [])
-            if tag.id and tag.group and tag.group.slug == "series"
+            if tag.id
+            and PublicTaxonomyService.is_public_tag(tag)
+            and tag.group.slug == "series"
         ]
 
         specs = product.specs if isinstance(product.specs, dict) else {}
@@ -108,7 +113,8 @@ class ProductSeriesService:
             series_tag_ids = [
                 tag.id
                 for tag in (product.tags or [])
-                if tag.group and tag.group.slug == "series"
+                if PublicTaxonomyService.is_public_tag(tag)
+                and tag.group.slug == "series"
             ]
             if not series_tag_ids:
                 return []

--- a/services/product_series_service.py
+++ b/services/product_series_service.py
@@ -22,10 +22,13 @@ from services.public_taxonomy_service import PublicTaxonomyService
 class ProductSeriesService:
     @staticmethod
     def _sort_series_candidates(reference: Product, candidates: List[Product]) -> List[Product]:
+        reference_brand = PublicTaxonomyService.public_brand(reference)
+
         def score(item: Product) -> tuple[int, float, float, float, str, int]:
             same_brand = 1
-            if reference.brand_id and item.brand_id:
-                same_brand = 0 if reference.brand_id == item.brand_id else 1
+            item_brand = PublicTaxonomyService.public_brand(item)
+            if reference_brand is not None and item_brand is not None:
+                same_brand = 0 if reference_brand.id == item_brand.id else 1
             else:
                 reference_brand_ids = {
                     tag.id for tag in (reference.tags or [])
@@ -74,13 +77,14 @@ class ProductSeriesService:
 
     @staticmethod
     def _series_payload(product: Product) -> ProductSeriesResponse | None:
-        series = product.series if product.series_id else None
+        series = PublicTaxonomyService.public_series(product)
         return build_product_series_response(series)
 
     @staticmethod
     def _series_group_keys(product: Product) -> List[str]:
-        if product.series_id:
-            return [f"series:{product.series_id}"]
+        series = PublicTaxonomyService.public_series(product)
+        if series is not None and getattr(series, "id", None):
+            return [f"series:{series.id}"]
 
         keys = [
             f"tag:{tag.id}"
@@ -107,8 +111,9 @@ class ProductSeriesService:
     ) -> List[Product]:
         stmt = select(Product).where(Product.id != product.id).where(Product.is_published == True)
 
-        if product.series_id:
-            stmt = stmt.where(Product.series_id == product.series_id)
+        series = PublicTaxonomyService.public_series(product)
+        if series is not None and series.id is not None:
+            stmt = stmt.where(Product.series_id == series.id)
         else:
             series_tag_ids = [
                 tag.id
@@ -127,7 +132,10 @@ class ProductSeriesService:
             )
             stmt = stmt.join(series_product_ids, Product.id == series_product_ids.c.product_id)
 
-        stmt = stmt.options(selectinload(Product.tags).selectinload(Tag.group))
+        stmt = stmt.options(
+            selectinload(Product.brand),
+            selectinload(Product.tags).selectinload(Tag.group),
+        )
         candidates = list((await session.execute(stmt)).scalars().all())
         return ProductSeriesService._sort_series_candidates(product, candidates)[:limit]
 
@@ -140,6 +148,7 @@ class ProductSeriesService:
             select(Product)
             .where(Product.is_published == True)
             .options(
+                selectinload(Product.brand),
                 selectinload(Product.series)
                 .selectinload(ProductSeries.feature_links)
                 .selectinload(FeatureSeriesLink.feature),

--- a/services/public_catalog_service.py
+++ b/services/public_catalog_service.py
@@ -6,12 +6,12 @@ from dataclasses import dataclass
 from typing import Any, Optional
 
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlmodel import select
 
 from api_contracts.public_catalog import PublicProductSearchItemResponse
+from crud.canonical_public_catalog import CanonicalPublicCatalogDAO
 from crud.product import ProductDAO
 from crud.public_catalog import PublicCatalogDAO
-from models import Brand
+from crud.public_taxonomy import PublicTaxonomyDAO
 from models.tenancy import TenantScope
 from schemas import (
     ProductSeriesNavigationItemResponse,
@@ -31,6 +31,7 @@ from services.public_catalog_visibility_service import (
     PublicCatalogVisibilityService,
     PublicProductProjection,
 )
+from services.public_taxonomy_service import PublicTaxonomyService
 from services.tag_logic import is_invalid_brand_name, is_invalid_brand_slug
 
 
@@ -47,21 +48,11 @@ class PublicCatalogService:
         tag_slugs: Optional[list[str]],
         brand_slugs: Optional[list[str]],
     ) -> tuple[dict[int, list[int]] | None, list[str]]:
-        faceted_tag_ids = None
-        resolved_brand_slugs = list(brand_slugs or [])
-        if tag_slugs:
-            brand_rows = (
-                await session.execute(select(Brand.slug).where(Brand.slug.in_(tag_slugs)))
-            ).scalars().all()
-            legacy_brand_slugs = [slug for slug in brand_rows if slug]
-            resolved_brand_slugs.extend(legacy_brand_slugs)
-            brand_slug_set = set(legacy_brand_slugs)
-            facet_slugs = [slug for slug in tag_slugs if slug not in brand_slug_set]
-            faceted_tag_ids = await ProductReadService.resolve_slugs_to_grouped_ids(
-                session,
-                facet_slugs,
-            )
-        return faceted_tag_ids, list(dict.fromkeys(resolved_brand_slugs))
+        return await PublicTaxonomyDAO.resolve_filter_ids(
+            session,
+            tag_slugs=tag_slugs,
+            brand_slugs=brand_slugs,
+        )
 
     @staticmethod
     async def get_catalog_page(
@@ -279,11 +270,10 @@ class PublicCatalogService:
             session,
             tenant_scope,
         ):
-            products = await ProductDAO.get_filtered(
+            products = await CanonicalPublicCatalogDAO.get_filtered(
                 session,
                 is_inverter=is_inverter,
                 search_query=(query or "").strip() or None,
-                is_published=True,
                 limit=max(limit, 1),
                 page=1,
                 sort="recommended",
@@ -448,12 +438,14 @@ class PublicCatalogService:
                 reference_brand_ids = {
                     tag.id
                     for tag in (reference_product.tags or [])
-                    if tag.group and tag.group.slug == "brand"
+                    if PublicTaxonomyService.is_public_tag(tag)
+                    and tag.group.slug == "brand"
                 }
                 product_brand_ids = {
                     tag.id
                     for tag in (product.tags or [])
-                    if tag.group and tag.group.slug == "brand"
+                    if PublicTaxonomyService.is_public_tag(tag)
+                    and tag.group.slug == "brand"
                 }
                 same_brand = (
                     0

--- a/services/public_catalog_service.py
+++ b/services/public_catalog_service.py
@@ -419,6 +419,7 @@ class PublicCatalogService:
         candidates: list[PublicProductProjection],
     ) -> list[PublicProductProjection]:
         reference_product = reference.product
+        reference_brand = PublicTaxonomyService.public_brand(reference_product)
 
         def numeric(value) -> float:
             if value is None:
@@ -432,8 +433,9 @@ class PublicCatalogService:
         def score(item: PublicProductProjection):
             product = item.product
             same_brand = 1
-            if reference_product.brand_id and product.brand_id:
-                same_brand = 0 if reference_product.brand_id == product.brand_id else 1
+            product_brand = PublicTaxonomyService.public_brand(product)
+            if reference_brand is not None and product_brand is not None:
+                same_brand = 0 if reference_brand.id == product_brand.id else 1
             else:
                 reference_brand_ids = {
                     tag.id
@@ -521,7 +523,7 @@ class PublicCatalogService:
             )[:limit_per_product]
             payload[product.slug] = ProductSeriesNavigationItemResponse(
                 series=build_product_series_response(
-                    product.series if product.series_id else None
+                    PublicTaxonomyService.public_series(product)
                 ),
                 series_siblings=[
                     ProductSiblingResponse(

--- a/services/public_catalog_service.py
+++ b/services/public_catalog_service.py
@@ -1,0 +1,548 @@
+"""Public catalog projection selected by a trusted storefront scope."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from api_contracts.public_catalog import PublicProductSearchItemResponse
+from crud.product import ProductDAO
+from crud.public_catalog import PublicCatalogDAO
+from models import Brand
+from models.tenancy import TenantScope
+from schemas import (
+    ProductSeriesNavigationItemResponse,
+    ProductSeriesNavigationResponse,
+    ProductSiblingResponse,
+)
+from services.catalog import CatalogService
+from services.feature_resolver_service import FeatureResolverService
+from services.product_area import area_from_specs
+from services.product_filter_service import ProductFilterService
+from services.product_read_service import ProductReadService
+from services.product_response_mapper import map_product_to_response
+from services.product_series_service import ProductSeriesService
+from services.product_series_payloads import build_product_series_response
+from services.product_serialization import sanitize_specs
+from services.public_catalog_visibility_service import (
+    PublicCatalogVisibilityService,
+    PublicProductProjection,
+)
+from services.tag_logic import is_invalid_brand_name, is_invalid_brand_slug
+
+
+@dataclass(frozen=True)
+class PublicProductPage:
+    product: PublicProductProjection
+    siblings: list[PublicProductProjection]
+
+
+class PublicCatalogService:
+    @staticmethod
+    async def _resolve_filter_ids(
+        session: AsyncSession,
+        tag_slugs: Optional[list[str]],
+        brand_slugs: Optional[list[str]],
+    ) -> tuple[dict[int, list[int]] | None, list[str]]:
+        faceted_tag_ids = None
+        resolved_brand_slugs = list(brand_slugs or [])
+        if tag_slugs:
+            brand_rows = (
+                await session.execute(select(Brand.slug).where(Brand.slug.in_(tag_slugs)))
+            ).scalars().all()
+            legacy_brand_slugs = [slug for slug in brand_rows if slug]
+            resolved_brand_slugs.extend(legacy_brand_slugs)
+            brand_slug_set = set(legacy_brand_slugs)
+            facet_slugs = [slug for slug in tag_slugs if slug not in brand_slug_set]
+            faceted_tag_ids = await ProductReadService.resolve_slugs_to_grouped_ids(
+                session,
+                facet_slugs,
+            )
+        return faceted_tag_ids, list(dict.fromkeys(resolved_brand_slugs))
+
+    @staticmethod
+    async def get_catalog_page(
+        session: AsyncSession,
+        *,
+        tenant_scope: TenantScope,
+        page: int = 1,
+        limit: int = 20,
+        sort: str = "recommended",
+        min_price: Optional[int] = None,
+        max_price: Optional[int] = None,
+        area_min: Optional[int] = None,
+        area_max: Optional[int] = None,
+        heating_min: Optional[int] = None,
+        has_wifi: Optional[bool] = None,
+        has_fresh_air: Optional[bool] = None,
+        color: Optional[str] = None,
+        indoor_types: Optional[list[str]] = None,
+        tag_slugs: Optional[list[str]] = None,
+        brand_slugs: Optional[list[str]] = None,
+        is_inverter: Optional[bool] = None,
+        search: Optional[str] = None,
+    ) -> dict[str, Any]:
+        if await PublicCatalogVisibilityService.is_canonical_scope(
+            session,
+            tenant_scope,
+        ):
+            payload = await ProductReadService.get_catalog_page(
+                session,
+                page=page,
+                limit=limit,
+                sort=sort,
+                min_price=min_price,
+                max_price=max_price,
+                area_min=area_min,
+                area_max=area_max,
+                heating_min=heating_min,
+                has_wifi=has_wifi,
+                has_fresh_air=has_fresh_air,
+                color=color,
+                indoor_types=indoor_types,
+                tag_slugs=tag_slugs,
+                brand_slugs=brand_slugs,
+                is_inverter=is_inverter,
+                search=search,
+            )
+            return {
+                "items": [
+                    PublicCatalogVisibilityService.project_product(product)
+                    for product in payload["items"]
+                ],
+                "meta": payload["meta"],
+            }
+
+        faceted_tag_ids, resolved_brand_slugs = await PublicCatalogService._resolve_filter_ids(
+            session,
+            tag_slugs,
+            brand_slugs,
+        )
+        query = {
+            "tenant_scope": tenant_scope,
+            "area_min": area_min,
+            "area_max": area_max,
+            "min_price": min_price,
+            "max_price": max_price,
+            "heating_min": heating_min,
+            "has_wifi": has_wifi,
+            "has_fresh_air": has_fresh_air,
+            "color": color,
+            "indoor_types": indoor_types,
+            "is_inverter": is_inverter,
+            "brand_slugs": resolved_brand_slugs,
+            "faceted_tag_ids": faceted_tag_ids,
+            "search_query": search,
+        }
+        rows = await PublicCatalogDAO.get_filtered(
+            session,
+            **query,
+            sort=sort,
+            page=page,
+            limit=limit,
+            load_image_variants=True,
+        )
+        total = await PublicCatalogDAO.count_filtered(session, **query)
+        return {
+            "items": [
+                PublicCatalogVisibilityService.project_row(row) for row in rows
+            ],
+            "meta": {
+                "total": total,
+                "page": page,
+                "limit": limit,
+                "pages": (total + limit - 1) // limit if limit > 0 else 0,
+            },
+        }
+
+    @staticmethod
+    async def get_product_page(
+        session: AsyncSession,
+        *,
+        tenant_scope: TenantScope,
+        identifier: str,
+        sibling_limit: int = 8,
+    ) -> PublicProductPage | None:
+        if await PublicCatalogVisibilityService.is_canonical_scope(
+            session,
+            tenant_scope,
+        ):
+            product = await ProductReadService.get_public_product_by_identifier(
+                session,
+                identifier,
+            )
+            if product is None:
+                return None
+            siblings = await ProductSeriesService.get_series_siblings(
+                session,
+                product,
+                limit=sibling_limit,
+            )
+            return PublicProductPage(
+                product=PublicCatalogVisibilityService.project_product(product),
+                siblings=[
+                    PublicCatalogVisibilityService.project_product(sibling)
+                    for sibling in siblings
+                ],
+            )
+
+        row = await PublicCatalogDAO.get_by_identifier(
+            session,
+            tenant_scope=tenant_scope,
+            identifier=identifier,
+        )
+        if row is None:
+            return None
+        projection = PublicCatalogVisibilityService.project_row(row)
+        visible_rows = await PublicCatalogDAO.get_series_siblings(
+            session,
+            tenant_scope=tenant_scope,
+            product=projection.product,
+        )
+        ordered = PublicCatalogService._sort_series_projections(
+            projection,
+            [
+                PublicCatalogVisibilityService.project_row(candidate)
+                for candidate in visible_rows
+            ],
+        )[:sibling_limit]
+        return PublicProductPage(product=projection, siblings=ordered)
+
+    @staticmethod
+    async def get_vitebsk_featured_products(
+        session: AsyncSession,
+        *,
+        tenant_scope: TenantScope,
+        limit: int = 6,
+    ) -> list[PublicProductProjection]:
+        if await PublicCatalogVisibilityService.is_canonical_scope(
+            session,
+            tenant_scope,
+        ):
+            products = await CatalogService.get_vitebsk_featured_products(
+                session,
+                limit=limit,
+            )
+            return [
+                PublicCatalogVisibilityService.project_product(item)
+                for item in products
+            ]
+        rows = await PublicCatalogDAO.get_vitebsk_featured(
+            session,
+            tenant_scope=tenant_scope,
+            limit=limit,
+        )
+        return [PublicCatalogVisibilityService.project_row(row) for row in rows]
+
+    @staticmethod
+    async def get_products_by_series_id(
+        session: AsyncSession,
+        *,
+        tenant_scope: TenantScope,
+        series_id: int,
+        load_image_variants: bool = True,
+    ) -> list[PublicProductProjection]:
+        if await PublicCatalogVisibilityService.is_canonical_scope(
+            session,
+            tenant_scope,
+        ):
+            products = await ProductDAO.get_published_by_series_id(
+                session,
+                series_id,
+                load_image_variants=load_image_variants,
+            )
+            return [
+                PublicCatalogVisibilityService.project_product(item)
+                for item in products
+            ]
+        rows = await PublicCatalogDAO.get_by_series_id(
+            session,
+            tenant_scope=tenant_scope,
+            series_id=series_id,
+            load_image_variants=load_image_variants,
+        )
+        return [PublicCatalogVisibilityService.project_row(row) for row in rows]
+
+    @staticmethod
+    async def search(
+        session: AsyncSession,
+        *,
+        tenant_scope: TenantScope,
+        query: str | None,
+        is_inverter: bool | None,
+        limit: int = 10,
+    ) -> list[PublicProductSearchItemResponse]:
+        if await PublicCatalogVisibilityService.is_canonical_scope(
+            session,
+            tenant_scope,
+        ):
+            products = await ProductDAO.get_filtered(
+                session,
+                is_inverter=is_inverter,
+                search_query=(query or "").strip() or None,
+                is_published=True,
+                limit=max(limit, 1),
+                page=1,
+                sort="recommended",
+                load_image_variants=True,
+            )
+            projections = [
+                PublicCatalogVisibilityService.project_product(product)
+                for product in products
+            ]
+        else:
+            rows = await PublicCatalogDAO.get_filtered(
+                session,
+                tenant_scope=tenant_scope,
+                is_inverter=is_inverter,
+                search_query=(query or "").strip() or None,
+                limit=max(limit, 1),
+                page=1,
+                sort="recommended",
+                load_image_variants=True,
+            )
+            projections = [
+                PublicCatalogVisibilityService.project_row(row) for row in rows
+            ]
+
+        supply_metrics = await ProductReadService.get_supply_metrics_map(
+            session,
+            [projection.product for projection in projections],
+        )
+        return [
+            PublicCatalogService._to_public_search_item(
+                projection,
+                supply_metrics.get(int(projection.product.id or 0), {}),
+            )
+            for projection in projections[:limit]
+        ]
+
+    @staticmethod
+    def _to_public_search_item(
+        projection: PublicProductProjection,
+        supply_metrics: dict[str, Any],
+    ) -> PublicProductSearchItemResponse:
+        mapped = map_product_to_response(
+            projection.product,
+            supply_metrics=supply_metrics,
+            pricing=projection.pricing,
+        )
+        return PublicProductSearchItemResponse(
+            id=mapped.id,
+            title=mapped.title,
+            slug=mapped.slug,
+            price=mapped.price,
+            old_price=mapped.old_price,
+            product_kind=mapped.product_kind,
+            is_inverter=mapped.is_inverter,
+            power_cooling=mapped.power_cooling,
+            main_image=mapped.main_image,
+            card_image=mapped.card_image,
+            full_image=mapped.full_image,
+            specs=mapped.specs,
+            vitebsk_qty=mapped.vitebsk_qty,
+            minsk_qty=mapped.minsk_qty,
+            availability_status=mapped.availability_status,
+            public_stock_state=mapped.public_stock_state,
+            delivery_min_days=mapped.delivery_min_days,
+            delivery_max_days=mapped.delivery_max_days,
+        )
+
+    @staticmethod
+    async def get_filters_config(
+        session: AsyncSession,
+        *,
+        tenant_scope: TenantScope,
+    ) -> dict[str, Any]:
+        if await PublicCatalogVisibilityService.is_canonical_scope(
+            session,
+            tenant_scope,
+        ):
+            return await ProductFilterService.get_filters_config(session)
+
+        price_min, price_max, area_min, area_max, brands = (
+            await PublicCatalogDAO.get_filter_stats(
+                session,
+                tenant_scope=tenant_scope,
+            )
+        )
+        expert_tags = await PublicCatalogDAO.list_expert_tags(
+            session,
+            tenant_scope=tenant_scope,
+        )
+        brands = [
+            brand
+            for brand in brands
+            if not is_invalid_brand_name(brand.title)
+            and not is_invalid_brand_slug(brand.slug)
+        ]
+        return {
+            "price": {"min": price_min, "max": price_max},
+            "area": {"min": area_min, "max": area_max},
+            "brands": [
+                {
+                    "id": brand.id,
+                    "title": brand.title,
+                    "slug": brand.slug,
+                    "logo_url": brand.logo_url,
+                    "sort_order": brand.sort_order,
+                }
+                for brand in brands
+            ],
+            "expert_tags": [
+                {"id": tag.id, "title": tag.title, "slug": tag.slug}
+                for tag in expert_tags
+            ],
+        }
+
+    @staticmethod
+    async def get_public_spec_keys(
+        session: AsyncSession,
+        *,
+        tenant_scope: TenantScope,
+    ) -> dict[str, Any]:
+        if await PublicCatalogVisibilityService.is_canonical_scope(
+            session,
+            tenant_scope,
+        ):
+            return await ProductReadService.get_public_spec_keys(session)
+        all_specs = await PublicCatalogDAO.get_public_specs(
+            session,
+            tenant_scope=tenant_scope,
+        )
+        stats: dict[str, int] = {}
+        for spec_dict in all_specs:
+            if not spec_dict:
+                continue
+            for key in spec_dict:
+                if str(key).startswith("__"):
+                    continue
+                stats[key] = stats.get(key, 0) + 1
+        return {"keys": sorted(stats), "total_products_using": stats}
+
+    @staticmethod
+    def _sort_series_projections(
+        reference: PublicProductProjection,
+        candidates: list[PublicProductProjection],
+    ) -> list[PublicProductProjection]:
+        reference_product = reference.product
+
+        def numeric(value) -> float:
+            if value is None:
+                return float("inf")
+            try:
+                number = float(value)
+            except (TypeError, ValueError):
+                return float("inf")
+            return number if number > 0 else float("inf")
+
+        def score(item: PublicProductProjection):
+            product = item.product
+            same_brand = 1
+            if reference_product.brand_id and product.brand_id:
+                same_brand = 0 if reference_product.brand_id == product.brand_id else 1
+            else:
+                reference_brand_ids = {
+                    tag.id
+                    for tag in (reference_product.tags or [])
+                    if tag.group and tag.group.slug == "brand"
+                }
+                product_brand_ids = {
+                    tag.id
+                    for tag in (product.tags or [])
+                    if tag.group and tag.group.slug == "brand"
+                }
+                same_brand = (
+                    0
+                    if reference_brand_ids
+                    and product_brand_ids.intersection(reference_brand_ids)
+                    else 1
+                )
+            return (
+                same_brand,
+                numeric(area_from_specs(product.specs)),
+                numeric(product.power_cooling),
+                numeric(item.price),
+                (product.title or "").casefold(),
+                product.id or 0,
+            )
+
+        return sorted(candidates, key=score)
+
+    @staticmethod
+    async def get_series_navigation(
+        session: AsyncSession,
+        *,
+        tenant_scope: TenantScope,
+        limit_per_product: int = 8,
+    ) -> ProductSeriesNavigationResponse:
+        if await PublicCatalogVisibilityService.is_canonical_scope(
+            session,
+            tenant_scope,
+        ):
+            return await ProductSeriesService.get_series_navigation(
+                session,
+                limit_per_product=limit_per_product,
+            )
+
+        rows = await PublicCatalogDAO.get_all(
+            session,
+            tenant_scope=tenant_scope,
+        )
+        projections = [
+            PublicCatalogVisibilityService.project_row(row) for row in rows
+        ]
+        products = [projection.product for projection in projections]
+        await FeatureResolverService.resolve_for_products(session, products)
+
+        product_group_keys: dict[int, list[str]] = {}
+        groups: dict[str, list[PublicProductProjection]] = {}
+        for projection in projections:
+            product = projection.product
+            if not product.id:
+                continue
+            keys = ProductSeriesService._series_group_keys(product)
+            product_group_keys[int(product.id)] = keys
+            for key in keys:
+                groups.setdefault(key, []).append(projection)
+
+        payload: dict[str, ProductSeriesNavigationItemResponse] = {}
+        for projection in projections:
+            product = projection.product
+            if not product.id or not product.slug:
+                continue
+            group_keys = product_group_keys.get(int(product.id), [])
+            if not group_keys:
+                continue
+            siblings_by_id: dict[int, PublicProductProjection] = {}
+            for key in group_keys:
+                for candidate in groups.get(key, []):
+                    candidate_id = int(candidate.product.id or 0)
+                    if candidate_id and candidate_id != product.id:
+                        siblings_by_id[candidate_id] = candidate
+            siblings = PublicCatalogService._sort_series_projections(
+                projection,
+                list(siblings_by_id.values()),
+            )[:limit_per_product]
+            payload[product.slug] = ProductSeriesNavigationItemResponse(
+                series=build_product_series_response(
+                    product.series if product.series_id else None
+                ),
+                series_siblings=[
+                    ProductSiblingResponse(
+                        id=item.product.id,
+                        title=item.product.title,
+                        slug=item.product.slug,
+                        price=item.price,
+                        old_price=item.old_price,
+                        specs=sanitize_specs(item.product.specs),
+                        is_inverter=item.product.is_inverter,
+                        main_image=item.product.main_image,
+                    )
+                    for item in siblings
+                ],
+            )
+        return ProductSeriesNavigationResponse(products=payload)

--- a/services/public_catalog_visibility_service.py
+++ b/services/public_catalog_visibility_service.py
@@ -1,0 +1,109 @@
+"""Single visibility and pricing boundary for every public product surface."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from crud.product import ProductDAO
+from crud.public_catalog import PublicCatalogDAO, PublicCatalogRow
+from crud.public_catalog_checkout import PublicCatalogCheckoutDAO
+from models import Product
+from models.tenancy import TenantScope
+from services.tenant_scope_service import SystemTenantScopeResolver
+
+
+@dataclass(frozen=True)
+class PublicProductProjection:
+    product: Product
+    price: int
+    old_price: int | None
+
+    @property
+    def pricing(self) -> tuple[int, int | None]:
+        return self.price, self.old_price
+
+
+class PublicCatalogVisibilityService:
+    """Canonical MVN sees published products; other storefronts need an offer."""
+
+    @staticmethod
+    async def is_canonical_scope(
+        session: AsyncSession,
+        tenant_scope: TenantScope,
+    ) -> bool:
+        if tenant_scope.is_canonical_storefront is not None:
+            return tenant_scope.is_canonical_storefront
+        canonical = await SystemTenantScopeResolver.resolve(session)
+        return (
+            tenant_scope.tenant_id == canonical.tenant_id
+            and tenant_scope.storefront_id == canonical.storefront_id
+        )
+
+    @staticmethod
+    def project_row(row: PublicCatalogRow) -> PublicProductProjection:
+        product, price, old_price = row
+        return PublicProductProjection(
+            product=product,
+            price=price,
+            old_price=old_price,
+        )
+
+    @staticmethod
+    def project_product(product: Product) -> PublicProductProjection:
+        return PublicProductProjection(
+            product=product,
+            price=int(product.price),
+            old_price=(int(product.old_price) if product.old_price is not None else None),
+        )
+
+    @classmethod
+    async def get_visible_product_by_id(
+        cls,
+        session: AsyncSession,
+        *,
+        tenant_scope: TenantScope,
+        product_id: int,
+    ) -> PublicProductProjection | None:
+        if await cls.is_canonical_scope(session, tenant_scope):
+            product = await ProductDAO.get_by_id(
+                session,
+                product_id,
+                is_published=True,
+            )
+            if product is None:
+                return None
+            return cls.project_product(product)
+
+        rows = await PublicCatalogDAO.get_by_ids(
+            session,
+            tenant_scope=tenant_scope,
+            product_ids=[product_id],
+        )
+        return cls.project_row(rows[0]) if rows else None
+
+    @classmethod
+    async def get_checkout_prices(
+        cls,
+        session: AsyncSession,
+        *,
+        tenant_scope: TenantScope,
+        product_ids: set[int],
+    ) -> tuple[dict[int, int], str]:
+        if await cls.is_canonical_scope(session, tenant_scope):
+            return (
+                await PublicCatalogCheckoutDAO.get_shared_prices_by_ids(
+                    session,
+                    product_ids=product_ids,
+                ),
+                "shared_product",
+            )
+        return (
+            await PublicCatalogCheckoutDAO.get_offer_prices_by_ids(
+                session,
+                tenant_scope=tenant_scope,
+                product_ids=product_ids,
+            ),
+            "tenant_offer",
+        )

--- a/services/public_catalog_visibility_service.py
+++ b/services/public_catalog_visibility_service.py
@@ -11,6 +11,7 @@ from crud.public_catalog import PublicCatalogDAO, PublicCatalogRow
 from crud.public_catalog_checkout import PublicCatalogCheckoutDAO
 from models import Product
 from models.tenancy import TenantScope
+from services.order_product_link_command import OrderProductCatalogSnapshot
 from services.tenant_scope_service import SystemTenantScopeResolver
 
 
@@ -84,26 +85,34 @@ class PublicCatalogVisibilityService:
         return cls.project_row(rows[0]) if rows else None
 
     @classmethod
-    async def get_checkout_prices(
+    async def get_checkout_snapshots(
         cls,
         session: AsyncSession,
         *,
         tenant_scope: TenantScope,
         product_ids: set[int],
-    ) -> tuple[dict[int, int], str]:
+    ) -> dict[int, OrderProductCatalogSnapshot]:
         if await cls.is_canonical_scope(session, tenant_scope):
-            return (
-                await PublicCatalogCheckoutDAO.get_shared_prices_by_ids(
-                    session,
-                    product_ids=product_ids,
-                ),
-                "shared_product",
-            )
-        return (
-            await PublicCatalogCheckoutDAO.get_offer_prices_by_ids(
+            rows = await PublicCatalogCheckoutDAO.get_shared_snapshots_by_ids(
                 session,
                 tenant_scope=tenant_scope,
                 product_ids=product_ids,
-            ),
-            "tenant_offer",
-        )
+            )
+            source = "shared_product"
+        else:
+            rows = await PublicCatalogCheckoutDAO.get_offer_snapshots_by_ids(
+                session,
+                tenant_scope=tenant_scope,
+                product_ids=product_ids,
+            )
+            source = "tenant_offer"
+        return {
+            product_id: OrderProductCatalogSnapshot(
+                product_id=row.product_id,
+                title=row.title,
+                unit_price=row.unit_price,
+                currency=row.currency,
+                pricing_source=source,
+            )
+            for product_id, row in rows.items()
+        }

--- a/services/public_series_page_service.py
+++ b/services/public_series_page_service.py
@@ -5,8 +5,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 from sqlmodel import select
 
-from crud.product import ProductDAO
+from crud.public_catalog import PublicCatalogDAO
 from models import Brand, FeatureSeriesLink, Product, ProductSeries
+from models.tenancy import TenantScope
 from schemas import (
     ProductBrandResponse,
     PublicRelatedSeriesResponse,
@@ -16,6 +17,8 @@ from services.feature_resolver_service import FeatureResolverService
 from services.product_read_service import ProductReadService
 from services.product_response_mapper import map_product_to_response
 from services.product_series_payloads import build_product_series_response
+from services.public_catalog_service import PublicCatalogService
+from services.public_catalog_visibility_service import PublicCatalogVisibilityService
 
 
 class PublicSeriesPageService:
@@ -27,6 +30,7 @@ class PublicSeriesPageService:
         *,
         brand_slug: str,
         series_slug: str,
+        tenant_scope: TenantScope,
     ) -> PublicSeriesPageResponse | None:
         row = (
             await session.execute(
@@ -49,11 +53,21 @@ class PublicSeriesPageService:
             return None
 
         series, brand = row
-        products = await ProductDAO.get_published_by_series_id(
+        projections = await PublicCatalogService.get_products_by_series_id(
             session,
-            int(series.id),
+            tenant_scope=tenant_scope,
+            series_id=int(series.id),
             load_image_variants=True,
         )
+        if (
+            not projections
+            and not await PublicCatalogVisibilityService.is_canonical_scope(
+                session,
+                tenant_scope,
+            )
+        ):
+            return None
+        products = [projection.product for projection in projections]
         supply_metrics = await ProductReadService.get_supply_metrics_map(session, products)
         await FeatureResolverService.resolve_for_products(session, products)
 
@@ -71,15 +85,17 @@ class PublicSeriesPageService:
             series=series_payload,
             products=[
                 map_product_to_response(
-                    product,
-                    supply_metrics=supply_metrics.get(int(product.id)),
+                    projection.product,
+                    supply_metrics=supply_metrics.get(int(projection.product.id)),
+                    pricing=projection.pricing,
                 )
-                for product in products
+                for projection in projections
             ],
             related_series=await PublicSeriesPageService._get_related_series(
                 session,
                 brand_id=int(brand.id),
                 current_series_id=int(series.id),
+                tenant_scope=tenant_scope,
             ),
         )
 
@@ -89,7 +105,29 @@ class PublicSeriesPageService:
         *,
         brand_id: int,
         current_series_id: int,
+        tenant_scope: TenantScope,
     ) -> list[PublicRelatedSeriesResponse]:
+        if not await PublicCatalogVisibilityService.is_canonical_scope(
+            session,
+            tenant_scope,
+        ):
+            rows = await PublicCatalogDAO.list_related_series(
+                session,
+                tenant_scope=tenant_scope,
+                brand_id=brand_id,
+                current_series_id=current_series_id,
+                limit=PublicSeriesPageService.RELATED_LIMIT,
+            )
+            return [
+                PublicRelatedSeriesResponse(
+                    title=related.title,
+                    slug=related.slug,
+                    short_description=related.short_description,
+                    hero_image=related.hero_image,
+                    products_count=products_count,
+                )
+                for related, products_count in rows
+            ]
         rows = list(
             (
                 await session.execute(

--- a/services/public_taxonomy_service.py
+++ b/services/public_taxonomy_service.py
@@ -1,0 +1,25 @@
+"""Pure public taxonomy visibility rules used by response mapping."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+
+class PublicTaxonomyService:
+    @staticmethod
+    def is_public_tag(tag: Any) -> bool:
+        group = getattr(tag, "group", None)
+        return bool(
+            getattr(tag, "is_public", False) is True
+            and group is not None
+            and getattr(group, "is_public", False) is True
+        )
+
+    @staticmethod
+    def visible_tags(tags: Iterable[Any] | None) -> list[Any]:
+        return [
+            tag
+            for tag in (tags or [])
+            if PublicTaxonomyService.is_public_tag(tag)
+        ]

--- a/services/public_taxonomy_service.py
+++ b/services/public_taxonomy_service.py
@@ -8,6 +8,22 @@ from typing import Any
 
 class PublicTaxonomyService:
     @staticmethod
+    def public_brand(product: Any) -> Any | None:
+        """Return the eagerly loaded brand only when it is public."""
+        brand = getattr(product, "__dict__", {}).get("brand")
+        if brand is None or getattr(brand, "is_published", False) is not True:
+            return None
+        return brand
+
+    @staticmethod
+    def public_series(product: Any) -> Any | None:
+        """Return the eagerly loaded series only when it is public."""
+        series = getattr(product, "__dict__", {}).get("series")
+        if series is None or getattr(series, "is_published", False) is not True:
+            return None
+        return series
+
+    @staticmethod
     def is_public_tag(tag: Any) -> bool:
         group = getattr(tag, "group", None)
         return bool(

--- a/services/tenant_scope_service.py
+++ b/services/tenant_scope_service.py
@@ -56,4 +56,5 @@ class SystemTenantScopeResolver:
             tenant_id=candidate.tenant_id,
             storefront_id=candidate.storefront_id,
             is_system=candidate.is_system,
+            is_canonical_storefront=True,
         )

--- a/services/website_lead_service.py
+++ b/services/website_lead_service.py
@@ -8,7 +8,6 @@ from sqlalchemy.orm.attributes import flag_modified
 from sqlmodel import select
 
 from core.input_validation import normalize_phone_digits
-from crud.product import ProductDAO
 from models import LeadSource, Order, OrderStatus, Product
 from schemas import (
     LeadCreatePayload,
@@ -25,6 +24,7 @@ from services.order_service import OrderService
 from services.product_availability_serialization import (
     ProductAvailabilitySerialization,
 )
+from services.public_catalog_visibility_service import PublicCatalogVisibilityService
 from services.public_write_fingerprint_service import PublicWriteFingerprintService
 from services.public_write_idempotency_service import (
     PublicWriteCommandResponse,
@@ -170,9 +170,14 @@ class WebsiteLeadService:
             product_id=payload.product_id,
             phone=payload.phone,
         )
-        product = await ProductDAO.get_by_id(session, payload.product_id)
-        if not product or not product.is_published:
-            raise LookupError(f"Product with id={payload.product_id} not found")
+        projection = await PublicCatalogVisibilityService.get_visible_product_by_id(
+            session,
+            tenant_scope=tenant_scope,
+            product_id=payload.product_id,
+        )
+        if projection is None:
+            raise LookupError("Product not found")
+        product = projection.product
 
         # Order timestamps are historically stored as naive UTC. The source is
         # nevertheless the authoritative database clock sampled after the

--- a/services/website_order_service.py
+++ b/services/website_order_service.py
@@ -13,7 +13,10 @@ from services.installation_pricing_service import (
     InstallationPricingError,
     InstallationPricingService,
 )
-from services.order_product_link_command import OrderProductLinkCommand
+from services.order_product_link_command import (
+    OrderProductCatalogSnapshot,
+    OrderProductLinkCommand,
+)
 from services.order_service import OrderService
 from services.public_catalog_visibility_service import PublicCatalogVisibilityService
 from services.public_write_fingerprint_service import PublicWriteFingerprintService
@@ -87,17 +90,16 @@ class WebsiteOrderService:
             for item in payload.items
             if item.product_id is not None
         }
-        storefront_prices: dict[int, int] = {}
-        pricing_source: str | None = None
+        storefront_snapshots: dict[int, OrderProductCatalogSnapshot] = {}
         if product_ids:
-            storefront_prices, pricing_source = (
-                await PublicCatalogVisibilityService.get_checkout_prices(
+            storefront_snapshots = (
+                await PublicCatalogVisibilityService.get_checkout_snapshots(
                     session,
                     tenant_scope=tenant_scope,
                     product_ids=product_ids,
                 )
             )
-        missing_product_ids = sorted(product_ids - storefront_prices.keys())
+        missing_product_ids = sorted(product_ids - storefront_snapshots.keys())
         if missing_product_ids:
             raise InstallationPricingError(
                 f"Товар #{missing_product_ids[0]} недоступен для этой витрины",
@@ -118,17 +120,14 @@ class WebsiteOrderService:
             if item["with_installation"]
         ]
         catalog_pricing_snapshots = [
-            {
-                "product_id": int(item["product_id"]),
-                "unit_price": storefront_prices[int(item["product_id"])],
-                "source": pricing_source,
-            }
+            storefront_snapshots[int(item["product_id"])].as_technical_meta()
             for item in items
             if item.get("product_id") is not None
         ]
         technical_meta = {}
         if catalog_pricing_snapshots:
             technical_meta["public_catalog_pricing"] = {
+                "snapshot_version": 1,
                 "items": catalog_pricing_snapshots,
             }
         if pricing_snapshots:
@@ -156,7 +155,7 @@ class WebsiteOrderService:
             customer_bank_name=payload.customer.bank_name,
             order_technical_meta=technical_meta or None,
             product_link_command=OrderProductLinkCommand.storefront_snapshot(
-                storefront_prices
+                storefront_snapshots
             ),
             tenant_scope=tenant_scope,
             commit=False,

--- a/services/website_order_service.py
+++ b/services/website_order_service.py
@@ -13,6 +13,7 @@ from services.installation_pricing_service import (
     InstallationPricingError,
     InstallationPricingService,
 )
+from services.order_product_link_command import OrderProductLinkCommand
 from services.order_service import OrderService
 from services.public_catalog_visibility_service import PublicCatalogVisibilityService
 from services.public_write_fingerprint_service import PublicWriteFingerprintService
@@ -154,7 +155,9 @@ class WebsiteOrderService:
             customer_bic=payload.customer.bic,
             customer_bank_name=payload.customer.bank_name,
             order_technical_meta=technical_meta or None,
-            product_price_overrides=storefront_prices,
+            product_link_command=OrderProductLinkCommand.storefront_snapshot(
+                storefront_prices
+            ),
             tenant_scope=tenant_scope,
             commit=False,
         )

--- a/services/website_order_service.py
+++ b/services/website_order_service.py
@@ -9,8 +9,12 @@ from schemas import OrderPayload, OrderResponse
 from services.communications.tenant_website_event_service import (
     TenantWebsiteEventService,
 )
-from services.installation_pricing_service import InstallationPricingService
+from services.installation_pricing_service import (
+    InstallationPricingError,
+    InstallationPricingService,
+)
 from services.order_service import OrderService
+from services.public_catalog_visibility_service import PublicCatalogVisibilityService
 from services.public_write_fingerprint_service import PublicWriteFingerprintService
 from services.public_write_idempotency_service import (
     PublicWriteCommandResponse,
@@ -77,7 +81,31 @@ class WebsiteOrderService:
             len(payload.items),
             len([item for item in payload.items if item.with_installation]),
         )
-        items = await InstallationPricingService.price_public_items(session, payload.items)
+        product_ids = {
+            int(item.product_id)
+            for item in payload.items
+            if item.product_id is not None
+        }
+        storefront_prices: dict[int, int] = {}
+        pricing_source: str | None = None
+        if product_ids:
+            storefront_prices, pricing_source = (
+                await PublicCatalogVisibilityService.get_checkout_prices(
+                    session,
+                    tenant_scope=tenant_scope,
+                    product_ids=product_ids,
+                )
+            )
+        missing_product_ids = sorted(product_ids - storefront_prices.keys())
+        if missing_product_ids:
+            raise InstallationPricingError(
+                f"Товар #{missing_product_ids[0]} недоступен для этой витрины",
+                code="product_not_available",
+            )
+        items = await InstallationPricingService.price_public_items(
+            session,
+            payload.items,
+        )
         pricing_snapshots = [
             {
                 "item_index": index,
@@ -88,6 +116,25 @@ class WebsiteOrderService:
             for index, item in enumerate(items)
             if item["with_installation"]
         ]
+        catalog_pricing_snapshots = [
+            {
+                "product_id": int(item["product_id"]),
+                "unit_price": storefront_prices[int(item["product_id"])],
+                "source": pricing_source,
+            }
+            for item in items
+            if item.get("product_id") is not None
+        ]
+        technical_meta = {}
+        if catalog_pricing_snapshots:
+            technical_meta["public_catalog_pricing"] = {
+                "items": catalog_pricing_snapshots,
+            }
+        if pricing_snapshots:
+            technical_meta["public_installation_pricing"] = {
+                "pricing_version": InstallationPricingService.PRICING_VERSION,
+                "items": pricing_snapshots,
+            }
 
         order = await OrderService.create_from_website(
             session=session,
@@ -106,12 +153,8 @@ class WebsiteOrderService:
             customer_iban=payload.customer.iban,
             customer_bic=payload.customer.bic,
             customer_bank_name=payload.customer.bank_name,
-            order_technical_meta={
-                "public_installation_pricing": {
-                    "pricing_version": InstallationPricingService.PRICING_VERSION,
-                    "items": pricing_snapshots,
-                }
-            } if pricing_snapshots else None,
+            order_technical_meta=technical_meta or None,
+            product_price_overrides=storefront_prices,
             tenant_scope=tenant_scope,
             commit=False,
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -219,7 +219,12 @@ async def db(db_engine):
 def tenant_scope():
     from services.tenant_scope_service import TenantScope
 
-    return TenantScope(tenant_id=1, storefront_id=1, is_system=True)
+    return TenantScope(
+        tenant_id=1,
+        storefront_id=1,
+        is_system=True,
+        is_canonical_storefront=True,
+    )
 
 @pytest.fixture(scope="function")
 async def async_client(db):

--- a/tests/integration/test_catalog_api.py
+++ b/tests/integration/test_catalog_api.py
@@ -1,7 +1,15 @@
 import pytest
 from httpx import AsyncClient
 from datetime import datetime, timedelta
-from models import Brand, Product, ProductImage, ProductImageVariant
+from models import (
+    Brand,
+    Product,
+    ProductImage,
+    ProductImageVariant,
+    ProductTagLink,
+    Tag,
+    TagGroup,
+)
 from crud.supplier import ProductLocalStockDAO
 from services.product_image_processing_contract import (
     ProductImageManualQualityStatus,
@@ -428,22 +436,39 @@ async def test_catalog_rejects_unknown_color(async_client: AsyncClient):
 async def test_catalog_filters_by_brand_entity_slug(async_client: AsyncClient, db):
     mdv = Brand(title="MDV", slug="mdv", is_published=True, sort_order=10)
     haier = Brand(title="Haier", slug="haier", is_published=True, sort_order=40)
-    db.add_all([mdv, haier])
+    brand_group = TagGroup(
+        title="Brand",
+        slug="brand",
+        is_public=True,
+    )
+    db.add_all([mdv, haier, brand_group])
     await db.flush()
 
-    db.add_all(
-        [
-            Product(title="MDV product", slug="mdv-product", price=1000, specs={"area_m2": 25}, brand_id=mdv.id, is_published=True),
-            Product(
-                title="Haier product",
-                slug="haier-product",
-                price=1000,
-                specs={"area_m2": 25},
-                brand_id=haier.id,
-                is_published=True,
-            ),
-        ]
+    mdv_tag = Tag(
+        title="MDV",
+        slug="mdv",
+        group_id=brand_group.id,
+        is_public=True,
     )
+    mdv_product = Product(
+        title="MDV product",
+        slug="mdv-product",
+        price=1000,
+        specs={"area_m2": 25},
+        brand_id=mdv.id,
+        is_published=True,
+    )
+    haier_product = Product(
+        title="Haier product",
+        slug="haier-product",
+        price=1000,
+        specs={"area_m2": 25},
+        brand_id=haier.id,
+        is_published=True,
+    )
+    db.add_all([mdv_tag, mdv_product, haier_product])
+    await db.flush()
+    db.add(ProductTagLink(product_id=mdv_product.id, tag_id=mdv_tag.id))
     await db.commit()
 
     response = await async_client.get("/api/v1/products?tag_slugs=mdv")

--- a/tests/integration/test_public_storefront_context.py
+++ b/tests/integration/test_public_storefront_context.py
@@ -6,7 +6,7 @@ from sqlmodel import select
 
 from core.config import settings
 from core.public_write_key import public_write_idempotency_key_sha256
-from models import Lead, Order, Product
+from models import Lead, Order, Product, TenantOffer
 from models.tenancy import Storefront, StorefrontDomain, TenantScope
 from services.catalog_revision_service import CatalogRevisionService
 from services.storefront_context_signature_service import (
@@ -153,6 +153,19 @@ async def test_signed_context_routes_public_order_to_secondary_storefront(
         is_published=True,
     )
     db.add(product)
+    await db.flush()
+    db.add(
+        TenantOffer(
+            tenant_id=1,
+            storefront_id=int(storefront.id),
+            product_id=int(product.id),
+            price=2100,
+            is_published=True,
+            status="active",
+            created_by_username="test",
+            updated_by_username="test",
+        )
+    )
     await db.commit()
     await db.refresh(product)
     _configure_signing(monkeypatch)
@@ -231,13 +244,25 @@ async def test_signed_context_authenticates_public_catalog_raw_query(
     db,
     monkeypatch,
 ):
-    await _seed_secondary_storefront(db)
+    storefront = await _seed_secondary_storefront(db)
+    product = Product(
+        title="Signed catalog product",
+        slug="signed-catalog-product",
+        price=1800,
+        is_published=True,
+    )
+    db.add(product)
+    await db.flush()
     db.add(
-        Product(
-            title="Signed catalog product",
-            slug="signed-catalog-product",
+        TenantOffer(
+            tenant_id=1,
+            storefront_id=int(storefront.id),
+            product_id=int(product.id),
             price=1800,
             is_published=True,
+            status="active",
+            created_by_username="test",
+            updated_by_username="test",
         )
     )
     await db.commit()

--- a/tests/integration/test_public_tenant_offer_isolation_postgres.py
+++ b/tests/integration/test_public_tenant_offer_isolation_postgres.py
@@ -1,0 +1,409 @@
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import select
+
+from core.config import settings
+from models import (
+    Customer,
+    IntegrationOutboxEvent,
+    Order,
+    OrderProductLink,
+    Product,
+    PublicWriteIdempotency,
+    Storefront,
+    StorefrontDomain,
+    Tenant,
+    TenantOffer,
+)
+from schemas import OrderPayload
+from services.communications.tenant_website_events import (
+    TENANT_WEBSITE_CHECKOUT_CREATED_EVENT,
+)
+from services.public_write_idempotency_service import PublicWriteIdempotencyService
+from services.storefront_context_signature_service import (
+    StorefrontContextSignatureService,
+)
+from services.tenant_scope_service import TenantScope
+from services.website_order_service import WebsiteOrderService
+
+
+_KEY_ID = "test-public-catalog"
+_SECRET = "test-public-catalog-secret-at-least-32-bytes"
+_SECONDARY_HOST = "orsha.catalog.test"
+
+
+def _signed_read_headers(path_and_query: str) -> dict[str, str]:
+    timestamp = int(time.time())
+    return {
+        "Host": "test",
+        "X-MVN-Storefront-Key-Id": _KEY_ID,
+        "X-MVN-Storefront-Host": _SECONDARY_HOST,
+        "X-MVN-Storefront-Timestamp": str(timestamp),
+        "X-MVN-Storefront-Signature": StorefrontContextSignatureService.sign(
+            secret=_SECRET,
+            timestamp=timestamp,
+            method="GET",
+            path_and_query=path_and_query,
+            api_hostname="test",
+            storefront_hostname=_SECONDARY_HOST,
+            body_sha256=StorefrontContextSignatureService.EMPTY_BODY_SHA256,
+            idempotency_key_sha256="",
+        ),
+    }
+
+
+def _configure_signing(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "STOREFRONT_CONTEXT_SIGNING_KEY_ID", _KEY_ID)
+    monkeypatch.setattr(settings, "STOREFRONT_CONTEXT_SIGNING_SECRET", _SECRET)
+    monkeypatch.setattr(
+        settings,
+        "STOREFRONT_CONTEXT_PREVIOUS_SIGNING_KEY_ID",
+        "",
+    )
+    monkeypatch.setattr(
+        settings,
+        "STOREFRONT_CONTEXT_PREVIOUS_SIGNING_SECRET",
+        "",
+    )
+
+
+@pytest.mark.asyncio
+async def test_secondary_catalog_scopes_offers_before_sort_and_pagination(
+    async_client,
+    db,
+    monkeypatch,
+):
+    storefront = Storefront(
+        id=2,
+        tenant_id=1,
+        slug="orsha",
+        display_name="MVN Orsha",
+        status="active",
+        city="Orsha",
+        is_default=False,
+    )
+    db.add(storefront)
+    await db.flush()
+    db.add(
+        StorefrontDomain(
+            storefront_id=int(storefront.id),
+            hostname=_SECONDARY_HOST,
+            status="active",
+            is_primary=True,
+        )
+    )
+    low_offer = Product(
+        title="Offer low",
+        slug="offer-low",
+        price=9000,
+        is_published=True,
+    )
+    high_offer = Product(
+        title="Offer high",
+        slug="offer-high",
+        price=1000,
+        is_published=True,
+    )
+    no_offer = Product(
+        title="No offer",
+        slug="no-offer",
+        price=2000,
+        is_published=True,
+    )
+    disabled_offer = Product(
+        title="Disabled offer",
+        slug="disabled-offer",
+        price=2500,
+        is_published=True,
+    )
+    db.add_all([low_offer, high_offer, no_offer, disabled_offer])
+    await db.flush()
+    db.add_all(
+        [
+            TenantOffer(
+                tenant_id=1,
+                storefront_id=2,
+                product_id=int(low_offer.id),
+                price=3000,
+                old_price=3500,
+                status="active",
+                is_published=True,
+                created_by_username="test",
+                updated_by_username="test",
+            ),
+            TenantOffer(
+                tenant_id=1,
+                storefront_id=2,
+                product_id=int(high_offer.id),
+                price=7000,
+                status="active",
+                is_published=True,
+                created_by_username="test",
+                updated_by_username="test",
+            ),
+            TenantOffer(
+                tenant_id=1,
+                storefront_id=2,
+                product_id=int(disabled_offer.id),
+                price=4000,
+                status="disabled",
+                is_published=False,
+                created_by_username="test",
+                updated_by_username="test",
+            ),
+        ]
+    )
+    await db.commit()
+    _configure_signing(monkeypatch)
+
+    target = "/api/v1/products?sort=price_asc&limit=1&page=2"
+    response = await async_client.get(
+        target,
+        headers=_signed_read_headers(target),
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["meta"] == {
+        "total": 2,
+        "page": 2,
+        "limit": 1,
+        "pages": 2,
+    }
+    assert [item["slug"] for item in payload["items"]] == [high_offer.slug]
+    assert payload["items"][0]["price"] == 7000
+    assert no_offer.slug not in {item["slug"] for item in payload["items"]}
+    assert disabled_offer.slug not in {
+        item["slug"] for item in payload["items"]
+    }
+
+    first_page_target = "/api/v1/products?sort=price_asc&limit=1"
+    first_page = await async_client.get(
+        first_page_target,
+        headers=_signed_read_headers(first_page_target),
+    )
+    assert first_page.status_code == 200, first_page.text
+    assert first_page.json()["items"][0]["slug"] == low_offer.slug
+    assert first_page.json()["items"][0]["price"] == 3000
+    assert first_page.json()["items"][0]["old_price"] == 3500
+
+
+@pytest.mark.asyncio
+async def test_concurrent_checkout_isolated_by_exact_tenant_storefront_scope(
+    db_engine,
+):
+    assert db_engine.dialect.name == "postgresql"
+    factory = sessionmaker(
+        bind=db_engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+    async with factory() as setup:
+        tenant_b = Tenant(
+            id=2,
+            slug="tenant-b",
+            display_name="Tenant B",
+            status="active",
+            is_system=False,
+        )
+        storefront_a = Storefront(
+            id=2,
+            tenant_id=1,
+            slug="orsha",
+            display_name="MVN Orsha",
+            status="active",
+            currency="BYN",
+            is_default=False,
+        )
+        storefront_b = Storefront(
+            id=3,
+            tenant_id=2,
+            slug="main",
+            display_name="Tenant B Main",
+            status="active",
+            currency="EUR",
+            is_default=True,
+        )
+        product = Product(
+            title="Shared catalog product",
+            slug="shared-catalog-product",
+            price=9999,
+            is_published=True,
+        )
+        setup.add(tenant_b)
+        await setup.flush()
+        setup.add_all([storefront_a, storefront_b, product])
+        await setup.flush()
+        setup.add_all(
+            [
+                TenantOffer(
+                    tenant_id=1,
+                    storefront_id=2,
+                    product_id=int(product.id),
+                    price=3100,
+                    status="active",
+                    is_published=True,
+                    created_by_username="test",
+                    updated_by_username="test",
+                ),
+                TenantOffer(
+                    tenant_id=2,
+                    storefront_id=3,
+                    product_id=int(product.id),
+                    price=4200,
+                    status="active",
+                    is_published=True,
+                    created_by_username="test",
+                    updated_by_username="test",
+                ),
+            ]
+        )
+        await setup.commit()
+        product_id = int(product.id)
+
+    payload = OrderPayload.model_validate(
+        {
+            "customer": {
+                "name": "Same public customer",
+                "phone": "+375291112233",
+            },
+            "items": [{"product_id": product_id, "quantity": 1}],
+            "comment": "Same request content across isolated scopes",
+        }
+    )
+    scopes = (
+        TenantScope(
+            tenant_id=1,
+            storefront_id=2,
+            is_system=True,
+            is_canonical_storefront=False,
+        ),
+        TenantScope(
+            tenant_id=2,
+            storefront_id=3,
+            is_system=False,
+            is_canonical_storefront=False,
+        ),
+    )
+    idempotency_key = "cross-scope-checkout-same-key-0001"
+    barrier = asyncio.Barrier(2)
+
+    async def submit(scope: TenantScope):
+        async with factory() as session:
+            await barrier.wait()
+            return await WebsiteOrderService.create_order(
+                session,
+                payload,
+                tenant_scope=scope,
+                idempotency_key=idempotency_key,
+            )
+
+    response_a, response_b = await asyncio.gather(
+        submit(scopes[0]),
+        submit(scopes[1]),
+    )
+    assert response_a.id != response_b.id
+
+    expected = {
+        (1, 2): (3100, "BYN"),
+        (2, 3): (4200, "EUR"),
+    }
+    async with factory() as verification:
+        orders = list(
+            (
+                await verification.execute(
+                    select(Order).where(
+                        Order.id.in_([response_a.id, response_b.id])
+                    )
+                )
+            ).scalars()
+        )
+        links = list(
+            (
+                await verification.execute(
+                    select(OrderProductLink).where(
+                        OrderProductLink.order_id.in_(
+                            [response_a.id, response_b.id]
+                        )
+                    )
+                )
+            ).scalars()
+        )
+        customers = list(
+            (
+                await verification.execute(
+                    select(Customer).where(
+                        Customer.id.in_([order.customer_id for order in orders])
+                    )
+                )
+            ).scalars()
+        )
+        receipts = list(
+            (
+                await verification.execute(
+                    select(PublicWriteIdempotency).where(
+                        PublicWriteIdempotency.key_hash
+                        == PublicWriteIdempotencyService.key_hash(
+                            idempotency_key
+                        )
+                    )
+                )
+            ).scalars()
+        )
+        events = list(
+            (
+                await verification.execute(
+                    select(IntegrationOutboxEvent).where(
+                        IntegrationOutboxEvent.event_type
+                        == TENANT_WEBSITE_CHECKOUT_CREATED_EVENT,
+                        IntegrationOutboxEvent.aggregate_id.in_(
+                            [str(response_a.id), str(response_b.id)]
+                        ),
+                    )
+                )
+            ).scalars()
+        )
+
+    assert len(orders) == len(links) == len(customers) == len(receipts) == 2
+    assert len(events) == 2
+    assert {(order.tenant_id, order.storefront_id) for order in orders} == set(
+        expected
+    )
+    assert {customer.tenant_id for customer in customers} == {1, 2}
+    assert {receipt.tenant_id for receipt in receipts} == {1, 2}
+    assert {
+        (receipt.tenant_id, receipt.storefront_id) for receipt in receipts
+    } == set(expected)
+
+    orders_by_id = {int(order.id): order for order in orders}
+    for link in links:
+        order = orders_by_id[int(link.order_id)]
+        price, currency = expected[(order.tenant_id, order.storefront_id)]
+        assert link.product_id == product_id
+        assert link.price == price
+        assert link.title_snapshot == "Shared catalog product"
+        assert link.currency_snapshot == currency
+        pricing = order.technical_meta["public_catalog_pricing"]
+        assert pricing["snapshot_version"] == 1
+        assert pricing["items"] == [
+            {
+                "product_id": product_id,
+                "title_snapshot": "Shared catalog product",
+                "unit_price": price,
+                "currency_snapshot": currency,
+                "source": "tenant_offer",
+            }
+        ]
+
+    for event in events:
+        tenant_id = int(event.payload["tenant_id"])
+        storefront_id = int(event.payload["storefront_id"])
+        price, currency = expected[(tenant_id, storefront_id)]
+        assert event.payload["currency"] == currency
+        assert event.payload["product_lines"][0]["unit_price"] == str(price)

--- a/tests/integration/test_public_write_idempotency_postgres.py
+++ b/tests/integration/test_public_write_idempotency_postgres.py
@@ -18,6 +18,7 @@ from models import (
     PublicWriteIdempotency,
     ServiceAttachment,
     Storefront,
+    TenantOffer,
 )
 from schemas import (
     OrderPayload,
@@ -308,6 +309,19 @@ async def test_public_write_family_full_idempotency_matrix(
             is_published=True,
         )
         setup.add(product)
+        await setup.flush()
+        setup.add(
+            TenantOffer(
+                tenant_id=1,
+                storefront_id=2,
+                product_id=int(product.id),
+                price=1200,
+                is_published=True,
+                status="active",
+                created_by_username="test",
+                updated_by_username="test",
+            )
+        )
         await setup.commit()
         await setup.refresh(product)
         product_id = int(product.id or 0)

--- a/tests/unit/test_communication_contracts.py
+++ b/tests/unit/test_communication_contracts.py
@@ -41,6 +41,32 @@ def test_versioned_public_order_payload_is_bounded_and_json_safe():
     assert dumped["product_lines"][0]["product_id"] == 7
 
 
+def test_public_order_payload_accepts_storefront_currency_and_rejects_invalid_code():
+    payload = PublicOrderCreatedPayloadV1(
+        order_id=42,
+        status="negotiation",
+        customer=PublicOrderCustomerSnapshotV1(
+            name="Tenant customer",
+            phone="+375291112233",
+        ),
+        total_amount=Decimal("4200"),
+        currency="EUR",
+    )
+
+    assert payload.currency == "EUR"
+    with pytest.raises(ValidationError):
+        PublicOrderCreatedPayloadV1(
+            order_id=43,
+            status="negotiation",
+            customer=PublicOrderCustomerSnapshotV1(
+                name="Tenant customer",
+                phone="+375291112233",
+            ),
+            total_amount=Decimal("4200"),
+            currency="eur",
+        )
+
+
 def test_contact_lead_contract_matches_public_ingress_bounds():
     payload = PublicContactLeadCreatedPayloadV1(
         lead_id=12,

--- a/tests/unit/test_communication_installation_watermark_migration.py
+++ b/tests/unit/test_communication_installation_watermark_migration.py
@@ -32,7 +32,7 @@ def test_installation_watermark_precedes_the_single_provider_boundary_head():
     script = ScriptDirectory.from_config(Config("alembic.ini"))
     revision = script.get_revision(REVISION)
 
-    assert script.get_heads() == ["ab02c3d4e5f6"]
+    assert script.get_heads() == ["f2a3b4c5d6e7"]
     assert revision is not None
     assert revision.down_revision == "f4d5e6f7a8b9"
 

--- a/tests/unit/test_communication_website_canary_migration.py
+++ b/tests/unit/test_communication_website_canary_migration.py
@@ -15,6 +15,7 @@ from alembic.script import ScriptDirectory
 
 REVISION = "ab02c3d4e5f6"
 DOWN_REVISION = "aa91c2d4e6f8"
+HEAD_REVISION = "f2a3b4c5d6e7"
 MIGRATION_PATH = Path(
     "alembic/versions/ab02c3d4e5f6_add_website_canary_runtime_target.py"
 )
@@ -58,10 +59,11 @@ def _create_previous_schema(connection) -> None:
     metadata.create_all(connection)
 
 
-def test_website_canary_migration_is_the_additive_single_head() -> None:
+def test_website_canary_migration_precedes_the_additive_catalog_snapshot_head() -> None:
     script = ScriptDirectory.from_config(Config("alembic.ini"))
 
-    assert script.get_heads() == [REVISION]
+    assert script.get_heads() == [HEAD_REVISION]
+    assert script.get_revision(HEAD_REVISION).down_revision == REVISION
     assert script.get_revision(REVISION).down_revision == DOWN_REVISION
 
 

--- a/tests/unit/test_customer_manager_tenant_scope_migration.py
+++ b/tests/unit/test_customer_manager_tenant_scope_migration.py
@@ -13,7 +13,8 @@ REVISION = "b8d9e0f1a2c3"
 CONTRACT_REVISION = "c9e0f1a2b3d4"
 STOREFRONT_IDEMPOTENCY_REVISION = "d0f1a2b3c4d5"
 TENANT_OFFER_REVISION = "d0a1b2c3e4f6"
-HEAD_REVISION = "ab02c3d4e5f6"
+HEAD_REVISION = "f2a3b4c5d6e7"
+WEBSITE_CANARY_REVISION = "ab02c3d4e5f6"
 PUBLIC_WRITE_REVISION = "aa91c2d4e6f8"
 CATALOG_REVISION = "e1f2a3b4c5d6"
 MIGRATION_PATH = Path(
@@ -95,6 +96,10 @@ def test_customer_manager_tenant_scope_is_single_alembic_head():
     assert script.get_current_head() == HEAD_REVISION
     assert (
         script.get_revision(HEAD_REVISION).down_revision
+        == WEBSITE_CANARY_REVISION
+    )
+    assert (
+        script.get_revision(WEBSITE_CANARY_REVISION).down_revision
         == PUBLIC_WRITE_REVISION
     )
     assert (

--- a/tests/unit/test_installation_pricing_service.py
+++ b/tests/unit/test_installation_pricing_service.py
@@ -13,7 +13,9 @@ from models import (
     OrderServiceLink,
     Product,
     Service,
+    Storefront,
     Tag,
+    Tenant,
 )
 from schemas import OrderPayload
 from services.installation_pricing_service import (
@@ -31,6 +33,29 @@ async def sqlite_checkout_session(tmp_path: Path):
 
     session_factory = sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
     async with session_factory() as session:
+        session.add(
+            Tenant(
+                id=1,
+                slug="mvn",
+                display_name="MVN",
+                kind="operator",
+                status="active",
+                is_system=True,
+            )
+        )
+        await session.flush()
+        session.add(
+            Storefront(
+                id=1,
+                tenant_id=1,
+                slug="main",
+                display_name="MVN",
+                status="active",
+                currency="BYN",
+                is_default=True,
+            )
+        )
+        await session.commit()
         yield session
 
     await engine.dispose()

--- a/tests/unit/test_lead_order_tenant_provenance_expand.py
+++ b/tests/unit/test_lead_order_tenant_provenance_expand.py
@@ -19,7 +19,8 @@ CUSTOMER_SCOPE_REVISION = "b8d9e0f1a2c3"
 CONTRACT_REVISION = "c9e0f1a2b3d4"
 STOREFRONT_IDEMPOTENCY_REVISION = "d0f1a2b3c4d5"
 TENANT_OFFER_REVISION = "d0a1b2c3e4f6"
-HEAD_REVISION = "ab02c3d4e5f6"
+HEAD_REVISION = "f2a3b4c5d6e7"
+WEBSITE_CANARY_REVISION = "ab02c3d4e5f6"
 PUBLIC_WRITE_REVISION = "aa91c2d4e6f8"
 CATALOG_REVISION = "e1f2a3b4c5d6"
 MIGRATION_PATH = Path("alembic/versions/f6b2a4d8e1c3_add_lead_order_tenant_provenance_expand.py")
@@ -84,6 +85,10 @@ def test_lead_order_tenant_provenance_expand_is_in_single_head_chain():
     assert revision.down_revision == "e9a1b2c3d4e5"
     assert (
         script.get_revision(HEAD_REVISION).down_revision
+        == WEBSITE_CANARY_REVISION
+    )
+    assert (
+        script.get_revision(WEBSITE_CANARY_REVISION).down_revision
         == PUBLIC_WRITE_REVISION
     )
     assert (

--- a/tests/unit/test_order_product_catalog_snapshot_migration.py
+++ b/tests/unit/test_order_product_catalog_snapshot_migration.py
@@ -55,9 +55,24 @@ def test_order_product_catalog_snapshot_is_nullable_and_reversible():
             )
         }
         assert columns["title_snapshot"]["nullable"] is True
-        assert columns["title_snapshot"]["type"].length == 500
+        assert isinstance(columns["title_snapshot"]["type"], sa.Text)
         assert columns["currency_snapshot"]["nullable"] is True
         assert columns["currency_snapshot"]["type"].length == 3
+
+        long_title = "Т" * 700
+        connection.execute(
+            sa.text(
+                "INSERT INTO order_product_link "
+                "(id, price, title_snapshot, currency_snapshot) "
+                "VALUES (1, 10, :title, 'BYN')"
+            ),
+            {"title": long_title},
+        )
+        assert connection.execute(
+            sa.text(
+                "SELECT title_snapshot FROM order_product_link WHERE id = 1"
+            )
+        ).scalar_one() == long_title
 
         migration.downgrade()
         remaining_columns = {

--- a/tests/unit/test_order_product_catalog_snapshot_migration.py
+++ b/tests/unit/test_order_product_catalog_snapshot_migration.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import sqlalchemy as sa
+from alembic.config import Config
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from alembic.script import ScriptDirectory
+
+
+REVISION = "f2a3b4c5d6e7"
+DOWN_REVISION = "ab02c3d4e5f6"
+MIGRATION_PATH = Path(
+    "alembic/versions/f2a3b4c5d6e7_add_order_product_catalog_snapshot.py"
+)
+
+
+def _load_migration_module():
+    spec = importlib.util.spec_from_file_location(
+        "order_product_catalog_snapshot_migration",
+        MIGRATION_PATH,
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_order_product_catalog_snapshot_is_the_single_alembic_head():
+    script = ScriptDirectory.from_config(Config("alembic.ini"))
+
+    assert script.get_heads() == [REVISION]
+    assert script.get_revision(REVISION).down_revision == DOWN_REVISION
+
+
+def test_order_product_catalog_snapshot_is_nullable_and_reversible():
+    migration = _load_migration_module()
+    engine = sa.create_engine("sqlite:///:memory:")
+    with engine.begin() as connection:
+        connection.execute(
+            sa.text(
+                "CREATE TABLE order_product_link "
+                "(id INTEGER PRIMARY KEY, price INTEGER NOT NULL DEFAULT 0)"
+            )
+        )
+        migration.op = Operations(MigrationContext.configure(connection))
+        migration.upgrade()
+
+        columns = {
+            column["name"]: column
+            for column in sa.inspect(connection).get_columns(
+                "order_product_link"
+            )
+        }
+        assert columns["title_snapshot"]["nullable"] is True
+        assert columns["title_snapshot"]["type"].length == 500
+        assert columns["currency_snapshot"]["nullable"] is True
+        assert columns["currency_snapshot"]["type"].length == 3
+
+        migration.downgrade()
+        remaining_columns = {
+            column["name"]
+            for column in sa.inspect(connection).get_columns(
+                "order_product_link"
+            )
+        }
+        assert remaining_columns == {"id", "price"}

--- a/tests/unit/test_order_product_link_command.py
+++ b/tests/unit/test_order_product_link_command.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import pytest
+
+from models import Product
+from services.order_product_link_command import OrderProductLinkCommand
+
+
+def _product() -> Product:
+    return Product(
+        id=17,
+        title="Public product",
+        slug="public-product",
+        price=9000,
+        specs={},
+        is_published=True,
+    )
+
+
+def test_shared_catalog_command_snapshots_product_price_and_link_fields():
+    mutation = OrderProductLinkCommand.shared_catalog().build(
+        order_id=10,
+        proposal_id=20,
+        product=_product(),
+        item={
+            "product_id": 17,
+            "quantity": 2,
+            "with_installation": True,
+            "installation_price": 750,
+            "installation_meta": {"meters": 4},
+        },
+        product_cost=1234,
+    )
+
+    assert mutation.link.price == 9000
+    assert mutation.link.cost == 1234
+    assert mutation.link.quantity == 2
+    assert mutation.link.installation_price == 750
+    assert mutation.link.installation_details == {"meters": 4}
+    assert mutation.product_total == 18000
+
+
+def test_storefront_command_uses_exact_locked_price_snapshot():
+    mutation = OrderProductLinkCommand.storefront_snapshot({17: 3200}).build(
+        order_id=10,
+        proposal_id=20,
+        product=_product(),
+        item={"product_id": 17, "quantity": 3},
+        product_cost=1234,
+    )
+
+    assert mutation.link.price == 3200
+    assert mutation.product_total == 9600
+
+
+def test_storefront_command_never_falls_back_when_snapshot_is_missing():
+    command = OrderProductLinkCommand.storefront_snapshot({18: 3200})
+
+    with pytest.raises(KeyError):
+        command.build(
+            order_id=10,
+            proposal_id=20,
+            product=_product(),
+            item={"product_id": 17, "quantity": 1},
+            product_cost=1234,
+        )

--- a/tests/unit/test_order_product_link_command.py
+++ b/tests/unit/test_order_product_link_command.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+from sqlalchemy import Text
 
 from models import OrderProductLink, Product
 from schemas_manager_orders import OrderProductLineResponse
@@ -127,3 +128,27 @@ def test_manager_product_line_dto_prefers_immutable_title_snapshot():
     assert response.product_title == "Public title at checkout"
     assert response.title_snapshot == "Public title at checkout"
     assert response.currency_snapshot == "BYN"
+
+
+def test_snapshot_preserves_unbounded_valid_product_title_exactly():
+    long_title = "  " + ("Товар " * 110) + "\n"
+    assert len(long_title) > 500
+    product = _product()
+    product.title = long_title
+
+    mutation = OrderProductLinkCommand.shared_catalog().build(
+        order_id=10,
+        proposal_id=20,
+        product=product,
+        item={"product_id": 17, "quantity": 1},
+        product_cost=1234,
+    )
+
+    assert mutation.link.title_snapshot == long_title
+    assert isinstance(mutation.link.__table__.c.title_snapshot.type, Text)
+    mutation.link.id = 32
+    response = OrderProductLineResponse.model_validate(
+        OrderProjectionService._map_product_line(mutation.link)
+    )
+    assert response.title_snapshot == long_title
+    assert response.product_title == long_title

--- a/tests/unit/test_order_product_link_command.py
+++ b/tests/unit/test_order_product_link_command.py
@@ -2,8 +2,13 @@ from __future__ import annotations
 
 import pytest
 
-from models import Product
-from services.order_product_link_command import OrderProductLinkCommand
+from models import OrderProductLink, Product
+from schemas_manager_orders import OrderProductLineResponse
+from services.order_product_link_command import (
+    OrderProductCatalogSnapshot,
+    OrderProductLinkCommand,
+)
+from services.order_projection_service import OrderProjectionService
 
 
 def _product() -> Product:
@@ -33,6 +38,8 @@ def test_shared_catalog_command_snapshots_product_price_and_link_fields():
     )
 
     assert mutation.link.price == 9000
+    assert mutation.link.title_snapshot == "Public product"
+    assert mutation.link.currency_snapshot == "BYN"
     assert mutation.link.cost == 1234
     assert mutation.link.quantity == 2
     assert mutation.link.installation_price == 750
@@ -40,8 +47,15 @@ def test_shared_catalog_command_snapshots_product_price_and_link_fields():
     assert mutation.product_total == 18000
 
 
-def test_storefront_command_uses_exact_locked_price_snapshot():
-    mutation = OrderProductLinkCommand.storefront_snapshot({17: 3200}).build(
+def test_storefront_command_uses_exact_locked_catalog_snapshot():
+    snapshot = OrderProductCatalogSnapshot(
+        product_id=17,
+        title="Public title at checkout",
+        unit_price=3200,
+        currency="eur",
+        pricing_source="tenant_offer",
+    )
+    mutation = OrderProductLinkCommand.storefront_snapshot({17: snapshot}).build(
         order_id=10,
         proposal_id=20,
         product=_product(),
@@ -50,11 +64,23 @@ def test_storefront_command_uses_exact_locked_price_snapshot():
     )
 
     assert mutation.link.price == 3200
+    assert mutation.link.title_snapshot == "Public title at checkout"
+    assert mutation.link.currency_snapshot == "EUR"
     assert mutation.product_total == 9600
 
 
 def test_storefront_command_never_falls_back_when_snapshot_is_missing():
-    command = OrderProductLinkCommand.storefront_snapshot({18: 3200})
+    command = OrderProductLinkCommand.storefront_snapshot(
+        {
+            18: OrderProductCatalogSnapshot(
+                product_id=18,
+                title="Other product",
+                unit_price=3200,
+                currency="BYN",
+                pricing_source="tenant_offer",
+            )
+        }
+    )
 
     with pytest.raises(KeyError):
         command.build(
@@ -64,3 +90,40 @@ def test_storefront_command_never_falls_back_when_snapshot_is_missing():
             item={"product_id": 17, "quantity": 1},
             product_cost=1234,
         )
+
+
+def test_storefront_command_rejects_mismatched_snapshot_key():
+    snapshot = OrderProductCatalogSnapshot(
+        product_id=17,
+        title="Public product",
+        unit_price=3200,
+        currency="BYN",
+        pricing_source="shared_product",
+    )
+
+    with pytest.raises(ValueError, match="snapshot key"):
+        OrderProductLinkCommand.storefront_snapshot({18: snapshot})
+
+
+def test_manager_product_line_dto_prefers_immutable_title_snapshot():
+    changed_product = _product()
+    changed_product.title = "Renamed after checkout"
+    link = OrderProductLink(
+        id=31,
+        order_id=10,
+        proposal_id=20,
+        product_id=17,
+        quantity=2,
+        price=3200,
+        title_snapshot="Public title at checkout",
+        currency_snapshot="BYN",
+        cost=1000,
+    )
+    link.product = changed_product
+
+    payload = OrderProjectionService._map_product_line(link)
+    response = OrderProductLineResponse.model_validate(payload)
+
+    assert response.product_title == "Public title at checkout"
+    assert response.title_snapshot == "Public title at checkout"
+    assert response.currency_snapshot == "BYN"

--- a/tests/unit/test_order_product_transfer_service.py
+++ b/tests/unit/test_order_product_transfer_service.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from models import OrderProductLink, Product
+from services.order_product_transfer_service import OrderProductTransferService
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+class _ScalarResult:
+    def __init__(self, product: Product):
+        self._product = product
+
+    def scalars(self):
+        return self
+
+    def first(self):
+        return self._product
+
+    def all(self):
+        return [self._product]
+
+
+class _ProductSession:
+    def __init__(self, product: Product):
+        self.product = product
+        self.statements = []
+
+    async def execute(self, statement):
+        self.statements.append(statement)
+        return _ScalarResult(self.product)
+
+
+def _product(*, title: str) -> Product:
+    return Product(
+        id=17,
+        title=title,
+        slug="stable-product-slug",
+        source_url="https://example.com/stable-product",
+        price=9000,
+        specs={},
+        is_published=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_legacy_none_title_snapshot_survives_renamed_product_roundtrip():
+    exported_product = _product(title="Catalog title at export")
+    legacy_link = OrderProductLink(
+        id=31,
+        order_id=10,
+        proposal_id=20,
+        product_id=17,
+        quantity=1,
+        price=3200,
+        title_snapshot=None,
+        currency_snapshot=None,
+    )
+    legacy_link.product = exported_product
+
+    transferred_line = OrderProductTransferService.snapshot_line(legacy_link)
+    assert transferred_line.product.title == "Catalog title at export"
+    assert transferred_line.title_snapshot is None
+
+    renamed_product = _product(title="Catalog title after rename")
+    resolved = await OrderProductTransferService.resolve_product(
+        _ProductSession(renamed_product),
+        transferred_line.product,
+    )
+    assert resolved.product is renamed_product
+    assert resolved.reason == "slug"
+
+    imported_link = OrderProductTransferService.build_import_link(
+        order_id=40,
+        proposal_id=50,
+        product_line=transferred_line,
+        product=renamed_product,
+    )
+
+    assert imported_link.product_id == renamed_product.id
+    assert imported_link.title_snapshot is None
+    assert imported_link.currency_snapshot is None
+
+
+def test_product_reference_title_is_separate_from_historical_snapshot():
+    product = _product(title="Current catalog title")
+    link = OrderProductLink(
+        id=31,
+        product_id=17,
+        quantity=1,
+        price=3200,
+        title_snapshot="Historical checkout title",
+        currency_snapshot="BYN",
+    )
+    link.product = product
+
+    transferred_line = OrderProductTransferService.snapshot_line(link)
+
+    assert transferred_line.product.title == "Current catalog title"
+    assert transferred_line.title_snapshot == "Historical checkout title"
+
+
+def test_order_transfer_modules_stay_below_monolith_gate():
+    for relative_path in (
+        "services/order_transfer_service.py",
+        "services/order_product_transfer_service.py",
+    ):
+        source = (PROJECT_ROOT / relative_path).read_text(encoding="utf-8")
+        assert len(source.splitlines()) < 700

--- a/tests/unit/test_order_source_fingerprint_migration.py
+++ b/tests/unit/test_order_source_fingerprint_migration.py
@@ -30,7 +30,7 @@ def test_order_source_fingerprint_remains_in_the_single_alembic_chain():
     script = ScriptDirectory.from_config(Config("alembic.ini"))
     revision = script.get_revision(REVISION)
 
-    assert script.get_heads() == ["ab02c3d4e5f6"]
+    assert script.get_heads() == ["f2a3b4c5d6e7"]
     assert revision is not None
     assert revision.down_revision == "f3c4d5e6f7a8"
     assert set(revision.nextrev) == {"d8e7f6a5b4c3"}

--- a/tests/unit/test_product_collection_eligibility.py
+++ b/tests/unit/test_product_collection_eligibility.py
@@ -61,3 +61,25 @@ def test_yandex_business_does_not_require_card_only_fields():
         supply_metrics={},
     )
     assert result.is_eligible
+
+
+def test_secondary_collection_eligibility_uses_offer_price_override():
+    product = Product(
+        title="Split",
+        slug="split",
+        product_kind="complete_split_system",
+        price=0,
+        main_image="/media/split.webp",
+        specs={"area_m2": 25},
+        is_published=True,
+    )
+
+    result = ProductCollectionEligibility.evaluate(
+        product,
+        surface_key="home",
+        slot_key="featured_products",
+        supply_metrics={"availability_status": "in_stock_now"},
+        price_override=2400,
+    )
+
+    assert result.is_eligible

--- a/tests/unit/test_product_collection_rule_matcher.py
+++ b/tests/unit/test_product_collection_rule_matcher.py
@@ -78,3 +78,14 @@ def test_rule_matcher_requires_every_selected_effective_feature():
         rule_config={"feature_ids": [10, 30]},
         supply_metrics={},
     )
+
+
+def test_secondary_collection_rules_use_offer_price_override():
+    product = _product(price=9000)
+
+    assert ProductCollectionRuleMatcher.matches(
+        product,
+        rule_config={"min_price": 2500, "max_price": 3500},
+        supply_metrics={},
+        price_override=3000,
+    )

--- a/tests/unit/test_product_response_mapper_variants.py
+++ b/tests/unit/test_product_response_mapper_variants.py
@@ -1,6 +1,13 @@
 import pytest
 
-from models import Product, ProductImage, ProductImageVariant, ProductSeries
+from models import (
+    Product,
+    ProductImage,
+    ProductImageVariant,
+    ProductSeries,
+    Tag,
+    TagGroup,
+)
 from services.product_image_processing_contract import (
     ProductImageManualQualityStatus,
     ProductImageProcessingStatus,
@@ -44,6 +51,54 @@ def _product_with_variant(
     ]
     product.gallery_images = [source_image]
     return product
+
+
+def test_map_product_to_response_excludes_hidden_tags_and_hidden_groups():
+    product = _product_with_variant()
+    public_group = TagGroup(
+        id=1,
+        title="Public group",
+        slug="public-group",
+        is_public=True,
+    )
+    hidden_group = TagGroup(
+        id=2,
+        title="Internal group",
+        slug="internal-group",
+        is_public=False,
+    )
+    public_tag = Tag(
+        id=10,
+        group_id=1,
+        title="Visible",
+        slug="visible",
+        is_public=True,
+    )
+    hidden_tag = Tag(
+        id=11,
+        group_id=1,
+        title="Internal tag",
+        slug="internal-tag",
+        is_public=False,
+    )
+    tag_in_hidden_group = Tag(
+        id=12,
+        group_id=2,
+        title="Internal group tag",
+        slug="internal-group-tag",
+        is_public=True,
+    )
+    public_tag.group = public_group
+    hidden_tag.group = public_group
+    tag_in_hidden_group.group = hidden_group
+    product.tags = [public_tag, hidden_tag, tag_in_hidden_group]
+
+    payload = map_product_to_response(product)
+
+    assert [tag.slug for tag in payload.tags] == ["visible"]
+    serialized = payload.model_dump_json()
+    assert "Internal tag" not in serialized
+    assert "Internal group" not in serialized
 
 
 def test_map_product_to_response_selects_only_approved_ready_card_and_full_variants():

--- a/tests/unit/test_product_response_mapper_variants.py
+++ b/tests/unit/test_product_response_mapper_variants.py
@@ -1,6 +1,7 @@
 import pytest
 
 from models import (
+    Brand,
     Product,
     ProductImage,
     ProductImageVariant,
@@ -322,6 +323,30 @@ def test_map_product_to_response_hides_unpublished_series():
     payload = map_product_to_response(product)
 
     assert payload.series is None
+
+
+def test_map_product_to_response_hides_unpublished_brand():
+    brand = Brand(
+        id=9,
+        title="Internal brand",
+        slug="internal-brand",
+        is_published=False,
+    )
+    product = Product(
+        id=1,
+        title="Public product",
+        slug="public-product",
+        price=1200,
+        specs={"area_m2": 25},
+        is_published=True,
+        brand_id=brand.id,
+    )
+    product.brand = brand
+
+    payload = map_product_to_response(product)
+
+    assert payload.brand is None
+    assert "Internal brand" not in payload.model_dump_json()
 
 
 def test_map_product_to_response_projects_offer_prices_without_mutating_product():

--- a/tests/unit/test_product_response_mapper_variants.py
+++ b/tests/unit/test_product_response_mapper_variants.py
@@ -267,3 +267,39 @@ def test_map_product_to_response_hides_unpublished_series():
     payload = map_product_to_response(product)
 
     assert payload.series is None
+
+
+def test_map_product_to_response_projects_offer_prices_without_mutating_product():
+    product = Product(
+        id=1,
+        title="Shared product",
+        slug="shared-product",
+        price=9000,
+        old_price=9500,
+        specs={"area_m2": 25},
+        is_published=True,
+    )
+    sibling = Product(
+        id=2,
+        title="Shared sibling",
+        slug="shared-sibling",
+        price=10000,
+        old_price=10500,
+        specs={"area_m2": 35},
+        is_published=True,
+    )
+
+    payload = map_product_to_response(
+        product,
+        series_siblings=[sibling],
+        pricing=(3000, 3500),
+        sibling_pricing={2: (4000, 4500)},
+    )
+
+    assert (payload.price, payload.old_price) == (3000, 3500)
+    assert (
+        payload.series_siblings[0].price,
+        payload.series_siblings[0].old_price,
+    ) == (4000, 4500)
+    assert (product.price, product.old_price) == (9000, 9500)
+    assert (sibling.price, sibling.old_price) == (10000, 10500)

--- a/tests/unit/test_public_catalog_cache_headers.py
+++ b/tests/unit/test_public_catalog_cache_headers.py
@@ -1,0 +1,63 @@
+import pytest
+from starlette.responses import Response
+
+from core.storefront_request_envelope import force_private_storefront_response_headers
+from models.tenancy import TenantScope
+from routers.api_catalog_revision import get_catalog_revision
+from services.catalog_revision_service import CatalogRevisionService
+
+
+@pytest.mark.asyncio
+async def test_revision_etag_is_storefront_specific_and_varies_by_verified_host(
+    monkeypatch,
+):
+    async def fake_contextual(_session, *, tenant_scope):
+        storefront_revision = 3 if tenant_scope.storefront_id == 20 else 8
+        return {
+            "revision": 11,
+            "storefront_revision": storefront_revision,
+            "cache_key": f"g11-s{storefront_revision}",
+            "updated_at": "2026-08-01T00:00:00+00:00",
+        }
+
+    monkeypatch.setattr(CatalogRevisionService, "get_contextual", fake_contextual)
+    scope_a = TenantScope(2, 20, is_canonical_storefront=False)
+    scope_b = TenantScope(2, 21, is_canonical_storefront=False)
+    response_a = Response()
+    response_b = Response()
+
+    payload_a = await get_catalog_revision(
+        response_a,
+        session=object(),
+        tenant_scope=scope_a,
+    )
+    payload_b = await get_catalog_revision(
+        response_b,
+        session=object(),
+        tenant_scope=scope_b,
+    )
+
+    assert payload_a["cache_key"] == "g11-s3"
+    assert payload_b["cache_key"] == "g11-s8"
+    assert response_a.headers["ETag"] == 'W/"catalog-g11-s3"'
+    assert response_b.headers["ETag"] == 'W/"catalog-g11-s8"'
+    assert response_a.headers["Vary"] == "X-MVN-Storefront-Host"
+    assert response_b.headers["Vary"] == "X-MVN-Storefront-Host"
+    assert response_a.headers["Cache-Control"] == "private, no-cache, max-age=0"
+
+
+def test_signed_storefront_cache_policy_preserves_etag_and_merges_vary():
+    headers = force_private_storefront_response_headers(
+        [
+            (b"etag", b'W/"catalog-g11-s3"'),
+            (b"cache-control", b"public, max-age=3600"),
+            (b"cdn-cache-control", b"public, max-age=3600"),
+            (b"vary", b"Accept-Encoding, accept-encoding"),
+        ]
+    )
+    by_name = {name.lower(): value.decode("latin-1") for name, value in headers}
+
+    assert by_name[b"etag"] == 'W/"catalog-g11-s3"'
+    assert by_name[b"cache-control"] == "private, no-store"
+    assert by_name[b"cdn-cache-control"] == "no-store"
+    assert by_name[b"vary"] == "Accept-Encoding, X-MVN-Storefront-Host"

--- a/tests/unit/test_public_catalog_checkout_locking.py
+++ b/tests/unit/test_public_catalog_checkout_locking.py
@@ -1,0 +1,67 @@
+import pytest
+from sqlalchemy.dialects import postgresql
+
+from crud.public_catalog_checkout import PublicCatalogCheckoutDAO
+from models.tenancy import TenantScope
+
+
+class _Result:
+    def all(self):
+        return []
+
+
+class _CapturingSession:
+    def __init__(self):
+        self.statement = None
+
+    async def execute(self, statement):
+        self.statement = statement
+        return _Result()
+
+
+def _postgres_sql(statement) -> str:
+    return str(
+        statement.compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={"literal_binds": True},
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_shared_checkout_prices_use_deterministic_compatible_row_locks():
+    session = _CapturingSession()
+
+    result = await PublicCatalogCheckoutDAO.get_shared_prices_by_ids(
+        session,
+        product_ids={9, 3},
+    )
+
+    sql = _postgres_sql(session.statement)
+    assert result == {}
+    assert "ORDER BY product.id ASC" in sql
+    assert "FOR SHARE OF product" in sql
+    assert "FOR UPDATE" not in sql
+
+
+@pytest.mark.asyncio
+async def test_offer_checkout_prices_lock_exact_scope_in_product_order():
+    session = _CapturingSession()
+
+    result = await PublicCatalogCheckoutDAO.get_offer_prices_by_ids(
+        session,
+        tenant_scope=TenantScope(
+            tenant_id=7,
+            storefront_id=11,
+            is_canonical_storefront=False,
+        ),
+        product_ids={9, 3},
+    )
+
+    sql = _postgres_sql(session.statement)
+    assert result == {}
+    assert "tenant_offer.tenant_id = 7" in sql
+    assert "tenant_offer.storefront_id = 11" in sql
+    assert "ORDER BY product.id ASC" in sql
+    assert "FOR SHARE OF product, tenant_offer" in sql
+    assert "FOR UPDATE" not in sql

--- a/tests/unit/test_public_catalog_checkout_locking.py
+++ b/tests/unit/test_public_catalog_checkout_locking.py
@@ -1,22 +1,29 @@
 import pytest
 from sqlalchemy.dialects import postgresql
 
-from crud.public_catalog_checkout import PublicCatalogCheckoutDAO
+from crud.public_catalog_checkout import (
+    LockedPublicCatalogProduct,
+    PublicCatalogCheckoutDAO,
+)
 from models.tenancy import TenantScope
 
 
 class _Result:
+    def __init__(self, rows=()):
+        self._rows = rows
+
     def all(self):
-        return []
+        return list(self._rows)
 
 
 class _CapturingSession:
-    def __init__(self):
+    def __init__(self, rows=()):
         self.statement = None
+        self.rows = rows
 
     async def execute(self, statement):
         self.statement = statement
-        return _Result()
+        return _Result(self.rows)
 
 
 def _postgres_sql(statement) -> str:
@@ -29,26 +36,43 @@ def _postgres_sql(statement) -> str:
 
 
 @pytest.mark.asyncio
-async def test_shared_checkout_prices_use_deterministic_compatible_row_locks():
-    session = _CapturingSession()
+async def test_shared_checkout_snapshot_locks_title_price_and_context_currency():
+    session = _CapturingSession([(3, "Model 03", 3200, "BYN")])
 
-    result = await PublicCatalogCheckoutDAO.get_shared_prices_by_ids(
+    result = await PublicCatalogCheckoutDAO.get_shared_snapshots_by_ids(
         session,
+        tenant_scope=TenantScope(
+            tenant_id=7,
+            storefront_id=11,
+            is_canonical_storefront=True,
+        ),
         product_ids={9, 3},
     )
 
     sql = _postgres_sql(session.statement)
-    assert result == {}
+    assert result == {
+        3: LockedPublicCatalogProduct(
+            product_id=3,
+            title="Model 03",
+            unit_price=3200,
+            currency="BYN",
+        )
+    }
+    assert "product.title" in sql
+    assert "storefront.currency" in sql
+    assert "storefront.id = 11" in sql
+    assert "storefront.tenant_id = 7" in sql
+    assert "storefront.status = 'active'" in sql
     assert "ORDER BY product.id ASC" in sql
-    assert "FOR SHARE OF product" in sql
+    assert "FOR SHARE OF product, storefront" in sql
     assert "FOR UPDATE" not in sql
 
 
 @pytest.mark.asyncio
-async def test_offer_checkout_prices_lock_exact_scope_in_product_order():
+async def test_offer_checkout_snapshot_locks_exact_scope_in_product_order():
     session = _CapturingSession()
 
-    result = await PublicCatalogCheckoutDAO.get_offer_prices_by_ids(
+    result = await PublicCatalogCheckoutDAO.get_offer_snapshots_by_ids(
         session,
         tenant_scope=TenantScope(
             tenant_id=7,
@@ -62,6 +86,8 @@ async def test_offer_checkout_prices_lock_exact_scope_in_product_order():
     assert result == {}
     assert "tenant_offer.tenant_id = 7" in sql
     assert "tenant_offer.storefront_id = 11" in sql
+    assert "product.title" in sql
+    assert "storefront.currency" in sql
     assert "ORDER BY product.id ASC" in sql
-    assert "FOR SHARE OF product, tenant_offer" in sql
+    assert "FOR SHARE OF product, tenant_offer, storefront" in sql
     assert "FOR UPDATE" not in sql

--- a/tests/unit/test_public_catalog_route_scope.py
+++ b/tests/unit/test_public_catalog_route_scope.py
@@ -1,0 +1,61 @@
+from fastapi.routing import APIRoute
+
+from api_contracts.public_catalog import PublicProductSearchItemResponse
+from core.tenant_scope import get_public_tenant_scope
+from main import app
+
+
+_SCOPED_PUBLIC_CATALOG_PATHS = {
+    "/api/products/search",
+    "/api/v1/catalog",
+    "/api/v1/products",
+    "/api/v1/products/vitebsk-featured",
+    "/api/v1/products/{identifier}",
+    "/api/v1/product-series/navigation",
+    "/api/v1/specs/keys",
+    "/api/v1/filters/config",
+    "/api/v1/content/brands",
+    "/api/v1/content/brands/{slug}",
+    "/api/v1/content/brands/{brand_slug}/series/{series_slug}",
+    "/api/v1/content/placements/{surface_key}/{slot_key}/collections",
+    "/api/v1/leads/product-availability",
+    "/api/v1/orders",
+}
+
+
+def _has_dependency(route: APIRoute, dependency_call) -> bool:
+    pending = list(route.dependant.dependencies)
+    while pending:
+        dependency = pending.pop()
+        if dependency.call is dependency_call:
+            return True
+        pending.extend(dependency.dependencies)
+    return False
+
+
+def test_every_product_bearing_public_surface_resolves_exact_storefront_scope():
+    routes = {
+        route.path: route
+        for route in app.routes
+        if isinstance(route, APIRoute) and route.path in _SCOPED_PUBLIC_CATALOG_PATHS
+    }
+
+    assert set(routes) == _SCOPED_PUBLIC_CATALOG_PATHS
+    assert all(
+        _has_dependency(route, get_public_tenant_scope)
+        for route in routes.values()
+    )
+
+
+def test_public_search_contract_excludes_internal_commercial_fields():
+    internal_fields = {
+        "source_url",
+        "min_cost_byn",
+        "recommended_price_byn",
+        "margin_abs_preview",
+        "margin_pct_preview",
+        "supplier_offer_id",
+        "tags",
+    }
+
+    assert internal_fields.isdisjoint(PublicProductSearchItemResponse.model_fields)

--- a/tests/unit/test_public_catalog_visibility.py
+++ b/tests/unit/test_public_catalog_visibility.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy.dialects import postgresql
+
+from crud.product import ProductDAO
+from crud.public_catalog import PublicCatalogDAO
+from models import Product
+from models.tenancy import TenantScope
+from services.product_read_service import ProductReadService
+from services.public_catalog_service import PublicCatalogService
+from services.public_catalog_visibility_service import PublicCatalogVisibilityService
+
+
+def _postgres_sql(statement) -> str:
+    return str(
+        statement.compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={"literal_binds": True},
+        )
+    )
+
+
+def _product(product_id: int = 17) -> Product:
+    return Product(
+        id=product_id,
+        title="Scoped product",
+        slug=f"scoped-product-{product_id}",
+        price=9000,
+        old_price=9500,
+        specs={"area_m2": 25},
+        is_published=True,
+    )
+
+
+class _RowsResult:
+    def all(self):
+        return []
+
+
+class _CapturingSession:
+    bind = None
+
+    def __init__(self):
+        self.statement = None
+
+    async def execute(self, statement):
+        self.statement = statement
+        return _RowsResult()
+
+
+def test_secondary_catalog_sql_requires_exact_active_published_offer_pair():
+    scope_a = TenantScope(
+        tenant_id=7,
+        storefront_id=11,
+        is_canonical_storefront=False,
+    )
+    scope_b = TenantScope(
+        tenant_id=8,
+        storefront_id=12,
+        is_canonical_storefront=False,
+    )
+
+    sql_a = _postgres_sql(PublicCatalogDAO._select_products(scope_a))
+    sql_b = _postgres_sql(PublicCatalogDAO._select_products(scope_b))
+
+    assert "product.is_published IS true" in sql_a
+    assert "tenant_offer.tenant_id = 7" in sql_a
+    assert "tenant_offer.storefront_id = 11" in sql_a
+    assert "tenant_offer.status = 'active'" in sql_a
+    assert "tenant_offer.is_published IS true" in sql_a
+    assert "tenant_offer.tenant_id = 8" in sql_b
+    assert "tenant_offer.storefront_id = 12" in sql_b
+    assert sql_a != sql_b
+
+
+@pytest.mark.asyncio
+async def test_secondary_price_filter_sort_and_pagination_use_offer_column():
+    session = _CapturingSession()
+
+    rows = await PublicCatalogDAO.get_filtered(
+        session,
+        tenant_scope=TenantScope(
+            tenant_id=7,
+            storefront_id=11,
+            is_canonical_storefront=False,
+        ),
+        min_price=2500,
+        max_price=3500,
+        sort="price_asc",
+        page=2,
+        limit=20,
+    )
+
+    sql = _postgres_sql(session.statement)
+    assert rows == []
+    assert "tenant_offer.price >= 2500" in sql
+    assert "tenant_offer.price <= 3500" in sql
+    assert "ORDER BY tenant_offer.price ASC, product.id ASC" in sql
+    assert "LIMIT 20 OFFSET 20" in sql
+    assert "product.price >=" not in sql
+    assert "product.price <=" not in sql
+
+
+@pytest.mark.asyncio
+async def test_visibility_is_negative_across_storefront_a_and_b(monkeypatch):
+    product = _product()
+    scope_a = TenantScope(tenant_id=2, storefront_id=20, is_canonical_storefront=False)
+    scope_b = TenantScope(tenant_id=2, storefront_id=21, is_canonical_storefront=False)
+    seen_scopes: list[tuple[int, int]] = []
+
+    async def fake_get_by_ids(
+        _session,
+        *,
+        tenant_scope,
+        product_ids,
+        load_image_variants=False,
+    ):
+        assert product_ids == [17]
+        assert load_image_variants is False
+        pair = (tenant_scope.tenant_id, tenant_scope.storefront_id)
+        seen_scopes.append(pair)
+        return [(product, 3000, 3500)] if pair == (2, 20) else []
+
+    monkeypatch.setattr(PublicCatalogDAO, "get_by_ids", fake_get_by_ids)
+
+    visible_a = await PublicCatalogVisibilityService.get_visible_product_by_id(
+        object(),
+        tenant_scope=scope_a,
+        product_id=17,
+    )
+    hidden_b = await PublicCatalogVisibilityService.get_visible_product_by_id(
+        object(),
+        tenant_scope=scope_b,
+        product_id=17,
+    )
+
+    assert visible_a is not None
+    assert visible_a.product is product
+    assert visible_a.pricing == (3000, 3500)
+    assert hidden_b is None
+    assert seen_scopes == [(2, 20), (2, 21)]
+
+
+@pytest.mark.asyncio
+async def test_canonical_visibility_requires_published_product(monkeypatch):
+    product = _product()
+    captured = {}
+
+    async def fake_get_by_id(_session, product_id, **kwargs):
+        captured.update(product_id=product_id, **kwargs)
+        return product
+
+    monkeypatch.setattr(ProductDAO, "get_by_id", fake_get_by_id)
+
+    projection = await PublicCatalogVisibilityService.get_visible_product_by_id(
+        object(),
+        tenant_scope=TenantScope(
+            tenant_id=1,
+            storefront_id=1,
+            is_system=True,
+            is_canonical_storefront=True,
+        ),
+        product_id=17,
+    )
+
+    assert projection is not None
+    assert projection.product is product
+    assert captured == {"product_id": 17, "is_published": True}
+
+
+@pytest.mark.asyncio
+async def test_canonical_public_search_explicitly_filters_unpublished(monkeypatch):
+    captured = {}
+
+    async def fake_get_filtered(_session, **kwargs):
+        captured.update(kwargs)
+        return []
+
+    async def fake_metrics(_session, _products):
+        return {}
+
+    monkeypatch.setattr(ProductDAO, "get_filtered", fake_get_filtered)
+    monkeypatch.setattr(ProductReadService, "get_supply_metrics_map", fake_metrics)
+
+    result = await PublicCatalogService.search(
+        SimpleNamespace(),
+        tenant_scope=TenantScope(
+            tenant_id=1,
+            storefront_id=1,
+            is_system=True,
+            is_canonical_storefront=True,
+        ),
+        query="hidden",
+        is_inverter=None,
+    )
+
+    assert result == []
+    assert captured["is_published"] is True

--- a/tests/unit/test_public_catalog_visibility.py
+++ b/tests/unit/test_public_catalog_visibility.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 import pytest
 from sqlalchemy.dialects import postgresql
 
+from crud.canonical_public_catalog import CanonicalPublicCatalogDAO
 from crud.product import ProductDAO
 from crud.public_catalog import PublicCatalogDAO
 from models import Product
@@ -105,6 +106,28 @@ async def test_secondary_price_filter_sort_and_pagination_use_offer_column():
 
 
 @pytest.mark.asyncio
+async def test_secondary_q_only_searches_public_taxonomy():
+    session = _CapturingSession()
+
+    rows = await PublicCatalogDAO.get_filtered(
+        session,
+        tenant_scope=TenantScope(
+            tenant_id=7,
+            storefront_id=11,
+            is_canonical_storefront=False,
+        ),
+        search_query="InternalTaxonomyTitle",
+    )
+
+    sql = _postgres_sql(session.statement)
+    assert rows == []
+    assert "tenant_offer.tenant_id = 7" in sql
+    assert "tag.title ILIKE '%%InternalTaxonomyTitle%%'" in sql
+    assert "tag.is_public IS true" in sql
+    assert "tag_group.is_public IS true" in sql
+
+
+@pytest.mark.asyncio
 async def test_visibility_is_negative_across_storefront_a_and_b(monkeypatch):
     product = _product()
     scope_a = TenantScope(tenant_id=2, storefront_id=20, is_canonical_storefront=False)
@@ -172,7 +195,7 @@ async def test_canonical_visibility_requires_published_product(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_canonical_public_search_explicitly_filters_unpublished(monkeypatch):
+async def test_canonical_public_search_uses_canonical_public_dao(monkeypatch):
     captured = {}
 
     async def fake_get_filtered(_session, **kwargs):
@@ -182,7 +205,7 @@ async def test_canonical_public_search_explicitly_filters_unpublished(monkeypatc
     async def fake_metrics(_session, _products):
         return {}
 
-    monkeypatch.setattr(ProductDAO, "get_filtered", fake_get_filtered)
+    monkeypatch.setattr(CanonicalPublicCatalogDAO, "get_filtered", fake_get_filtered)
     monkeypatch.setattr(ProductReadService, "get_supply_metrics_map", fake_metrics)
 
     result = await PublicCatalogService.search(
@@ -198,4 +221,4 @@ async def test_canonical_public_search_explicitly_filters_unpublished(monkeypatc
     )
 
     assert result == []
-    assert captured["is_published"] is True
+    assert captured["search_query"] == "hidden"

--- a/tests/unit/test_public_product_availability_api.py
+++ b/tests/unit/test_public_product_availability_api.py
@@ -4,7 +4,7 @@ import pytest
 from core.database import get_session
 from core.tenant_scope import get_public_tenant_scope
 from main import app
-from models import Product
+from models import Product, Tag, TagGroup
 from models.tenancy import TenantScope
 from services.feature_resolver_service import FeatureResolverService
 from services.public_catalog_service import PublicCatalogService, PublicProductPage
@@ -26,9 +26,50 @@ def _make_product(product_id: int = 1) -> Product:
     )
 
 
+def _attach_mixed_taxonomy(product: Product) -> None:
+    public_group = TagGroup(
+        id=10,
+        title="Public",
+        slug="public",
+        is_public=True,
+    )
+    hidden_group = TagGroup(
+        id=11,
+        title="Internal group",
+        slug="internal-group",
+        is_public=False,
+    )
+    public_tag = Tag(
+        id=20,
+        group_id=10,
+        title="Visible tag",
+        slug="visible-tag",
+        is_public=True,
+    )
+    hidden_tag = Tag(
+        id=21,
+        group_id=10,
+        title="Internal tag",
+        slug="internal-tag",
+        is_public=False,
+    )
+    hidden_group_tag = Tag(
+        id=22,
+        group_id=11,
+        title="Internal group tag",
+        slug="internal-group-tag",
+        is_public=True,
+    )
+    public_tag.group = public_group
+    hidden_tag.group = public_group
+    hidden_group_tag.group = hidden_group
+    product.tags = [public_tag, hidden_tag, hidden_group_tag]
+
+
 @pytest.mark.asyncio
 async def test_public_catalog_includes_city_availability(monkeypatch):
     product = _make_product()
+    _attach_mixed_taxonomy(product)
 
     async def override_get_session():
         yield object()
@@ -83,11 +124,15 @@ async def test_public_catalog_includes_city_availability(monkeypatch):
     assert payload["items"][0]["vitebsk_qty"] == 0
     assert payload["items"][0]["minsk_qty"] == 3
     assert payload["items"][0]["availability_status"] == "available_2_3_days"
+    assert [tag["slug"] for tag in payload["items"][0]["tags"]] == [
+        "visible-tag"
+    ]
 
 
 @pytest.mark.asyncio
 async def test_public_product_detail_includes_city_availability(monkeypatch):
     product = _make_product(34)
+    _attach_mixed_taxonomy(product)
 
     async def override_get_session():
         yield object()
@@ -140,3 +185,4 @@ async def test_public_product_detail_includes_city_availability(monkeypatch):
     assert payload["vitebsk_qty"] == 0
     assert payload["minsk_qty"] == 0
     assert payload["availability_status"] == "check_availability"
+    assert [tag["slug"] for tag in payload["tags"]] == ["visible-tag"]

--- a/tests/unit/test_public_product_availability_api.py
+++ b/tests/unit/test_public_product_availability_api.py
@@ -2,9 +2,13 @@ from httpx import ASGITransport, AsyncClient
 import pytest
 
 from core.database import get_session
+from core.tenant_scope import get_public_tenant_scope
 from main import app
 from models import Product
+from models.tenancy import TenantScope
 from services.feature_resolver_service import FeatureResolverService
+from services.public_catalog_service import PublicCatalogService, PublicProductPage
+from services.public_catalog_visibility_service import PublicProductProjection
 from services.product_service import ProductService
 
 
@@ -29,9 +33,23 @@ async def test_public_catalog_includes_city_availability(monkeypatch):
     async def override_get_session():
         yield object()
 
+    async def override_tenant_scope():
+        return TenantScope(
+            tenant_id=1,
+            storefront_id=1,
+            is_system=True,
+            is_canonical_storefront=True,
+        )
+
     async def fake_get_catalog_page(*args, **kwargs):
         return {
-            "items": [product],
+            "items": [
+                PublicProductProjection(
+                    product=product,
+                    price=product.price,
+                    old_price=product.old_price,
+                )
+            ],
             "meta": {"total": 1, "page": 1, "limit": 20, "pages": 1},
         }
 
@@ -47,10 +65,11 @@ async def test_public_catalog_includes_city_availability(monkeypatch):
     async def fake_resolve_features(*args, **kwargs):
         return {}
 
-    monkeypatch.setattr(ProductService, "get_catalog_page", fake_get_catalog_page)
+    monkeypatch.setattr(PublicCatalogService, "get_catalog_page", fake_get_catalog_page)
     monkeypatch.setattr(ProductService, "get_supply_metrics_map", fake_get_supply_metrics_map)
     monkeypatch.setattr(FeatureResolverService, "resolve_for_products", fake_resolve_features)
     app.dependency_overrides[get_session] = override_get_session
+    app.dependency_overrides[get_public_tenant_scope] = override_tenant_scope
 
     transport = ASGITransport(app=app)
     try:
@@ -73,11 +92,23 @@ async def test_public_product_detail_includes_city_availability(monkeypatch):
     async def override_get_session():
         yield object()
 
-    async def fake_get_public_product_by_identifier(*args, **kwargs):
-        return product
+    async def override_tenant_scope():
+        return TenantScope(
+            tenant_id=1,
+            storefront_id=1,
+            is_system=True,
+            is_canonical_storefront=True,
+        )
 
-    async def fake_get_series_siblings(*args, **kwargs):
-        return []
+    async def fake_get_product_page(*args, **kwargs):
+        return PublicProductPage(
+            product=PublicProductProjection(
+                product=product,
+                price=product.price,
+                old_price=product.old_price,
+            ),
+            siblings=[],
+        )
 
     async def fake_get_supply_metrics_map(*args, **kwargs):
         return {
@@ -91,11 +122,11 @@ async def test_public_product_detail_includes_city_availability(monkeypatch):
     async def fake_resolve_features(*args, **kwargs):
         return {}
 
-    monkeypatch.setattr(ProductService, "get_public_product_by_identifier", fake_get_public_product_by_identifier)
-    monkeypatch.setattr(ProductService, "get_series_siblings", fake_get_series_siblings)
+    monkeypatch.setattr(PublicCatalogService, "get_product_page", fake_get_product_page)
     monkeypatch.setattr(ProductService, "get_supply_metrics_map", fake_get_supply_metrics_map)
     monkeypatch.setattr(FeatureResolverService, "resolve_for_products", fake_resolve_features)
     app.dependency_overrides[get_session] = override_get_session
+    app.dependency_overrides[get_public_tenant_scope] = override_tenant_scope
 
     transport = ASGITransport(app=app)
     try:

--- a/tests/unit/test_public_taxonomy_boundary.py
+++ b/tests/unit/test_public_taxonomy_boundary.py
@@ -7,8 +7,16 @@ from sqlalchemy.dialects import postgresql
 from sqlmodel import select
 
 from crud.canonical_public_catalog import CanonicalPublicCatalogDAO
+from crud.public_catalog import PublicCatalogDAO
 from crud.public_taxonomy import PublicTaxonomyDAO
 from models import Product
+from models.tenancy import TenantScope
+from services.feature_resolver_service import FeatureResolverService
+from services.public_catalog_service import PublicCatalogService
+from services.public_catalog_visibility_service import (
+    PublicCatalogVisibilityService,
+    PublicProductProjection,
+)
 from services.product_series_service import ProductSeriesService
 
 
@@ -24,6 +32,9 @@ def _postgres_sql(statement) -> str:
 class _EmptyRows:
     def all(self):
         return []
+
+    def scalars(self):
+        return self
 
 
 class _Rows:
@@ -185,3 +196,199 @@ def test_series_group_keys_ignore_hidden_taxonomy():
     )
 
     assert ProductSeriesService._series_group_keys(product) == ["tag:1"]
+
+
+def test_hidden_series_id_does_not_override_public_fallback_group_key():
+    product = SimpleNamespace(
+        series_id=77,
+        series=SimpleNamespace(id=77, is_published=False),
+        tags=[
+            SimpleNamespace(
+                id=1,
+                is_public=True,
+                group=SimpleNamespace(slug="series", is_public=True),
+            )
+        ],
+        specs={"series": "Public fallback"},
+    )
+
+    assert ProductSeriesService._series_group_keys(product) == [
+        "tag:1",
+        "specs:public fallback",
+    ]
+
+
+class _FailIfExecuted:
+    async def execute(self, _statement):
+        raise AssertionError("hidden series must not issue a sibling query")
+
+
+@pytest.mark.asyncio
+async def test_hidden_series_cannot_drive_canonical_detail_siblings():
+    product = SimpleNamespace(
+        id=10,
+        series_id=77,
+        series=SimpleNamespace(id=77, is_published=False),
+        tags=[],
+        specs={},
+    )
+
+    siblings = await ProductSeriesService.get_series_siblings(
+        _FailIfExecuted(),
+        product,
+    )
+
+    assert siblings == []
+
+
+@pytest.mark.asyncio
+async def test_hidden_series_cannot_drive_offer_scoped_detail_siblings():
+    product = SimpleNamespace(
+        id=10,
+        series_id=77,
+        series=SimpleNamespace(id=77, is_published=False),
+        tags=[],
+        specs={},
+    )
+
+    siblings = await PublicCatalogDAO.get_series_siblings(
+        _FailIfExecuted(),
+        tenant_scope=SimpleNamespace(tenant_id=1, storefront_id=2),
+        product=product,
+    )
+
+    assert siblings == []
+
+
+def _series_sort_product(
+    product_id: int,
+    *,
+    brand_tag_id: int,
+):
+    return SimpleNamespace(
+        id=product_id,
+        title=f"Product {product_id}",
+        brand_id=99,
+        brand=SimpleNamespace(id=99, is_published=False),
+        tags=[
+            SimpleNamespace(
+                id=brand_tag_id,
+                is_public=True,
+                group=SimpleNamespace(slug="brand", is_public=True),
+            )
+        ],
+        specs={"area_m2": 25},
+        power_cooling=2.5,
+        price=1000,
+    )
+
+
+def test_hidden_brand_id_does_not_influence_canonical_sibling_order():
+    reference = _series_sort_product(1, brand_tag_id=10)
+    hidden_id_match = _series_sort_product(2, brand_tag_id=20)
+    public_tag_match = _series_sort_product(3, brand_tag_id=10)
+
+    ordered = ProductSeriesService._sort_series_candidates(
+        reference,
+        [hidden_id_match, public_tag_match],
+    )
+
+    assert [item.id for item in ordered] == [3, 2]
+
+
+def test_hidden_brand_id_does_not_influence_offer_sibling_order():
+    reference = PublicProductProjection(
+        product=_series_sort_product(1, brand_tag_id=10),
+        price=1000,
+        old_price=None,
+    )
+    hidden_id_match = PublicProductProjection(
+        product=_series_sort_product(2, brand_tag_id=20),
+        price=1000,
+        old_price=None,
+    )
+    public_tag_match = PublicProductProjection(
+        product=_series_sort_product(3, brand_tag_id=10),
+        price=1000,
+        old_price=None,
+    )
+
+    ordered = PublicCatalogService._sort_series_projections(
+        reference,
+        [hidden_id_match, public_tag_match],
+    )
+
+    assert [item.product.id for item in ordered] == [3, 2]
+
+
+@pytest.mark.asyncio
+async def test_hidden_series_is_absent_from_offer_navigation(monkeypatch):
+    hidden_series = SimpleNamespace(id=77, is_published=False)
+    products = [
+        SimpleNamespace(
+            id=product_id,
+            slug=f"hidden-series-{product_id}",
+            series_id=77,
+            series=hidden_series,
+            tags=[],
+            specs={},
+        )
+        for product_id in (1, 2)
+    ]
+
+    async def fake_is_canonical(_session, _scope):
+        return False
+
+    async def fake_get_all(_session, *, tenant_scope, load_image_variants=False):
+        assert tenant_scope.storefront_id == 2
+        assert load_image_variants is False
+        return [(product, 1000, None) for product in products]
+
+    async def fake_resolve(_session, candidates):
+        assert candidates == products
+
+    monkeypatch.setattr(
+        PublicCatalogVisibilityService,
+        "is_canonical_scope",
+        fake_is_canonical,
+    )
+    monkeypatch.setattr(PublicCatalogDAO, "get_all", fake_get_all)
+    monkeypatch.setattr(
+        FeatureResolverService,
+        "resolve_for_products",
+        fake_resolve,
+    )
+
+    navigation = await PublicCatalogService.get_series_navigation(
+        object(),
+        tenant_scope=TenantScope(
+            tenant_id=1,
+            storefront_id=2,
+            is_canonical_storefront=False,
+        ),
+    )
+
+    assert navigation.products == {}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("sort", "expected_order"),
+    [
+        ("price_asc", "product.price ASC, product.id ASC"),
+        ("price_desc", "product.price DESC, product.id DESC"),
+        ("area_asc", " ASC, product.id ASC"),
+        ("area_desc", " DESC, product.id DESC"),
+    ],
+)
+async def test_canonical_price_and_area_sorts_have_stable_id_tie_breaker(
+    sort,
+    expected_order,
+):
+    session = _EmptyPublicTaxonomySession()
+
+    await CanonicalPublicCatalogDAO.get_filtered(session, sort=sort)
+
+    sql = _postgres_sql(session.statements[0])
+    order_by = sql.split(" ORDER BY ", maxsplit=1)[1]
+    assert expected_order in order_by

--- a/tests/unit/test_public_taxonomy_boundary.py
+++ b/tests/unit/test_public_taxonomy_boundary.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy.dialects import postgresql
+from sqlmodel import select
+
+from crud.canonical_public_catalog import CanonicalPublicCatalogDAO
+from crud.public_taxonomy import PublicTaxonomyDAO
+from models import Product
+from services.product_series_service import ProductSeriesService
+
+
+def _postgres_sql(statement) -> str:
+    return str(
+        statement.compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={"literal_binds": True},
+        )
+    )
+
+
+class _EmptyRows:
+    def all(self):
+        return []
+
+
+class _Rows:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def all(self):
+        return list(self._rows)
+
+    def scalars(self):
+        return self
+
+
+class _EmptyPublicTaxonomySession:
+    bind = SimpleNamespace(dialect=SimpleNamespace(name="postgresql"))
+
+    def __init__(self) -> None:
+        self.statements = []
+
+    async def execute(self, statement):
+        self.statements.append(statement)
+        return _EmptyRows()
+
+
+class _QueuedSession(_EmptyPublicTaxonomySession):
+    def __init__(self, rows):
+        super().__init__()
+        self._rows = iter(rows)
+
+    async def execute(self, statement):
+        self.statements.append(statement)
+        return _Rows(next(self._rows))
+
+
+@pytest.mark.asyncio
+async def test_hidden_and_unknown_filter_slugs_have_identical_neutral_behavior():
+    hidden_session = _EmptyPublicTaxonomySession()
+    unknown_session = _EmptyPublicTaxonomySession()
+
+    hidden = await PublicTaxonomyDAO.resolve_filter_ids(
+        hidden_session,
+        tag_slugs=["internal-only"],
+        brand_slugs=None,
+    )
+    unknown = await PublicTaxonomyDAO.resolve_filter_ids(
+        unknown_session,
+        tag_slugs=["does-not-exist"],
+        brand_slugs=None,
+    )
+
+    assert hidden == unknown == (None, [])
+    for statement in hidden_session.statements + unknown_session.statements:
+        sql = _postgres_sql(statement)
+        assert "tag.is_public IS true" in sql
+        assert "tag_group.is_public IS true" in sql
+
+
+@pytest.mark.asyncio
+async def test_legacy_brand_slug_requires_public_tag_and_published_brand():
+    session = _QueuedSession(
+        [
+            [(7, 3, "brand-a", "brand")],
+            ["brand-a"],
+        ]
+    )
+
+    faceted_ids, brand_slugs = await PublicTaxonomyDAO.resolve_filter_ids(
+        session,
+        tag_slugs=["brand-a"],
+        brand_slugs=None,
+    )
+
+    assert faceted_ids is None
+    assert brand_slugs == ["brand-a"]
+    tag_sql, brand_sql = map(_postgres_sql, session.statements)
+    assert "tag.is_public IS true" in tag_sql
+    assert "tag_group.is_public IS true" in tag_sql
+    assert "brand.is_published IS true" in brand_sql
+
+
+@pytest.mark.asyncio
+async def test_unpublished_legacy_brand_is_neutral_like_unknown_slug():
+    hidden_brand_session = _QueuedSession(
+        [
+            [(7, 3, "hidden-brand", "brand")],
+            [],
+        ]
+    )
+    unknown_session = _EmptyPublicTaxonomySession()
+
+    hidden_brand = await PublicTaxonomyDAO.resolve_filter_ids(
+        hidden_brand_session,
+        tag_slugs=["hidden-brand"],
+        brand_slugs=None,
+    )
+    unknown = await PublicTaxonomyDAO.resolve_filter_ids(
+        unknown_session,
+        tag_slugs=["does-not-exist"],
+        brand_slugs=None,
+    )
+
+    assert hidden_brand == unknown == (None, [])
+
+
+def test_public_q_cannot_match_hidden_tag_title_or_hidden_group():
+    session = _EmptyPublicTaxonomySession()
+    statement = PublicTaxonomyDAO.apply_search_filter(
+        session,
+        select(Product),
+        "InternalTaxonomyTitle",
+    )
+
+    sql = _postgres_sql(statement)
+    assert "product.title ILIKE '%%InternalTaxonomyTitle%%'" in sql
+    assert "tag.title ILIKE '%%InternalTaxonomyTitle%%'" in sql
+    assert "tag.is_public IS true" in sql
+    assert "tag_group.is_public IS true" in sql
+
+
+@pytest.mark.asyncio
+async def test_canonical_public_search_selects_public_taxonomy_mode():
+    captured = {}
+
+    class _Result:
+        def scalars(self):
+            return self
+
+        def all(self):
+            return []
+
+    class _Session(_EmptyPublicTaxonomySession):
+        async def execute(self, statement):
+            captured["statement"] = statement
+            return _Result()
+
+    products = await CanonicalPublicCatalogDAO.get_filtered(
+        _Session(),
+        search_query="InternalTaxonomyTitle",
+    )
+
+    assert products == []
+    sql = _postgres_sql(captured["statement"])
+    assert "product.is_published = true" in sql
+    assert "tag.is_public IS true" in sql
+    assert "tag_group.is_public IS true" in sql
+
+
+def test_series_group_keys_ignore_hidden_taxonomy():
+    public_group = SimpleNamespace(slug="series", is_public=True)
+    hidden_group = SimpleNamespace(slug="series", is_public=False)
+    product = SimpleNamespace(
+        series_id=None,
+        tags=[
+            SimpleNamespace(id=1, is_public=True, group=public_group),
+            SimpleNamespace(id=2, is_public=False, group=public_group),
+            SimpleNamespace(id=3, is_public=True, group=hidden_group),
+        ],
+        specs={},
+    )
+
+    assert ProductSeriesService._series_group_keys(product) == ["tag:1"]

--- a/tests/unit/test_public_write_idempotency_migration.py
+++ b/tests/unit/test_public_write_idempotency_migration.py
@@ -11,7 +11,8 @@ from sqlalchemy import inspect, text
 
 
 REVISION = "aa91c2d4e6f8"
-HEAD_REVISION = "ab02c3d4e5f6"
+CANARY_REVISION = "ab02c3d4e5f6"
+HEAD_REVISION = "f2a3b4c5d6e7"
 MIGRATION_PATH = Path(
     "alembic/versions/aa91c2d4e6f8_add_public_write_idempotency.py"
 )
@@ -59,7 +60,8 @@ def test_public_write_idempotency_migration_is_single_head() -> None:
     revision = script.get_revision(REVISION)
 
     assert script.get_heads() == [HEAD_REVISION]
-    assert script.get_revision(HEAD_REVISION).down_revision == REVISION
+    assert script.get_revision(HEAD_REVISION).down_revision == CANARY_REVISION
+    assert script.get_revision(CANARY_REVISION).down_revision == REVISION
     assert revision is not None
     assert revision.down_revision == "e1f2a3b4c5d6"
 

--- a/tests/unit/test_storefront_catalog_revision_migration.py
+++ b/tests/unit/test_storefront_catalog_revision_migration.py
@@ -11,7 +11,7 @@ from sqlalchemy import inspect
 
 REVISION = "e1f2a3b4c5d6"
 DOWN_REVISION = "d0a1b2c3e4f6"
-HEAD_REVISION = "ab02c3d4e5f6"
+HEAD_REVISION = "f2a3b4c5d6e7"
 MIGRATION_PATH = Path(
     "alembic/versions/e1f2a3b4c5d6_add_storefront_catalog_revision.py"
 )
@@ -59,7 +59,8 @@ def test_storefront_catalog_revision_is_the_single_alembic_head():
     script = ScriptDirectory.from_config(Config("alembic.ini"))
 
     assert script.get_heads() == [HEAD_REVISION]
-    assert script.get_revision(HEAD_REVISION).down_revision == "aa91c2d4e6f8"
+    assert script.get_revision(HEAD_REVISION).down_revision == "ab02c3d4e5f6"
+    assert script.get_revision("ab02c3d4e5f6").down_revision == "aa91c2d4e6f8"
     assert script.get_revision("aa91c2d4e6f8").down_revision == REVISION
     assert script.get_revision(REVISION).down_revision == DOWN_REVISION
 

--- a/tests/unit/test_storefront_order_idempotency_migration.py
+++ b/tests/unit/test_storefront_order_idempotency_migration.py
@@ -60,7 +60,7 @@ def test_storefront_idempotency_migration_is_the_single_head():
     script = ScriptDirectory.from_config(Config("alembic.ini"))
     revision = script.get_revision(REVISION)
 
-    assert script.get_heads() == ["ab02c3d4e5f6"]
+    assert script.get_heads() == ["f2a3b4c5d6e7"]
     assert revision is not None
     assert revision.down_revision == "c9e0f1a2b3d4"
 

--- a/tests/unit/test_tenant_offer_foundation_migration.py
+++ b/tests/unit/test_tenant_offer_foundation_migration.py
@@ -53,7 +53,8 @@ def _create_parent_schema(connection) -> None:
 def test_tenant_offer_foundation_precedes_the_catalog_revision_head():
     script = ScriptDirectory.from_config(Config("alembic.ini"))
 
-    assert script.get_heads() == [HEAD_REVISION]
+    assert script.get_heads() == ["f2a3b4c5d6e7"]
+    assert script.get_revision("f2a3b4c5d6e7").down_revision == HEAD_REVISION
     assert script.get_revision(HEAD_REVISION).down_revision == "aa91c2d4e6f8"
     assert script.get_revision("aa91c2d4e6f8").down_revision == "e1f2a3b4c5d6"
     assert script.get_revision(REVISION).down_revision == DOWN_REVISION

--- a/tests/unit/test_tenant_provenance_contract_migration.py
+++ b/tests/unit/test_tenant_provenance_contract_migration.py
@@ -204,7 +204,7 @@ def test_tenant_provenance_contract_is_the_single_alembic_head():
     script = ScriptDirectory.from_config(Config("alembic.ini"))
     revision = script.get_revision(REVISION)
 
-    assert script.get_heads() == ["ab02c3d4e5f6"]
+    assert script.get_heads() == ["f2a3b4c5d6e7"]
     assert revision is not None
     assert revision.down_revision == "b8d9e0f1a2c3"
 

--- a/tests/unit/test_tenant_scope_service.py
+++ b/tests/unit/test_tenant_scope_service.py
@@ -29,6 +29,7 @@ async def test_resolve_system_scope_returns_immutable_server_scope(monkeypatch):
     assert scope.tenant_id == 11
     assert scope.storefront_id == 21
     assert scope.is_system is True
+    assert scope.is_canonical_storefront is True
     with pytest.raises(FrozenInstanceError):
         scope.tenant_id = 99  # type: ignore[misc]
     resolver.assert_awaited_once_with(

--- a/tests/unit/test_website_lead_service.py
+++ b/tests/unit/test_website_lead_service.py
@@ -6,7 +6,6 @@ import pytest
 
 from core.database import get_session
 from core.tenant_scope import get_public_tenant_scope
-from crud.product import ProductDAO
 from main import app
 from models import Customer, Lead, LeadSource, Order, OrderStatus, Product
 from schemas import (
@@ -23,6 +22,10 @@ from services.order_service import OrderService
 from services.product_availability_serialization import (
     ProductAvailabilitySerialization,
     ProductAvailabilitySerializationClaim,
+)
+from services.public_catalog_visibility_service import (
+    PublicCatalogVisibilityService,
+    PublicProductProjection,
 )
 from services.public_write_idempotency_service import PublicWriteIdempotencyService
 from services.website_lead_service import WebsiteLeadService
@@ -154,11 +157,17 @@ async def test_create_product_availability_request_enqueues_with_single_commit(
     )
     fake_session = SimpleNamespace(commit_calls=0, add=lambda *_args, **_kwargs: None)
     enqueued = []
+    expected_scope = tenant_scope
 
-    async def fake_get_by_id(_session, product_id):
+    async def fake_get_visible(_session, *, tenant_scope, product_id):
         availability_serialization_claim["steps"].append("product")
+        assert tenant_scope == expected_scope
         assert product_id == product.id
-        return product
+        return PublicProductProjection(
+            product=product,
+            price=product.price,
+            old_price=product.old_price,
+        )
 
     async def fake_find_recent(**kwargs):
         availability_serialization_claim["steps"].append("find")
@@ -187,7 +196,11 @@ async def test_create_product_availability_request_enqueues_with_single_commit(
     fake_session.commit = fake_commit
     fake_session.refresh = fake_refresh
 
-    monkeypatch.setattr(ProductDAO, "get_by_id", fake_get_by_id)
+    monkeypatch.setattr(
+        PublicCatalogVisibilityService,
+        "get_visible_product_by_id",
+        fake_get_visible,
+    )
     monkeypatch.setattr(WebsiteLeadService, "_find_recent_product_availability_order", fake_find_recent)
     monkeypatch.setattr(OrderService, "create_from_website", fake_create_from_website)
     monkeypatch.setattr(TenantWebsiteEventService, "enqueue_availability", fake_enqueue)
@@ -259,9 +272,13 @@ async def test_create_product_availability_request_reuses_recent_duplicate_witho
     existing_order.customer = customer
     fake_session = SimpleNamespace(commit_calls=0, add=lambda *_args, **_kwargs: None)
 
-    async def fake_get_by_id(_session, product_id):
+    async def fake_get_visible(_session, *, tenant_scope, product_id):
         assert product_id == product.id
-        return product
+        return PublicProductProjection(
+            product=product,
+            price=product.price,
+            old_price=product.old_price,
+        )
 
     async def fake_find_recent(**kwargs):
         return existing_order
@@ -278,7 +295,11 @@ async def test_create_product_availability_request_reuses_recent_duplicate_witho
     fake_session.commit = fake_commit
     fake_session.refresh = fake_refresh
 
-    monkeypatch.setattr(ProductDAO, "get_by_id", fake_get_by_id)
+    monkeypatch.setattr(
+        PublicCatalogVisibilityService,
+        "get_visible_product_by_id",
+        fake_get_visible,
+    )
     monkeypatch.setattr(WebsiteLeadService, "_find_recent_product_availability_order", fake_find_recent)
     monkeypatch.setattr(
         TenantWebsiteEventService,
@@ -338,9 +359,13 @@ async def test_create_product_availability_request_reuses_duplicate_and_notifies
     fake_session = SimpleNamespace(commit_calls=0, add=lambda *_args, **_kwargs: None)
     enqueued = []
 
-    async def fake_get_by_id(_session, product_id):
+    async def fake_get_visible(_session, *, tenant_scope, product_id):
         assert product_id == product.id
-        return product
+        return PublicProductProjection(
+            product=product,
+            price=product.price,
+            old_price=product.old_price,
+        )
 
     async def fake_find_recent(**kwargs):
         return existing_order
@@ -357,7 +382,11 @@ async def test_create_product_availability_request_reuses_duplicate_and_notifies
     fake_session.commit = fake_commit
     fake_session.refresh = fake_refresh
 
-    monkeypatch.setattr(ProductDAO, "get_by_id", fake_get_by_id)
+    monkeypatch.setattr(
+        PublicCatalogVisibilityService,
+        "get_visible_product_by_id",
+        fake_get_visible,
+    )
     monkeypatch.setattr(WebsiteLeadService, "_find_recent_product_availability_order", fake_find_recent)
     monkeypatch.setattr(TenantWebsiteEventService, "enqueue_availability", fake_enqueue)
     monkeypatch.setattr(PublicWriteIdempotencyService, "execute", _execute_once)
@@ -381,6 +410,70 @@ async def test_create_product_availability_request_reuses_duplicate_and_notifies
     assert len(enqueued) == 1
     assert enqueued[0]["order"] is existing_order
     assert enqueued[0]["is_repeat"] is True
+
+
+@pytest.mark.asyncio
+async def test_unoffered_product_in_storefront_b_is_neutral_and_has_no_side_effects(
+    monkeypatch,
+    availability_serialization_claim,
+):
+    scope_b = SimpleNamespace(
+        tenant_id=2,
+        storefront_id=21,
+        is_canonical_storefront=False,
+    )
+    calls = {"visibility": 0, "lookup": 0, "create": 0, "enqueue": 0}
+
+    async def fake_visible(_session, *, tenant_scope, product_id):
+        calls["visibility"] += 1
+        assert tenant_scope is scope_b
+        assert product_id == 7
+        return None
+
+    async def fail_lookup(*_args, **_kwargs):
+        calls["lookup"] += 1
+        raise AssertionError("recent orders must not be read for a hidden product")
+
+    async def fail_create(**_kwargs):
+        calls["create"] += 1
+        raise AssertionError("an order must not be created for a hidden product")
+
+    async def fail_enqueue(*_args, **_kwargs):
+        calls["enqueue"] += 1
+        raise AssertionError("an event must not be enqueued for a hidden product")
+
+    monkeypatch.setattr(
+        PublicCatalogVisibilityService,
+        "get_visible_product_by_id",
+        fake_visible,
+    )
+    monkeypatch.setattr(
+        WebsiteLeadService,
+        "_find_recent_product_availability_order",
+        fail_lookup,
+    )
+    monkeypatch.setattr(OrderService, "create_from_website", fail_create)
+    monkeypatch.setattr(
+        TenantWebsiteEventService,
+        "enqueue_availability",
+        fail_enqueue,
+    )
+    monkeypatch.setattr(PublicWriteIdempotencyService, "execute", _execute_once)
+
+    with pytest.raises(LookupError, match="^Product not found$"):
+        await WebsiteLeadService.create_product_availability_lead(
+            object(),
+            ProductAvailabilityLeadPayload(
+                product_id=7,
+                phone="+375 (29) 111-22-33",
+                name="Иван",
+            ),
+            tenant_scope=scope_b,
+            idempotency_key="availability-hidden-unit-0001",
+        )
+
+    assert availability_serialization_claim["steps"] == ["lock"]
+    assert calls == {"visibility": 1, "lookup": 0, "create": 0, "enqueue": 0}
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_website_order_service.py
+++ b/tests/unit/test_website_order_service.py
@@ -12,6 +12,7 @@ from services.installation_pricing_service import (
     InstallationPricingError,
     InstallationPricingService,
 )
+from services.order_product_link_command import OrderProductLinkCommand
 from services.order_service import OrderService
 from services.public_catalog_visibility_service import PublicCatalogVisibilityService
 from services.public_write_idempotency_service import PublicWriteIdempotencyService
@@ -106,7 +107,9 @@ async def test_website_checkout_creates_negotiation_order(monkeypatch, tenant_sc
     assert captured_kwargs["customer_address"] == "г. Минск, ул. Тестовая 10"
     assert captured_kwargs["items"][0]["product_id"] == 7
     assert captured_kwargs["items"][0]["with_installation"] is True
-    assert captured_kwargs["product_price_overrides"] == {7: 3000}
+    product_link_command = captured_kwargs["product_link_command"]
+    assert isinstance(product_link_command, OrderProductLinkCommand)
+    assert dict(product_link_command.unit_prices or {}) == {7: 3000}
     assert captured_kwargs["commit"] is False
     assert captured_kwargs["order_technical_meta"]["public_catalog_pricing"] == {
         "items": [

--- a/tests/unit/test_website_order_service.py
+++ b/tests/unit/test_website_order_service.py
@@ -12,7 +12,10 @@ from services.installation_pricing_service import (
     InstallationPricingError,
     InstallationPricingService,
 )
-from services.order_product_link_command import OrderProductLinkCommand
+from services.order_product_link_command import (
+    OrderProductCatalogSnapshot,
+    OrderProductLinkCommand,
+)
 from services.order_service import OrderService
 from services.public_catalog_visibility_service import PublicCatalogVisibilityService
 from services.public_write_idempotency_service import PublicWriteIdempotencyService
@@ -56,17 +59,25 @@ async def test_website_checkout_creates_negotiation_order(monkeypatch, tenant_sc
     async def fake_price_items(_session, items):
         return [item.model_dump() for item in items]
 
-    async def fake_checkout_prices(_session, *, tenant_scope, product_ids):
+    async def fake_checkout_snapshots(_session, *, tenant_scope, product_ids):
         assert tenant_scope is not None
         assert product_ids == {7}
-        return {7: 3000}, "shared_product"
+        return {
+            7: OrderProductCatalogSnapshot(
+                product_id=7,
+                title="Checkout title",
+                unit_price=3000,
+                currency="BYN",
+                pricing_source="shared_product",
+            )
+        }
 
     monkeypatch.setattr(OrderService, "create_from_website", fake_create_from_website)
     monkeypatch.setattr(InstallationPricingService, "price_public_items", fake_price_items)
     monkeypatch.setattr(
         PublicCatalogVisibilityService,
-        "get_checkout_prices",
-        fake_checkout_prices,
+        "get_checkout_snapshots",
+        fake_checkout_snapshots,
     )
     monkeypatch.setattr(TenantWebsiteEventService, "enqueue_checkout", fake_enqueue)
     monkeypatch.setattr(PublicWriteIdempotencyService, "execute", _execute_once)
@@ -110,12 +121,17 @@ async def test_website_checkout_creates_negotiation_order(monkeypatch, tenant_sc
     product_link_command = captured_kwargs["product_link_command"]
     assert isinstance(product_link_command, OrderProductLinkCommand)
     assert dict(product_link_command.unit_prices or {}) == {7: 3000}
+    assert product_link_command.snapshots[7].title == "Checkout title"
+    assert product_link_command.snapshots[7].currency == "BYN"
     assert captured_kwargs["commit"] is False
     assert captured_kwargs["order_technical_meta"]["public_catalog_pricing"] == {
+        "snapshot_version": 1,
         "items": [
             {
                 "product_id": 7,
+                "title_snapshot": "Checkout title",
                 "unit_price": 3000,
+                "currency_snapshot": "BYN",
                 "source": "shared_product",
             }
         ]
@@ -188,9 +204,9 @@ async def test_unoffered_checkout_fails_before_order_mutation(monkeypatch, tenan
         pricing_calls += 1
         raise AssertionError("hidden product must fail before installation pricing")
 
-    async def fake_checkout_prices(_session, *, tenant_scope, product_ids):
+    async def fake_checkout_snapshots(_session, *, tenant_scope, product_ids):
         assert product_ids == {7}
-        return {}, "tenant_offer"
+        return {}
 
     async def fail_create_from_website(**_kwargs):
         nonlocal mutation_calls
@@ -204,8 +220,8 @@ async def test_unoffered_checkout_fails_before_order_mutation(monkeypatch, tenan
     )
     monkeypatch.setattr(
         PublicCatalogVisibilityService,
-        "get_checkout_prices",
-        fake_checkout_prices,
+        "get_checkout_snapshots",
+        fake_checkout_snapshots,
     )
     monkeypatch.setattr(
         OrderService,

--- a/tests/unit/test_website_order_service.py
+++ b/tests/unit/test_website_order_service.py
@@ -8,10 +8,14 @@ from schemas import OrderPayload
 from services.communications.tenant_website_event_service import (
     TenantWebsiteEventService,
 )
-from services.installation_pricing_service import InstallationPricingService
+from services.installation_pricing_service import (
+    InstallationPricingError,
+    InstallationPricingService,
+)
 from services.order_service import OrderService
-from services.website_order_service import WebsiteOrderService
+from services.public_catalog_visibility_service import PublicCatalogVisibilityService
 from services.public_write_idempotency_service import PublicWriteIdempotencyService
+from services.website_order_service import WebsiteOrderService
 
 
 async def _execute_once(session, *, operation, **_kwargs):
@@ -51,8 +55,18 @@ async def test_website_checkout_creates_negotiation_order(monkeypatch, tenant_sc
     async def fake_price_items(_session, items):
         return [item.model_dump() for item in items]
 
+    async def fake_checkout_prices(_session, *, tenant_scope, product_ids):
+        assert tenant_scope is not None
+        assert product_ids == {7}
+        return {7: 3000}, "shared_product"
+
     monkeypatch.setattr(OrderService, "create_from_website", fake_create_from_website)
     monkeypatch.setattr(InstallationPricingService, "price_public_items", fake_price_items)
+    monkeypatch.setattr(
+        PublicCatalogVisibilityService,
+        "get_checkout_prices",
+        fake_checkout_prices,
+    )
     monkeypatch.setattr(TenantWebsiteEventService, "enqueue_checkout", fake_enqueue)
     monkeypatch.setattr(PublicWriteIdempotencyService, "execute", _execute_once)
 
@@ -92,6 +106,17 @@ async def test_website_checkout_creates_negotiation_order(monkeypatch, tenant_sc
     assert captured_kwargs["customer_address"] == "г. Минск, ул. Тестовая 10"
     assert captured_kwargs["items"][0]["product_id"] == 7
     assert captured_kwargs["items"][0]["with_installation"] is True
+    assert captured_kwargs["product_price_overrides"] == {7: 3000}
+    assert captured_kwargs["commit"] is False
+    assert captured_kwargs["order_technical_meta"]["public_catalog_pricing"] == {
+        "items": [
+            {
+                "product_id": 7,
+                "unit_price": 3000,
+                "source": "shared_product",
+            }
+        ]
+    }
     assert captured_kwargs["tenant_scope"] == tenant_scope
     assert captured_kwargs["commit"] is False
     assert captured_event["session"] is session
@@ -148,3 +173,61 @@ async def test_website_checkout_replay_does_not_repeat_mutation_or_enqueue(
     )
 
     assert response.id == 56
+
+
+@pytest.mark.asyncio
+async def test_unoffered_checkout_fails_before_order_mutation(monkeypatch, tenant_scope):
+    mutation_calls = 0
+    pricing_calls = 0
+
+    async def fake_price_items(_session, items):
+        nonlocal pricing_calls
+        pricing_calls += 1
+        raise AssertionError("hidden product must fail before installation pricing")
+
+    async def fake_checkout_prices(_session, *, tenant_scope, product_ids):
+        assert product_ids == {7}
+        return {}, "tenant_offer"
+
+    async def fail_create_from_website(**_kwargs):
+        nonlocal mutation_calls
+        mutation_calls += 1
+        raise AssertionError("hidden product must fail before order mutation")
+
+    monkeypatch.setattr(
+        InstallationPricingService,
+        "price_public_items",
+        fake_price_items,
+    )
+    monkeypatch.setattr(
+        PublicCatalogVisibilityService,
+        "get_checkout_prices",
+        fake_checkout_prices,
+    )
+    monkeypatch.setattr(
+        OrderService,
+        "create_from_website",
+        fail_create_from_website,
+    )
+
+    payload = OrderPayload.model_validate(
+        {
+            "customer": {
+                "name": "Тестовый клиент",
+                "phone": "+375291112233",
+            },
+            "items": [{"product_id": 7, "quantity": 1}],
+        }
+    )
+
+    with pytest.raises(InstallationPricingError) as exc_info:
+        await WebsiteOrderService._create_order_mutation(
+            object(),
+            payload,
+            tenant_scope=tenant_scope,
+            request_key_hash="0" * 64,
+        )
+
+    assert exc_info.value.code == "product_not_available"
+    assert pricing_calls == 0
+    assert mutation_calls == 0


### PR DESCRIPTION
## Outcome

- Projects every product-bearing public surface through the exact tenant and storefront offer boundary while preserving the canonical MVN catalog behavior.
- Applies offer visibility, price, sorting, filtering, taxonomy, collections, search, availability, and checkout consistently.
- Locks immutable checkout title, price, and currency snapshots and preserves them during order transfer.
- Propagates the resolved storefront currency into tenant website communication events.
- Adds direct PostgreSQL proof that simultaneous requests with the same idempotency key remain isolated across two tenants and storefronts.

## HA compatibility

- Based on main after PRs 892, 894, 896, 897, 898, and 900.
- Does not change Patroni roles, fencing, Compose profiles, host assets, readiness, replication, or PITR workflows.
- Keeps the public-write idempotency and communications outbox path introduced by PR 900.

## Database

- Adds migration f2a3b4c5d6e7 after ab02c3d4e5f6 for immutable order product title and currency snapshots.
- Empty PostgreSQL upgrade to head passed.
- Alembic check reports no pending schema operations and there is exactly one head.

## Verification

- Unit: 2985 passed, 4 skipped.
- Integration PostgreSQL: 320 passed.
- Manager component tests: 60 passed.
- Manager UI logic audit passed.
- Manager production build passed.
- OpenAPI and generated manager client regenerate without diff.
- New concurrency proof verifies separate orders, customers, receipts, offer prices, currencies, and outbox events for two exact scopes.

Supersedes draft PR 881.