### PR TITLE
Cache CI build layers across isolated test lanes

### DIFF
--- a/.github/docker-compose.ci.yml
+++ b/.github/docker-compose.ci.yml
@@ -1,0 +1,3 @@
+services:
+  app:
+    image: ${CI_APP_IMAGE:?CI_APP_IMAGE must be set for CI}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,33 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
+  manager-dist:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: manager_frontend/package-lock.json
+
+      - name: Build Manager Frontend
+        working-directory: ./manager_frontend
+        run: |
+          npm ci
+          npm run build
+
+      - name: Upload Manager Frontend Build
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: manager-dist-${{ github.run_id }}-${{ github.run_attempt }}
+          path: manager_frontend/dist
+          if-no-files-found: error
+          retention-days: 1
+
   manager:
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -30,18 +57,28 @@ jobs:
           cache: npm
           cache-dependency-path: manager_frontend/package-lock.json
 
-      - name: Build Manager Frontend and Run Component Tests
+      - name: Run Manager Frontend Component Tests
         working-directory: ./manager_frontend
         run: |
           npm ci
-          npm run build
           npm run test:components
 
   backend-contracts:
+    needs: manager-dist
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      COMPOSE_FILE: docker-compose.yml:.github/docker-compose.ci.yml
+      COMPOSE_PROJECT_NAME: air-api-ci
+      CI_APP_IMAGE: air-api-ci-app:latest
     steps:
       - uses: actions/checkout@v6
+
+      - name: Download Manager Frontend Build
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: manager-dist-${{ github.run_id }}-${{ github.run_attempt }}
+          path: manager_frontend/dist
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -70,14 +107,37 @@ jobs:
             echo "WEBSITE_URL=http://localhost:4321"
           } > .env
 
-      - name: Build Manager Frontend for Immutable API Image
+      - name: Install Manager API Client Generator
         working-directory: ./manager_frontend
+        run: npm ci
+
+      - name: Set Up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Build Immutable API Image With Remote Cache
+        id: cached-image
+        continue-on-error: true
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: .
+          load: true
+          pull: true
+          tags: ${{ env.CI_APP_IMAGE }}
+          cache-from: type=gha,scope=air-api-ci-backend-v1,timeout=3m
+          # Keep one writer per workflow run. PR caches remain scoped to their
+          # merge ref; forks restore the trusted base cache but cannot export.
+          cache-to: ${{ (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) && 'type=gha,mode=min,scope=air-api-ci-backend-v1,ignore-error=true,timeout=5m' || '' }}
+          provenance: false
+          sbom: false
+
+      - name: Fall Back to Uncached API Image Build
+        if: steps.cached-image.outcome == 'failure'
         run: |
-          npm ci
-          npm run build
+          echo "::warning::Remote Docker cache unavailable; rebuilding without it."
+          docker build --pull --tag "${CI_APP_IMAGE}" .
 
       - name: Start Backend Contract Services
-        run: docker compose up -d --build app
+        run: docker compose up -d --no-build app
 
       - name: Wait for DB
         run: scripts/ci/wait_for_stable_postgres.sh db air_conditioners postgres
@@ -135,14 +195,25 @@ jobs:
 
   python-tests:
     name: pytest-${{ matrix.suite }}
+    needs: manager-dist
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         suite: [unit, integration]
     timeout-minutes: 60
+    env:
+      COMPOSE_FILE: docker-compose.yml:.github/docker-compose.ci.yml
+      COMPOSE_PROJECT_NAME: air-api-ci
+      CI_APP_IMAGE: air-api-ci-app:latest
     steps:
       - uses: actions/checkout@v6
+
+      - name: Download Manager Frontend Build
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: manager-dist-${{ github.run_id }}-${{ github.run_attempt }}
+          path: manager_frontend/dist
 
       - name: Create Dummy Env
         run: |
@@ -164,21 +235,31 @@ jobs:
             echo "WEBSITE_URL=http://localhost:4321"
           } > .env
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '20'
-          cache: npm
-          cache-dependency-path: manager_frontend/package-lock.json
+      - name: Set Up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
-      - name: Build Manager Frontend for Immutable Test Image
-        working-directory: ./manager_frontend
+      - name: Build Immutable Test Image With Remote Cache
+        id: cached-image
+        continue-on-error: true
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: .
+          load: true
+          pull: true
+          tags: ${{ env.CI_APP_IMAGE }}
+          # Restore-only: backend-contracts owns cache export for this run.
+          cache-from: type=gha,scope=air-api-ci-backend-v1,timeout=3m
+          provenance: false
+          sbom: false
+
+      - name: Fall Back to Uncached Test Image Build
+        if: steps.cached-image.outcome == 'failure'
         run: |
-          npm ci
-          npm run build
+          echo "::warning::Remote Docker cache unavailable; rebuilding without it."
+          docker build --pull --tag "${CI_APP_IMAGE}" .
 
       - name: Start Isolated Test Services
-        run: docker compose up -d --build app db_test
+        run: docker compose up -d --no-build app db_test
 
       - name: Wait for DB
         run: |
@@ -225,20 +306,23 @@ jobs:
 
   test:
     if: always()
-    needs: [manager, backend-contracts, python-tests]
+    needs: [manager-dist, manager, backend-contracts, python-tests]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Require Every CI Lane
         env:
+          MANAGER_DIST_RESULT: ${{ needs.manager-dist.result }}
           MANAGER_RESULT: ${{ needs.manager.result }}
           BACKEND_CONTRACTS_RESULT: ${{ needs.backend-contracts.result }}
           PYTHON_TESTS_RESULT: ${{ needs.python-tests.result }}
         run: |
           printf '%s\n' \
+            "manager-dist=${MANAGER_DIST_RESULT}" \
             "manager=${MANAGER_RESULT}" \
             "backend-contracts=${BACKEND_CONTRACTS_RESULT}" \
             "python-tests=${PYTHON_TESTS_RESULT}"
+          test "${MANAGER_DIST_RESULT}" = "success"
           test "${MANAGER_RESULT}" = "success"
           test "${BACKEND_CONTRACTS_RESULT}" = "success"
           test "${PYTHON_TESTS_RESULT}" = "success"

--- a/tests/unit/test_ci_migration_workflow.py
+++ b/tests/unit/test_ci_migration_workflow.py
@@ -4,6 +4,7 @@ import yaml
 
 
 CI_WORKFLOW = Path(".github/workflows/ci.yml")
+CI_COMPOSE_OVERRIDE = Path(".github/docker-compose.ci.yml")
 
 
 def test_ci_verifies_empty_database_migration_and_single_head():
@@ -28,19 +29,39 @@ def test_ci_parallelizes_isolated_lanes_behind_required_test_gate():
     workflow = yaml.safe_load(CI_WORKFLOW.read_text(encoding="utf-8"))
     jobs = workflow["jobs"]
 
-    assert set(jobs) == {"manager", "backend-contracts", "python-tests", "test"}
+    assert set(jobs) == {
+        "manager-dist",
+        "manager",
+        "backend-contracts",
+        "python-tests",
+        "test",
+    }
     assert jobs["python-tests"]["strategy"] == {
         "fail-fast": False,
         "matrix": {"suite": ["unit", "integration"]},
     }
     assert jobs["python-tests"]["timeout-minutes"] == 60
+    assert "needs" not in jobs["manager-dist"]
+    assert "needs" not in jobs["manager"]
+    assert jobs["backend-contracts"]["needs"] == "manager-dist"
+    assert jobs["python-tests"]["needs"] == "manager-dist"
     assert jobs["test"]["needs"] == [
+        "manager-dist",
         "manager",
         "backend-contracts",
         "python-tests",
     ]
     assert jobs["test"]["if"] == "always()"
     assert jobs["test"]["timeout-minutes"] == 5
+    gate = jobs["test"]["steps"][0]
+    assert gate["env"] == {
+        "MANAGER_DIST_RESULT": "${{ needs.manager-dist.result }}",
+        "MANAGER_RESULT": "${{ needs.manager.result }}",
+        "BACKEND_CONTRACTS_RESULT": "${{ needs.backend-contracts.result }}",
+        "PYTHON_TESTS_RESULT": "${{ needs.python-tests.result }}",
+    }
+    for result in gate["env"]:
+        assert f'test "${{{result}}}" = "success"' in gate["run"]
 
 
 def test_ci_keeps_full_coverage_with_compact_diagnostic_output():
@@ -59,7 +80,72 @@ def test_ci_keeps_full_coverage_with_compact_diagnostic_output():
 
 def test_ci_uses_dependency_cache_and_isolated_compose_cleanup():
     workflow = CI_WORKFLOW.read_text(encoding="utf-8")
+    jobs = yaml.safe_load(workflow)["jobs"]
 
     assert workflow.count("cache-dependency-path: manager_frontend/package-lock.json") == 3
-    assert "docker compose up -d --build app db_test" in workflow
+    assert workflow.count("npm run build") == 1
+    assert workflow.count("actions/download-artifact@") == 2
+    assert "manager-dist-${{ github.run_id }}-${{ github.run_attempt }}" in workflow
+    assert workflow.count("docker/setup-buildx-action@") == 2
+    assert workflow.count("docker/build-push-action@") == 2
+    assert (
+        workflow.count("cache-from: type=gha,scope=air-api-ci-backend-v1,timeout=3m")
+        == 2
+    )
+    assert workflow.count("cache-to:") == 1
+    assert "github.event.pull_request.head.repo.full_name == github.repository" in workflow
+    assert "docker compose up -d --no-build app db_test" in workflow
+    assert "docker compose up -d --build" not in workflow
     assert workflow.count("docker compose down -v --remove-orphans") == 2
+
+    expected_image_env = {
+        "COMPOSE_FILE": "docker-compose.yml:.github/docker-compose.ci.yml",
+        "COMPOSE_PROJECT_NAME": "air-api-ci",
+        "CI_APP_IMAGE": "air-api-ci-app:latest",
+    }
+    assert jobs["backend-contracts"]["env"] == expected_image_env
+    assert jobs["python-tests"]["env"] == expected_image_env
+
+    manager_upload = next(
+        step
+        for step in jobs["manager-dist"]["steps"]
+        if step.get("name") == "Upload Manager Frontend Build"
+    )
+    assert manager_upload["uses"] == (
+        "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
+    )
+    assert manager_upload["with"]["retention-days"] == 1
+    assert manager_upload["with"]["if-no-files-found"] == "error"
+    manager_steps = "\n".join(
+        str(step.get("run", "")) for step in jobs["manager"]["steps"]
+    )
+    assert "npm run test:components" in manager_steps
+    assert "npm run build" not in manager_steps
+
+    backend_build = next(
+        step
+        for step in jobs["backend-contracts"]["steps"]
+        if step.get("name") == "Build Immutable API Image With Remote Cache"
+    )
+    python_build = next(
+        step
+        for step in jobs["python-tests"]["steps"]
+        if step.get("name") == "Build Immutable Test Image With Remote Cache"
+    )
+    assert backend_build["with"]["cache-to"].endswith("|| '' }}")
+    assert "ignore-error=true" in backend_build["with"]["cache-to"]
+    assert "timeout=5m" in backend_build["with"]["cache-to"]
+    assert "cache-to" not in python_build["with"]
+    assert backend_build["continue-on-error"] is True
+    assert python_build["continue-on-error"] is True
+    assert backend_build["with"]["load"] is True
+    assert python_build["with"]["load"] is True
+    assert workflow.count("Remote Docker cache unavailable") == 2
+    assert workflow.count('docker build --pull --tag "${CI_APP_IMAGE}" .') == 2
+
+    compose_override = yaml.safe_load(CI_COMPOSE_OVERRIDE.read_text(encoding="utf-8"))
+    assert compose_override == {
+        "services": {
+            "app": {"image": "${CI_APP_IMAGE:?CI_APP_IMAGE must be set for CI}"}
+        }
+    }


### PR DESCRIPTION
## Summary

- build the manager frontend once per workflow run and pass its small `dist` artifact to backend lanes
- keep manager component tests independent so a UI failure does not hide backend diagnostics
- reuse Docker dependency layers through the GitHub Actions BuildKit cache while preserving one isolated database per pytest lane
- keep cache use best-effort with an explicit plain-Docker fallback and an explicit CI-only Compose image binding
- preserve the required `test` gate and its full manager, migration, contract, unit, and integration coverage

## Why this shape

The application image is about 1.5 GB, so transferring it as a workflow artifact would trade CPU time for artifact quota and network time. This PR shares only the small manager build and caches immutable Docker layers. The cache is not part of correctness: every lane can rebuild normally when it is unavailable.

No pytest sharding or xdist is introduced because database tests currently recreate a shared test schema and must remain isolated.

## Measured result

Phase 1 baseline on `main`, run 31289969104:

- wall clock: 15m43s
- summed runner time: 34m45s

PR run 31298278903:

| Attempt | Profile | Wall clock | Runner time | Result |
| --- | --- | ---: | ---: | --- |
| 1 | cold cache seed | 17m15s | 37m49s | all green |
| 2 | warm cache, slow integration runner | 20m30s | 36m57s | all green; integration pytest took 17m27s |
| 3 | warm cache, normal test profile | **14m33s** | **30m10s** | all green |

Normal warm improvement versus Phase 1:

- wall clock: **1m10s faster** (`-7.4%`)
- summed runner time: **4m35s lower** (`-13.2%`)
- backend contracts: 4m03s cold to 2m04s warm
- three Docker build steps: 8m03s cold total to 2m22s warm total
- all three warm backend lanes imported the GitHub Actions cache

Attempt 2 exposed existing pytest/database timing variance rather than a cache regression. Its integration tests alone grew from 12m35s to 17m27s. Attempt 3 returned to 12m11s with the same SHA and cache. This PR removes stable build overhead; it does not claim to solve test-database variability.

## Coverage evidence

Every attempt passed:

- manager: 21 files / 60 component tests
- unit: 3,020 passed, 2 skipped
- integration: 332 passed
- empty-database Alembic upgrade and single-head check
- generated OpenAPI and manager client synchronization
- required aggregate `test` check

## Local verification

- `actionlint .github/workflows/ci.yml`
- `pytest -q tests/unit/test_ci_migration_workflow.py tests/unit/test_ci_postgres_stability.py` — 13 passed
- manager build — passed
- manager component tests — 21 files / 60 tests passed
- resolved Compose image — `air-api-ci-app:latest`
- `git diff --check`

## Rollout note

Keep the PR draft until review. The next independent optimization should target PostgreSQL fixture/schema setup and only introduce pytest parallelism after each worker receives a truly isolated database.
