### PR TITLE
Fix transient PITR readiness lock contention

### DIFF
--- a/.github/workflows/api-restore-drill.yml
+++ b/.github/workflows/api-restore-drill.yml
@@ -6,7 +6,8 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: api-restore-drill
+  group: postgres-pitr-host-operations
+  queue: max
   cancel-in-progress: false
 
 env:

--- a/.github/workflows/check-api-ha-readiness.yml
+++ b/.github/workflows/check-api-ha-readiness.yml
@@ -11,6 +11,11 @@ on:
         required: false
         default: false
 
+concurrency:
+  group: postgres-pitr-host-operations
+  queue: max
+  cancel-in-progress: false
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
   HA_READINESS_STRICT: ${{ github.event_name == 'workflow_dispatch' && inputs.strict || vars.API_HA_READINESS_STRICT || 'false' }}

--- a/.github/workflows/check-postgres-pitr.yml
+++ b/.github/workflows/check-postgres-pitr.yml
@@ -11,6 +11,11 @@ on:
         required: false
         default: true
 
+concurrency:
+  group: postgres-pitr-host-operations
+  queue: max
+  cancel-in-progress: false
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
   PITR_CHECK_REQUIRED: ${{ github.event_name == 'workflow_dispatch' && format('{0}', inputs.required) || vars.POSTGRES_PITR_REQUIRED || 'false' }}

--- a/.github/workflows/postgres-pitr-restore-drill.yml
+++ b/.github/workflows/postgres-pitr-restore-drill.yml
@@ -26,6 +26,11 @@ on:
         required: false
         default: true
 
+concurrency:
+  group: postgres-pitr-host-operations
+  queue: max
+  cancel-in-progress: false
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
   PITR_RESTORE_DRILL_REQUIRED: ${{ github.event_name == 'workflow_dispatch' && format('{0}', inputs.required) || vars.POSTGRES_PITR_REQUIRED || 'false' }}

--- a/.github/workflows/rollout-postgres-pitr-host-assets.yml
+++ b/.github/workflows/rollout-postgres-pitr-host-assets.yml
@@ -12,7 +12,8 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 concurrency:
-  group: production-postgres-pitr-host-assets
+  group: postgres-pitr-host-operations
+  queue: max
   cancel-in-progress: false
 
 jobs:

--- a/scripts/ha/run_postgres_pitr_manual.py
+++ b/scripts/ha/run_postgres_pitr_manual.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Run the two reviewed manual PITR phases through the host operation guard."""
+"""Run reviewed manual PITR phases through the host operation guard."""
 
 from __future__ import annotations
 
@@ -12,6 +12,7 @@ import os
 import re
 import stat
 import sys
+import time
 from pathlib import Path
 from typing import Sequence
 
@@ -33,6 +34,8 @@ PHASE_TIMEOUTS = {
     "restore-drill": 7200.0,
     "logical-restore-drill": 1200.0,
 }
+LOCK_WAIT_SECONDS = 30.0
+LOCK_RETRY_SECONDS = 0.25
 OPERATION_RE = re.compile(r"^[0-9a-f]{32}$")
 BACKUP_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 UTC_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
@@ -162,6 +165,26 @@ def _open_lock(path: Path = LOCK_PATH) -> int:
         os.close(descriptor)
         raise
     return descriptor
+
+
+def _open_lock_bounded(
+    path: Path,
+    *,
+    busy_message: str,
+    wait_seconds: float = LOCK_WAIT_SECONDS,
+    deadline: float | None = None,
+) -> int:
+    """Wait briefly for normal deploy/PITR lock hand-offs, then fail closed."""
+    if deadline is None:
+        deadline = time.monotonic() + wait_seconds
+    while True:
+        try:
+            return _open_lock(path)
+        except BlockingIOError as exc:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise RuntimeError(busy_message) from exc
+            time.sleep(min(LOCK_RETRY_SECONDS, remaining))
 
 
 def _reject_maintenance_marker() -> None:
@@ -332,9 +355,18 @@ def run_manual(
     elif expected_database_role:
         raise RuntimeError(f"{phase} does not accept an expected database role")
 
-    shared_lock = _open_lock()
+    lock_deadline = time.monotonic() + LOCK_WAIT_SECONDS
+    shared_lock = _open_lock_bounded(
+        LOCK_PATH,
+        busy_message="another PITR host operation remained active",
+        deadline=lock_deadline,
+    )
     try:
-        deploy_lock = _open_lock(project / ".deploy.lock")
+        deploy_lock = _open_lock_bounded(
+            project / ".deploy.lock",
+            busy_message="project deployment lock remained active",
+            deadline=lock_deadline,
+        )
         try:
             _reject_maintenance_marker()
             for helper in REQUIRED_HELPERS:

--- a/tests/unit/test_ha_alert_workflows.py
+++ b/tests/unit/test_ha_alert_workflows.py
@@ -89,7 +89,8 @@ def test_restore_drill_checks_out_repo_before_local_alert_action():
         "persist-credentials": "false",
     }
     assert workflow["concurrency"] == {
-        "group": "api-restore-drill",
+        "group": "postgres-pitr-host-operations",
+        "queue": "max",
         "cancel-in-progress": "false",
     }
     assert run_step["env"] == {"SSH_KEY": "${{ secrets.SSH_KEY }}"}

--- a/tests/unit/test_ha_readiness_workflow.py
+++ b/tests/unit/test_ha_readiness_workflow.py
@@ -33,6 +33,11 @@ def test_ha_readiness_workflow_wires_core_and_soft_blocker_inputs():
     summary_step = _step(workflow, "Write Summary")
     artifact_step = _step(workflow, "Upload HA readiness log")
 
+    assert workflow["concurrency"] == {
+        "group": "postgres-pitr-host-operations",
+        "queue": "max",
+        "cancel-in-progress": "false",
+    }
     assert dispatch_inputs["strict"]["default"] == "false"
     assert "API_HA_READINESS_STRICT" in workflow["env"]["HA_READINESS_STRICT"]
     assert "secrets.SSH_HOST_API" in ssh_step["env"]["SSH_HOST_API"]

--- a/tests/unit/test_pitr_host_asset_rollout_workflow.py
+++ b/tests/unit/test_pitr_host_asset_rollout_workflow.py
@@ -30,9 +30,8 @@ def test_pitr_host_asset_rollout_is_manual_main_only_and_exact_sha_gated():
     workflow = _workflow()
     assert set(workflow["on"]) == {"workflow_dispatch"}
     assert workflow["concurrency"]["cancel-in-progress"] == "false"
-    assert workflow["concurrency"]["group"] == (
-        "production-postgres-pitr-host-assets"
-    )
+    assert workflow["concurrency"]["queue"] == "max"
+    assert workflow["concurrency"]["group"] == "postgres-pitr-host-operations"
 
     guard = _step(workflow, "Require Reviewed Main SHA")
     assert "refs/heads/main" in guard["run"]

--- a/tests/unit/test_postgres_pitr_manual_runner.py
+++ b/tests/unit/test_postgres_pitr_manual_runner.py
@@ -73,6 +73,67 @@ def test_self_attestation_rejects_checkout_execution():
         manual._validate_self()
 
 
+def test_manual_lock_waits_boundedly_for_transient_owner(monkeypatch):
+    attempts = []
+    sleeps = []
+
+    def open_lock(path):
+        attempts.append(path)
+        if len(attempts) < 3:
+            raise BlockingIOError(11, "temporarily unavailable")
+        return 17
+
+    monotonic_values = iter((10.0, 10.1, 10.2))
+    monkeypatch.setattr(manual, "_open_lock", open_lock)
+    monkeypatch.setattr(manual.time, "monotonic", lambda: next(monotonic_values))
+    monkeypatch.setattr(manual.time, "sleep", sleeps.append)
+
+    descriptor = manual._open_lock_bounded(
+        manual.LOCK_PATH,
+        busy_message="lock remained active",
+        wait_seconds=1.0,
+    )
+
+    assert descriptor == 17
+    assert attempts == [manual.LOCK_PATH] * 3
+    assert sleeps == [manual.LOCK_RETRY_SECONDS] * 2
+
+
+def test_manual_lock_fails_closed_after_bounded_wait(monkeypatch):
+    def open_busy_lock(_path):
+        raise BlockingIOError(11, "temporarily unavailable")
+
+    monkeypatch.setattr(manual, "_open_lock", open_busy_lock)
+    monotonic_values = iter((10.0, 40.0))
+    monkeypatch.setattr(manual.time, "monotonic", lambda: next(monotonic_values))
+
+    with pytest.raises(RuntimeError, match="lock remained active"):
+        manual._open_lock_bounded(
+            manual.LOCK_PATH,
+            busy_message="lock remained active",
+            wait_seconds=30.0,
+        )
+
+
+def test_manual_lock_does_not_retry_non_contention_failure(monkeypatch):
+    sleeps = []
+
+    def unsafe_lock(_path):
+        raise RuntimeError("unsafe shared PITR operation lock")
+
+    monkeypatch.setattr(manual, "_open_lock", unsafe_lock)
+    monkeypatch.setattr(manual.time, "sleep", sleeps.append)
+
+    with pytest.raises(RuntimeError, match="unsafe shared PITR operation lock"):
+        manual._open_lock_bounded(
+            manual.LOCK_PATH,
+            busy_message="lock remained active",
+            wait_seconds=30.0,
+        )
+
+    assert sleeps == []
+
+
 @pytest.mark.parametrize("kind", ["regular", "symlink"])
 def test_any_maintenance_marker_presence_fails_closed(tmp_path, monkeypatch, kind):
     marker = tmp_path / "maintenance"

--- a/tests/unit/test_postgres_pitr_workflows.py
+++ b/tests/unit/test_postgres_pitr_workflows.py
@@ -27,6 +27,11 @@ def test_postgres_pitr_check_workflow_preserves_strict_remote_gate():
     artifact_step = _step(workflow, "check", "Upload PITR Check Log")
 
     assert int(check_job["timeout-minutes"]) >= 30
+    assert workflow["concurrency"] == {
+        "group": "postgres-pitr-host-operations",
+        "queue": "max",
+        "cancel-in-progress": "false",
+    }
     assert dispatch_inputs == {"required": dispatch_inputs["required"]}
     assert checkout_step["uses"] == f"actions/checkout@{CHECKOUT_SHA}"
     assert checkout_step["with"] == {
@@ -88,6 +93,11 @@ def test_postgres_pitr_restore_drill_workflow_preserves_required_gate_and_wal_pr
     summary_step = _step(workflow, "pitr-restore-drill", "Write Summary")
     artifact_step = _step(workflow, "pitr-restore-drill", "Upload PITR Restore Drill Log")
 
+    assert workflow["concurrency"] == {
+        "group": "postgres-pitr-host-operations",
+        "queue": "max",
+        "cancel-in-progress": "false",
+    }
     assert "POSTGRES_PITR_REQUIRED" in env["PITR_RESTORE_DRILL_REQUIRED"]
     assert checkout_step["uses"] == f"actions/checkout@{CHECKOUT_SHA}"
     assert checkout_step["with"] == {


### PR DESCRIPTION
Production evidence showed strict readiness failing only when the manual PITR runner met a short-lived host or deploy lock, while replication, Patroni topology, fencing, etcd, CDN, Cloudflare LB, and a standalone PITR proof were healthy. This change serializes all GitHub PITR host operations in one non-cancelling concurrency group and lets the installed manual runner wait up to 30 seconds for normal lock hand-offs before failing closed. Validation: 3015 unit tests passed with 4 expected skips; 33 focused HA/PITR workflow tests passed after the final workflow changes; Python compilation and diff checks passed.