### PR TITLE
Parallelize CI feedback lanes and document agent routing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,7 +200,15 @@ jobs:
             -e SCHEDULER_ENABLED=false \
             -e PYTEST_SUITE="${suite}" \
             "${app_image}" \
-            sh -ec 'apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends openssh-client; export TEST_DATABASE_URL="postgresql+asyncpg://${POSTGRES_USER:-mvnadmin}:${POSTGRES_PASSWORD:-securepass}@db_test:5432/air_conditioners_test"; pytest -q --tb=short --durations=25 --durations-min=1.0 --junitxml=/test-results/results.xml "tests/${PYTEST_SUITE}"'
+            sh -ec '
+              apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends openssh-client
+              export TEST_DATABASE_URL="postgresql+asyncpg://${POSTGRES_USER:-mvnadmin}:${POSTGRES_PASSWORD:-securepass}@db_test:5432/air_conditioners_test"
+              set +e
+              pytest -q --tb=short --durations=25 --durations-min=1.0 --junitxml=/test-results/results.xml "tests/${PYTEST_SUITE}"
+              pytest_status=$?
+              chmod 0644 /test-results/results.xml 2>/dev/null || true
+              exit "${pytest_status}"
+            '
 
       - name: Upload Pytest Results
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,16 +17,38 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
-  test:
+  manager:
     runs-on: ubuntu-latest
-    # The immutable-image pytest suite can exceed 30 minutes on a throttled
-    # hosted runner while still making steady progress. The full job also
-    # includes manager builds and migration checks, so keep enough headroom
-    # around the observed 45-minute end-to-end runtime while retaining a hard
-    # bound for genuinely hung suites.
-    timeout-minutes: 60
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: manager_frontend/package-lock.json
+
+      - name: Build Manager Frontend and Run Component Tests
+        working-directory: ./manager_frontend
+        run: |
+          npm ci
+          npm run build
+          npm run test:components
+
+  backend-contracts:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: manager_frontend/package-lock.json
 
       - name: Create Dummy Env
         run: |
@@ -34,12 +56,9 @@ jobs:
             echo "POSTGRES_USER=postgres"
             echo "POSTGRES_PASSWORD=postgres"
             echo "POSTGRES_DB=air_conditioners"
-            # IMPORTANT: Inside docker network, host is 'db' (service name)
             echo "POSTGRES_SERVER=db"
             echo "POSTGRES_PORT=5432"
-            # Construct URL explicitly to be safe
             echo "DATABASE_URL=postgresql+asyncpg://postgres:postgres@db:5432/air_conditioners"
-
             echo "SECRET_KEY=dummy_secret_for_tests"
             echo "BOT_TOKEN=dummy_token"
             echo "BOT_API_TOKEN=dummy_bot_api_token"
@@ -49,27 +68,19 @@ jobs:
             echo "ADMIN_PASSWORD=admin"
             echo "ENVIRONMENT=test"
             echo "WEBSITE_URL=http://localhost:4321"
-          } >> .env
+          } > .env
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '20'
-
-      - name: Build Manager Frontend and Run Component Tests
+      - name: Build Manager Frontend for Immutable API Image
         working-directory: ./manager_frontend
         run: |
           npm ci
           npm run build
-          npm run test:components
 
-      - name: Start Services
-        run: docker compose up -d --build
+      - name: Start Backend Contract Services
+        run: docker compose up -d --build app
 
       - name: Wait for DB
-        run: |
-          scripts/ci/wait_for_stable_postgres.sh db air_conditioners postgres
-          scripts/ci/wait_for_stable_postgres.sh db_test air_conditioners_test postgres
+        run: scripts/ci/wait_for_stable_postgres.sh db air_conditioners postgres
 
       - name: Verify Alembic Upgrade From Empty Database
         run: |
@@ -118,21 +129,108 @@ jobs:
             exit 1
           )
 
-      - name: Run Pytest
-        # Test the immutable image rather than the bind-mounted development
-        # checkout. This preserves root-only control-plane ownership checks
-        # while sharing the already-started app container's database network.
+      - name: Stop Backend Contract Services
+        if: always()
+        run: docker compose down -v --remove-orphans
+
+  python-tests:
+    name: pytest-${{ matrix.suite }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        suite: [unit, integration]
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Create Dummy Env
         run: |
+          {
+            echo "POSTGRES_USER=postgres"
+            echo "POSTGRES_PASSWORD=postgres"
+            echo "POSTGRES_DB=air_conditioners"
+            echo "POSTGRES_SERVER=db"
+            echo "POSTGRES_PORT=5432"
+            echo "DATABASE_URL=postgresql+asyncpg://postgres:postgres@db:5432/air_conditioners"
+            echo "SECRET_KEY=dummy_secret_for_tests"
+            echo "BOT_TOKEN=dummy_token"
+            echo "BOT_API_TOKEN=dummy_bot_api_token"
+            echo "BOT_API_BASE_URL=http://app:8000/api/internal/bot/v1"
+            echo "BOT_ENABLED=false"
+            echo "ADMIN_USERNAME=admin"
+            echo "ADMIN_PASSWORD=admin"
+            echo "ENVIRONMENT=test"
+            echo "WEBSITE_URL=http://localhost:4321"
+          } > .env
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: manager_frontend/package-lock.json
+
+      - name: Build Manager Frontend for Immutable Test Image
+        working-directory: ./manager_frontend
+        run: |
+          npm ci
+          npm run build
+
+      - name: Start Isolated Test Services
+        run: docker compose up -d --build app db_test
+
+      - name: Wait for DB
+        run: |
+          scripts/ci/wait_for_stable_postgres.sh db air_conditioners postgres
+          scripts/ci/wait_for_stable_postgres.sh db_test air_conditioners_test postgres
+
+      - name: Run ${{ matrix.suite }} Tests
+        run: |
+          suite="${{ matrix.suite }}"
+          results_dir="${PWD}/test-results/${suite}"
+          mkdir -p "${results_dir}"
           app_container="$(docker compose ps -q app)"
           app_image="$(docker inspect --format '{{.Image}}' "${app_container}")"
           docker run --rm \
             --network "container:${app_container}" \
             --mount "type=bind,src=${PWD}/.github,dst=/app/.github,readonly" \
+            --mount "type=bind,src=${results_dir},dst=/test-results" \
             --env-file .env \
             -e SCHEDULER_ENABLED=false \
+            -e PYTEST_SUITE="${suite}" \
             "${app_image}" \
-            sh -ec 'apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends openssh-client; export TEST_DATABASE_URL="postgresql+asyncpg://${POSTGRES_USER:-mvnadmin}:${POSTGRES_PASSWORD:-securepass}@db_test:5432/air_conditioners_test"; pytest -v'
+            sh -ec 'apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends openssh-client; export TEST_DATABASE_URL="postgresql+asyncpg://${POSTGRES_USER:-mvnadmin}:${POSTGRES_PASSWORD:-securepass}@db_test:5432/air_conditioners_test"; pytest -q --tb=short --durations=25 --durations-min=1.0 --junitxml=/test-results/results.xml "tests/${PYTEST_SUITE}"'
 
-      - name: Stop CI Services
+      - name: Upload Pytest Results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: pytest-${{ matrix.suite }}-results-${{ github.run_id }}
+          path: test-results/${{ matrix.suite }}/results.xml
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Stop Isolated Test Services
         if: always()
         run: docker compose down -v --remove-orphans
+
+  test:
+    if: always()
+    needs: [manager, backend-contracts, python-tests]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require Every CI Lane
+        env:
+          MANAGER_RESULT: ${{ needs.manager.result }}
+          BACKEND_CONTRACTS_RESULT: ${{ needs.backend-contracts.result }}
+          PYTHON_TESTS_RESULT: ${{ needs.python-tests.result }}
+        run: |
+          printf '%s\n' \
+            "manager=${MANAGER_RESULT}" \
+            "backend-contracts=${BACKEND_CONTRACTS_RESULT}" \
+            "python-tests=${PYTHON_TESTS_RESULT}"
+          test "${MANAGER_RESULT}" = "success"
+          test "${BACKEND_CONTRACTS_RESULT}" = "success"
+          test "${PYTHON_TESTS_RESULT}" = "success"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,35 @@ This file defines practical workflows and commands for contributors and coding a
   - Do not add Astro/Vue storefront code, web deployment workflows, or web-only assets back into this repository.
   - Public pages consume this API only over HTTP. Storefront UI, theme rules, static content, and deployment tooling belong in `mvnby/mvn-web`.
 
+## Agent Delegation and Model Effort
+
+- Estimate task complexity before starting. When a bounded, independent task is
+  better handled separately, tell the user immediately: «Дружища, давай это
+  сделает отдельный агент и с пониженными весами».
+- Treat this repository rule as standing authorization to delegate safe,
+  in-scope subtasks. Do not delegate when coordination would cost more than the
+  task itself, when work is tightly coupled to the same files or decisions, or
+  when a separate agent cannot produce an independently verifiable result.
+- Choose the least expensive model and reasoning effort that reliably fits the
+  work:
+  - Terra `low`/`medium` for read-only inventory, formatting, focused checks,
+    documentation, and small isolated fixes;
+  - Terra `medium`/`high` for routine implementation, tests, and bounded
+    multi-file refactors;
+  - Sol `high`/`xhigh` for cross-domain architecture, concurrency, migrations,
+    HA, security, and other high-risk work;
+  - maximum/Ultra-style modes only for the hardest quality-first work when the
+    expected reliability gain justifies the extra time and tokens.
+- If the user's selected model or effort is materially excessive or
+  insufficient for the task, say so proactively and recommend the cheaper or
+  stronger setting.
+- Give subagents only the necessary goal, boundaries, relevant paths, and
+  acceptance evidence. Do not duplicate the full conversation history unless
+  it is genuinely required.
+- The primary agent owns integration, conflict resolution, final validation,
+  publication, and the user-facing report. Subagent output is evidence, not an
+  automatic merge decision.
+
 ## Commands
 
 Run from repo root unless noted.

--- a/tests/unit/test_ci_migration_workflow.py
+++ b/tests/unit/test_ci_migration_workflow.py
@@ -24,7 +24,39 @@ def test_ci_leaves_storefront_checks_to_the_standalone_service():
     assert "Check Storefront" not in workflow
 
 
-def test_ci_timeout_covers_the_full_immutable_image_suite():
+def test_ci_parallelizes_isolated_lanes_behind_required_test_gate():
     workflow = yaml.safe_load(CI_WORKFLOW.read_text(encoding="utf-8"))
+    jobs = workflow["jobs"]
 
-    assert workflow["jobs"]["test"]["timeout-minutes"] == 60
+    assert set(jobs) == {"manager", "backend-contracts", "python-tests", "test"}
+    assert jobs["python-tests"]["strategy"] == {
+        "fail-fast": False,
+        "matrix": {"suite": ["unit", "integration"]},
+    }
+    assert jobs["python-tests"]["timeout-minutes"] == 60
+    assert jobs["test"]["needs"] == [
+        "manager",
+        "backend-contracts",
+        "python-tests",
+    ]
+    assert jobs["test"]["if"] == "always()"
+    assert jobs["test"]["timeout-minutes"] == 5
+
+
+def test_ci_keeps_full_coverage_with_compact_diagnostic_output():
+    workflow = CI_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "suite: [unit, integration]" in workflow
+    assert 'pytest -q --tb=short --durations=25 --durations-min=1.0' in workflow
+    assert '"tests/${PYTEST_SUITE}"' in workflow
+    assert "--junitxml=/test-results/results.xml" in workflow
+    assert "actions/upload-artifact@v7" in workflow
+    assert "pytest -v" not in workflow
+
+
+def test_ci_uses_dependency_cache_and_isolated_compose_cleanup():
+    workflow = CI_WORKFLOW.read_text(encoding="utf-8")
+
+    assert workflow.count("cache-dependency-path: manager_frontend/package-lock.json") == 3
+    assert "docker compose up -d --build app db_test" in workflow
+    assert workflow.count("docker compose down -v --remove-orphans") == 2

--- a/tests/unit/test_ci_migration_workflow.py
+++ b/tests/unit/test_ci_migration_workflow.py
@@ -50,6 +50,9 @@ def test_ci_keeps_full_coverage_with_compact_diagnostic_output():
     assert 'pytest -q --tb=short --durations=25 --durations-min=1.0' in workflow
     assert '"tests/${PYTEST_SUITE}"' in workflow
     assert "--junitxml=/test-results/results.xml" in workflow
+    assert "pytest_status=$?" in workflow
+    assert "chmod 0644 /test-results/results.xml" in workflow
+    assert 'exit "${pytest_status}"' in workflow
     assert "actions/upload-artifact@v7" in workflow
     assert "pytest -v" not in workflow
 


### PR DESCRIPTION
## Что изменено

- CI разделён на независимые потоки: manager, backend contracts, unit tests и integration tests.
- Сохранён обязательный итоговый check `test`, поэтому защита ветки блокирует merge при падении любого потока.
- Полное покрытие тестами сохранено; unit и integration запускаются в изолированных окружениях без небезопасного xdist на общей БД.
- Добавлены npm cache, компактный pytest-вывод, JUnit-артефакты и гарантированная очистка Compose.
- Права JUnit-файла нормализуются внутри контейнера с сохранением настоящего exit code pytest.
- В AGENTS.md закреплён выбор минимально достаточной модели/усилия и проактивное делегирование недорогим агентам.

## Проверка

### Локально

- `actionlint .github/workflows/ci.yml`
- workflow/HA tests: 18 passed
- manager build: passed
- manager component tests: 60 passed
- unit: 3018 passed, 4 skipped
- integration: 332 passed
- OpenAPI/client regeneration: clean
- independent review: no P0-P2 findings

### GitHub Actions

Зелёный run: https://github.com/mvnby/air-api/actions/runs/31281316604

- manager: 0:53
- backend-contracts: 2:35
- pytest-unit: 13:29; 3020 passed, 2 skipped
- pytest-integration: 18:34; 332 passed
- required `test` gate: 0:03
- полный wall-clock workflow: 18:43

Медиана последних пяти зелёных push-прогонов на `main` была около 26:33. Фактическое сокращение ожидания — около 7:50, или 29%.

## Компромисс Phase 1

Wall-clock сокращён, но суммарное использование runner выросло примерно с 27 до 35.5 минут из-за независимых сборок. Phase 2 должна убрать дублирование Docker/manager build через безопасный переиспользуемый immutable image/cache; сокращать тестовое покрытие в этом PR не стали.

## Осознанное ограничение

Пока не включаем xdist/sharding внутри unit: часть unit-тестов использует общую тестовую БД и function-scoped drop/create schema. Это требует отдельного рефакторинга фикстур, иначе получим случайные падения.
