### PR TITLE
Isolate PostgreSQL databases per pytest worker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,6 +284,11 @@ jobs:
             sh -ec '
               apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends openssh-client
               export TEST_DATABASE_URL="postgresql+asyncpg://${POSTGRES_USER:-mvnadmin}:${POSTGRES_PASSWORD:-securepass}@db_test:5432/air_conditioners_test"
+              if [ "${PYTEST_SUITE}" = "integration" ]; then
+                EXPECT_XDIST_DATABASE_ISOLATION=1 \
+                  pytest -q -n 2 --dist load \
+                    tests/integration/test_postgres_worker_database_isolation.py
+              fi
               set +e
               pytest -q --tb=short --durations=25 --durations-min=1.0 --junitxml=/test-results/results.xml "tests/${PYTEST_SUITE}"
               pytest_status=$?

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,17 @@ Run from repo root unless noted.
 - Run all tests (local venv): `pytest`
 - Run unit tests only: `pytest tests/unit -q`
 - Run integration tests only: `pytest tests/integration -q`
+- Prove physical PostgreSQL isolation for two future pytest workers:
+  `pytest -q -n 2 --dist load tests/integration/test_postgres_worker_database_isolation.py`
+
+PostgreSQL test policy:
+
+- Every pytest process/xdist worker derives and owns a separate physical
+  database from `TEST_DATABASE_URL`.
+- Do not point `PYTEST_BASE_DATABASE_URL` at a production database. The test
+  bootstrap rejects base database names without a `test` marker.
+- Keep broad unit/integration suites serial until worker-isolation proof and
+  timing evidence are green in CI; enable xdist per suite as a separate change.
 
 ### Manager Frontend (Vue)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -85,6 +85,7 @@ python-dateutil==2.9.0.post0
 pytest==9.0.2
 pytest-asyncio==1.3.0
 pytest-env==1.2.0
+pytest-xdist==3.8.0
 python-dotenv==1.2.1
 python-multipart==0.0.21
 python-slugify==8.0.4

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,135 +71,229 @@ for cloudflare_name in (
 ):
     os.environ.pop(cloudflare_name, None)
 
-import asyncio
 import pytest
 from sqlalchemy import text
-from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import NullPool
+from sqlalchemy.schema import AddConstraint
 from sqlmodel import SQLModel
+
+from postgres_test_support import (
+    BASE_DATABASE_URL_ENV,
+    build_test_database_target,
+    create_test_database,
+    drop_test_database,
+    resolve_base_test_database_url,
+)
+
 
 def _running_inside_docker() -> bool:
     return os.path.exists("/.dockerenv")
 
 
-def _resolve_test_database_url() -> str:
-    configured_url = os.environ.get("TEST_DATABASE_URL") or os.environ.get("DATABASE_URL")
-    if configured_url and "test" in configured_url.lower():
-        return configured_url
-
-    pg_user = os.environ.get("POSTGRES_USER", "mvnadmin")
-    pg_pass = os.environ.get("POSTGRES_PASSWORD", "securepass")
-    test_db_host = os.environ.get("TEST_DB_HOST")
-    if not test_db_host:
-        test_db_host = "db_test" if _running_inside_docker() else "localhost"
-    test_db_port = os.environ.get("TEST_DB_PORT") or os.environ.get("POSTGRES_PORT")
-    if not test_db_port:
-        test_db_port = "5432" if test_db_host == "db_test" else "5433"
-    test_db_name = os.environ.get("TEST_POSTGRES_DB", "air_conditioners_test")
-    return f"postgresql+asyncpg://{pg_user}:{pg_pass}@{test_db_host}:{test_db_port}/{test_db_name}"
-
-
-# CRITICAL: Always use the TEST database for tests.
-TEST_DATABASE_URL = _resolve_test_database_url()
-
-# Safety net: abort if the URL doesn't contain 'test'
-assert "test" in TEST_DATABASE_URL.lower(), (
-    f"SAFETY: Refusing to run tests against a non-test database! URL={TEST_DATABASE_URL}"
+BASE_TEST_DATABASE_URL = resolve_base_test_database_url(
+    running_inside_docker=_running_inside_docker()
 )
+os.environ.setdefault(BASE_DATABASE_URL_ENV, BASE_TEST_DATABASE_URL)
+TEST_DATABASE_TARGET = build_test_database_target(BASE_TEST_DATABASE_URL)
+TEST_DATABASE_URL = TEST_DATABASE_TARGET.database_url
+
+# Application modules imported during collection must use the exact same
+# physical database as pytest fixtures. In CI, DATABASE_URL otherwise points at
+# the app service database while TEST_DATABASE_URL points at db_test.
+os.environ["TEST_DATABASE_URL"] = TEST_DATABASE_URL
+os.environ["DATABASE_URL"] = TEST_DATABASE_URL
+os.environ["TEST_POSTGRES_DB"] = TEST_DATABASE_TARGET.database_name
 
 # event_loop fixture removed to let pytest-asyncio handle it with scope=session
 
 
-@pytest.fixture(scope="function")
-async def db_engine(request):
-    """
-    Create a fresh database engine for the test session.
-    Always uses the dedicated test database (db_test service).
-    """
-    engine = create_async_engine(TEST_DATABASE_URL, echo=False)
+def _quoted_metadata_tables(connection) -> str:
+    preparer = connection.dialect.identifier_preparer
+    return ", ".join(
+        preparer.format_table(table) for table in SQLModel.metadata.sorted_tables
+    )
 
-    # Basic check if DB is up
-    async with engine.begin() as conn:
-        await conn.run_sync(SQLModel.metadata.drop_all)
-        await conn.run_sync(SQLModel.metadata.create_all)
-        await conn.execute(
+
+async def _seed_system_scope(connection) -> None:
+    await connection.execute(
+        text(
+            """
+            INSERT INTO tenant (
+                id, slug, display_name, kind, status, is_system, created_at, updated_at
+            ) VALUES (
+                1, 'mvn', 'Мастер Воздуха', 'operator', 'active', true,
+                CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+            )
+            """
+        )
+    )
+    await connection.execute(
+        text(
+            """
+            INSERT INTO storefront (
+                id, tenant_id, slug, display_name, status, city,
+                default_locale, currency, is_default, created_at, updated_at
+            ) VALUES (
+                1, 1, 'main', 'MVN', 'active', 'Витебск',
+                'ru-BY', 'BYN', true, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+            )
+            """
+        )
+    )
+    for table_name in ("tenant", "storefront"):
+        await connection.execute(
             text(
-                """
-                INSERT INTO tenant (
-                    id, slug, display_name, kind, status, is_system, created_at, updated_at
-                ) VALUES (
-                    1, 'mvn', 'Мастер Воздуха', 'operator', 'active', true,
-                    CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
-                )
-                """
+                "SELECT setval("
+                "pg_get_serial_sequence(:table_name, 'id'), "
+                f"(SELECT MAX(id) FROM {table_name}), true)"
+            ),
+            {"table_name": table_name},
+        )
+
+
+async def _apply_expand_phase_schema(connection) -> None:
+    # Historical backfill tests exercise the retired nullable schema.
+    for table_name, constraint_name in (
+        ("lead", "fk_lead_converted_order_scope"),
+        ("lead", "fk_lead_storefront_tenant"),
+        ("order", "fk_order_customer_tenant"),
+        ("order", "fk_order_storefront_tenant"),
+        (
+            "customer_requisites_recognition",
+            "fk_customer_requisites_confirmed_customer_tenant",
+        ),
+        (
+            "customer_requisites_recognition",
+            "fk_customer_requisites_duplicate_customer_tenant",
+        ),
+    ):
+        await connection.execute(
+            text(
+                f'ALTER TABLE "{table_name}" '
+                f'DROP CONSTRAINT "{constraint_name}"'
             )
         )
-        if request.node.get_closest_marker("expand_phase_schema"):
-            # Historical backfill tests exercise the retired nullable schema.
-            # Production and every other test use the contracted NOT NULL
-            # metadata so missing provenance cannot be hidden by fixtures.
-            for table_name, constraint_name in (
-                ("lead", "fk_lead_converted_order_scope"),
-                ("lead", "fk_lead_storefront_tenant"),
-                ("order", "fk_order_customer_tenant"),
-                ("order", "fk_order_storefront_tenant"),
-                (
-                    "customer_requisites_recognition",
-                    "fk_customer_requisites_confirmed_customer_tenant",
-                ),
-                (
-                    "customer_requisites_recognition",
-                    "fk_customer_requisites_duplicate_customer_tenant",
-                ),
-            ):
-                await conn.execute(
+    for table_name, column_names in (
+        ("customer", ("tenant_id",)),
+        ("customer_requisites_recognition", ("tenant_id",)),
+        ("lead", ("tenant_id", "storefront_id")),
+        ("order", ("tenant_id", "storefront_id")),
+    ):
+        for column_name in column_names:
+            await connection.execute(
+                text(
+                    f'ALTER TABLE "{table_name}" '
+                    f'ALTER COLUMN "{column_name}" DROP NOT NULL'
+                )
+            )
+
+
+async def _truncate_rows(connection) -> None:
+    table_list = _quoted_metadata_tables(connection)
+    if table_list:
+        await connection.execute(
+            text(f"TRUNCATE TABLE {table_list} RESTART IDENTITY CASCADE")
+        )
+
+
+async def _reset_rows(engine) -> None:
+    async with engine.begin() as connection:
+        await _truncate_rows(connection)
+        await _seed_system_scope(connection)
+
+
+async def _prepare_expand_phase_schema(engine) -> None:
+    async with engine.begin() as connection:
+        await _truncate_rows(connection)
+        await _apply_expand_phase_schema(connection)
+        await _seed_system_scope(connection)
+
+
+async def _restore_contracted_schema(engine) -> None:
+    async with engine.begin() as connection:
+        await _truncate_rows(connection)
+        for table_name, column_names in (
+            ("customer", ("tenant_id",)),
+            ("customer_requisites_recognition", ("tenant_id",)),
+            ("lead", ("tenant_id", "storefront_id")),
+            ("order", ("tenant_id", "storefront_id")),
+        ):
+            for column_name in column_names:
+                await connection.execute(
                     text(
                         f'ALTER TABLE "{table_name}" '
-                        f'DROP CONSTRAINT "{constraint_name}"'
+                        f'ALTER COLUMN "{column_name}" SET NOT NULL'
                     )
                 )
-            for table_name, column_names in (
-                ("customer", ("tenant_id",)),
-                ("customer_requisites_recognition", ("tenant_id",)),
-                ("lead", ("tenant_id", "storefront_id")),
-                ("order", ("tenant_id", "storefront_id")),
-            ):
-                for column_name in column_names:
-                    await conn.execute(
-                        text(
-                            f'ALTER TABLE "{table_name}" '
-                            f'ALTER COLUMN "{column_name}" DROP NOT NULL'
-                        )
-                    )
-        await conn.execute(
-            text(
-                """
-                INSERT INTO storefront (
-                    id, tenant_id, slug, display_name, status, city,
-                    default_locale, currency, is_default, created_at, updated_at
-                ) VALUES (
-                    1, 1, 'main', 'MVN', 'active', 'Витебск',
-                    'ru-BY', 'BYN', true, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
-                )
-                """
+
+        constraint_names = {
+            "fk_lead_converted_order_scope",
+            "fk_lead_storefront_tenant",
+            "fk_order_customer_tenant",
+            "fk_order_storefront_tenant",
+            "fk_customer_requisites_confirmed_customer_tenant",
+            "fk_customer_requisites_duplicate_customer_tenant",
+        }
+        constraints = {
+            constraint.name: constraint
+            for table in SQLModel.metadata.sorted_tables
+            for constraint in table.constraints
+            if constraint.name in constraint_names
+        }
+        missing_constraints = constraint_names - constraints.keys()
+        if missing_constraints:
+            raise RuntimeError(
+                "Missing contracted test constraints: "
+                + ", ".join(sorted(missing_constraints))
             )
-        )
-        # The test foundation inserts stable compatibility IDs directly. Keep
-        # PostgreSQL sequences aligned so services can safely create the next
-        # tenant/storefront without hard-coding test-only IDs.
-        for table_name in ("tenant", "storefront"):
-            await conn.execute(
-                text(
-                    "SELECT setval("
-                    "pg_get_serial_sequence(:table_name, 'id'), "
-                    f"(SELECT MAX(id) FROM {table_name}), true)"
-                ),
-                {"table_name": table_name},
-            )
-    
-    yield engine
-    
-    await engine.dispose()
+        for constraint_name in sorted(constraint_names):
+            await connection.execute(AddConstraint(constraints[constraint_name]))
+        await _seed_system_scope(connection)
+
+
+@pytest.fixture(scope="session")
+def test_database_url():
+    create_test_database(TEST_DATABASE_TARGET)
+    try:
+        yield TEST_DATABASE_URL
+    finally:
+        drop_test_database(TEST_DATABASE_TARGET)
+
+
+@pytest.fixture(scope="session")
+async def _session_db_engine(test_database_url):
+    # A narrow pytest selection may not import any model-bearing test module.
+    # Register the complete metadata explicitly before creating the worker DB.
+    import models  # noqa: F401
+
+    # NullPool prevents asyncpg connections created by a session-scoped engine
+    # from leaking across pytest-asyncio event loops.
+    engine = create_async_engine(test_database_url, echo=False, poolclass=NullPool)
+    async with engine.begin() as connection:
+        await connection.run_sync(SQLModel.metadata.create_all)
+    try:
+        yield engine
+    finally:
+        await engine.dispose()
+
+
+@pytest.fixture(scope="function")
+async def db_engine(request, _session_db_engine):
+    expand_phase = request.node.get_closest_marker("expand_phase_schema") is not None
+    if expand_phase:
+        await _prepare_expand_phase_schema(_session_db_engine)
+    else:
+        await _reset_rows(_session_db_engine)
+    try:
+        yield _session_db_engine
+    finally:
+        if expand_phase:
+            # Restore the contracted schema even when a historical backfill
+            # assertion fails, so the next test cannot inherit nullable scope.
+            await _restore_contracted_schema(_session_db_engine)
+
 
 @pytest.fixture(scope="function")
 async def db(db_engine):
@@ -211,19 +305,21 @@ async def db(db_engine):
     connection = await db_engine.connect()
     # Begin a non-ORM transaction
     transaction = await connection.begin()
-    
+
     # Bind an individual Session to the connection
     session_factory = sessionmaker(
         bind=connection,
         class_=AsyncSession,
         expire_on_commit=False,
+        join_transaction_mode="create_savepoint",
     )
-    
+
     async with session_factory() as session:
         yield session
-    
+
     # Rollback the setup transaction
-    await transaction.rollback()
+    if transaction.is_active:
+        await transaction.rollback()
     await connection.close()
 
 
@@ -238,6 +334,7 @@ def tenant_scope():
         is_canonical_storefront=True,
     )
 
+
 @pytest.fixture(scope="function")
 async def async_client(db):
     from httpx import AsyncClient, ASGITransport
@@ -248,9 +345,9 @@ async def async_client(db):
         yield db
 
     app.dependency_overrides[get_session] = override_get_session
-    
+
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         yield client
-    
+
     app.dependency_overrides.clear()

--- a/tests/integration/test_communication_delivery_concurrency.py
+++ b/tests/integration/test_communication_delivery_concurrency.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import os
 import uuid
 from datetime import datetime, timedelta, timezone
 
@@ -38,11 +37,8 @@ RUN_ID_B = "123e4567-e89b-42d3-a456-426614174001"
 
 
 @pytest.fixture
-async def communication_db_engine():
-    database_url = os.environ.get("TEST_DATABASE_URL") or os.environ.get("DATABASE_URL")
-    environment = os.environ.get("ENVIRONMENT", "").strip().lower()
-    assert database_url
-    assert "test" in database_url.lower() or environment == "test"
+async def communication_db_engine(test_database_url):
+    database_url = test_database_url
     schema_name = f"communication_c1_{uuid.uuid4().hex}"
     admin_engine = create_async_engine(database_url)
     async with admin_engine.begin() as connection:

--- a/tests/integration/test_communications_runtime_postgres.py
+++ b/tests/integration/test_communications_runtime_postgres.py
@@ -10,7 +10,6 @@ from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
 import services.communications.runtime as runtime_module
-from conftest import TEST_DATABASE_URL
 from models import (
     CommunicationRuntimeState,
     CommunicationWebsiteCanaryRun,
@@ -45,13 +44,13 @@ RUN_ID_B = "123e4567-e89b-42d3-a456-426614174001"
 
 
 @pytest_asyncio.fixture
-async def runtime_postgres_engine():
+async def runtime_postgres_engine(test_database_url):
     schema_name = f"communication_runtime_{uuid4().hex}"
-    admin_engine = create_async_engine(TEST_DATABASE_URL)
+    admin_engine = create_async_engine(test_database_url)
     async with admin_engine.begin() as connection:
         await connection.execute(text(f'CREATE SCHEMA "{schema_name}"'))
     engine = create_async_engine(
-        TEST_DATABASE_URL,
+        test_database_url,
         connect_args={"server_settings": {"search_path": schema_name}},
     )
     async with engine.begin() as connection:

--- a/tests/integration/test_installation_estimate_backlog_reconciliation_postgres.py
+++ b/tests/integration/test_installation_estimate_backlog_reconciliation_postgres.py
@@ -10,7 +10,6 @@ from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 from sqlmodel import select
 
-from conftest import TEST_DATABASE_URL
 from core.config import settings
 from models import (
     CommunicationDelivery,
@@ -33,13 +32,13 @@ from services.runtime_lock_service import RuntimeLock, RuntimeLockService
 
 
 @pytest_asyncio.fixture
-async def reconciliation_postgres_factory(monkeypatch):
+async def reconciliation_postgres_factory(monkeypatch, test_database_url):
     schema_name = f"communications_backlog_{uuid4().hex}"
-    admin_engine = create_async_engine(TEST_DATABASE_URL)
+    admin_engine = create_async_engine(test_database_url)
     async with admin_engine.begin() as connection:
         await connection.execute(text(f'CREATE SCHEMA "{schema_name}"'))
     engine = create_async_engine(
-        TEST_DATABASE_URL,
+        test_database_url,
         connect_args={"server_settings": {"search_path": schema_name}},
     )
     async with engine.begin() as connection:

--- a/tests/integration/test_postgres_worker_database_isolation.py
+++ b/tests/integration/test_postgres_worker_database_isolation.py
@@ -1,0 +1,26 @@
+import os
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.engine import make_url
+
+from conftest import TEST_DATABASE_TARGET, TEST_DATABASE_URL
+from core.config import settings
+from core.database import engine as application_engine
+
+
+@pytest.mark.parametrize("probe", range(4))
+async def test_pytest_worker_uses_its_own_physical_database(db_engine, probe):
+    del probe
+    async with db_engine.connect() as connection:
+        current_database = await connection.scalar(text("SELECT current_database()"))
+
+    assert current_database == TEST_DATABASE_TARGET.database_name
+    assert make_url(TEST_DATABASE_URL).database == current_database
+    assert make_url(settings.DATABASE_URL).database == current_database
+    assert application_engine.url.database == current_database
+
+    worker_id = os.environ.get("PYTEST_XDIST_WORKER", "master")
+    if os.environ.get("EXPECT_XDIST_DATABASE_ISOLATION") == "1":
+        assert worker_id.startswith("gw")
+    assert TEST_DATABASE_TARGET.worker_id == worker_id

--- a/tests/integration/test_website_backlog_operation_concurrency_postgres.py
+++ b/tests/integration/test_website_backlog_operation_concurrency_postgres.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import os
 import uuid
 from datetime import datetime, timedelta, timezone
 
@@ -32,14 +31,8 @@ class _HeldRuntimeLock:
 
 
 @pytest.fixture
-async def backlog_operation_session_factory():
-    database_url = os.environ.get("TEST_DATABASE_URL") or os.environ.get(
-        "DATABASE_URL"
-    )
-    environment = os.environ.get("ENVIRONMENT", "").strip().lower()
-    assert database_url
-    assert "test" in database_url.lower() or environment == "test"
-
+async def backlog_operation_session_factory(test_database_url):
+    database_url = test_database_url
     schema_name = f"website_backlog_c1_{uuid.uuid4().hex}"
     admin_engine = create_async_engine(database_url)
     async with admin_engine.begin() as connection:

--- a/tests/postgres_test_support.py
+++ b/tests/postgres_test_support.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import uuid
+from dataclasses import dataclass
+
+import psycopg
+from psycopg import sql
+from sqlalchemy.engine import URL, make_url
+
+
+POSTGRES_IDENTIFIER_LIMIT = 63
+BASE_DATABASE_URL_ENV = "PYTEST_BASE_DATABASE_URL"
+RUN_ID_ENV = "PYTEST_DB_RUN_ID"
+
+
+@dataclass(frozen=True)
+class TestDatabaseTarget:
+    base_database_name: str
+    database_name: str
+    database_url: str
+    run_id: str
+    worker_id: str
+
+
+def _render_url(url) -> str:
+    return url.render_as_string(hide_password=False)
+
+
+def _has_test_marker(database_name: str) -> bool:
+    return re.search(r"(?:^|_)test(?:_|$)", database_name.lower()) is not None
+
+
+def _test_database_url_from_environment() -> str | None:
+    base_override = os.environ.get(BASE_DATABASE_URL_ENV)
+    if base_override:
+        parsed = make_url(base_override)
+        database_name = parsed.database or ""
+        if parsed.get_backend_name() != "postgresql" or not _has_test_marker(
+            database_name
+        ):
+            raise ValueError(
+                f"{BASE_DATABASE_URL_ENV} must name a PostgreSQL test database"
+            )
+        return _render_url(parsed)
+
+    for variable_name in ("TEST_DATABASE_URL", "DATABASE_URL"):
+        configured_url = os.environ.get(variable_name)
+        if not configured_url:
+            continue
+        parsed = make_url(configured_url)
+        database_name = parsed.database or ""
+        if parsed.get_backend_name() == "postgresql" and _has_test_marker(
+            database_name
+        ):
+            return _render_url(parsed)
+    return None
+
+
+def resolve_base_test_database_url(*, running_inside_docker: bool) -> str:
+    configured_url = _test_database_url_from_environment()
+    if configured_url:
+        return configured_url
+
+    pg_user = os.environ.get("POSTGRES_USER", "mvnadmin")
+    pg_pass = os.environ.get("POSTGRES_PASSWORD", "securepass")
+    test_db_host = os.environ.get("TEST_DB_HOST")
+    if not test_db_host:
+        test_db_host = "db_test" if running_inside_docker else "localhost"
+    test_db_port = os.environ.get("TEST_DB_PORT") or os.environ.get("POSTGRES_PORT")
+    if not test_db_port:
+        test_db_port = "5432" if test_db_host == "db_test" else "5433"
+    test_db_name = os.environ.get("TEST_POSTGRES_DB", "air_conditioners_test")
+    return _render_url(
+        URL.create(
+            "postgresql+asyncpg",
+            username=pg_user,
+            password=pg_pass,
+            host=test_db_host,
+            port=int(test_db_port),
+            database=test_db_name,
+        )
+    )
+
+
+def _safe_identity_part(value: str, *, fallback: str) -> str:
+    sanitized = re.sub(r"[^a-z0-9]+", "_", value.strip().lower()).strip("_")
+    return sanitized or fallback
+
+
+def build_test_database_target(
+    base_database_url: str,
+    *,
+    run_id: str | None = None,
+    worker_id: str | None = None,
+) -> TestDatabaseTarget:
+    parsed = make_url(base_database_url)
+    base_database_name = parsed.database or ""
+    if parsed.get_backend_name() != "postgresql":
+        raise ValueError("PostgreSQL is required for the test database")
+    if not _has_test_marker(base_database_name):
+        raise ValueError(
+            "Refusing to derive a pytest database from a non-test database"
+        )
+
+    selected_run_id = (
+        run_id
+        or os.environ.get("PYTEST_XDIST_TESTRUNUID")
+        or os.environ.get(RUN_ID_ENV)
+        or uuid.uuid4().hex
+    )
+    selected_worker_id = (
+        worker_id or os.environ.get("PYTEST_XDIST_WORKER") or "master"
+    )
+    worker_token = _safe_identity_part(selected_worker_id, fallback="master")[:12]
+    run_token = hashlib.sha256(selected_run_id.encode("utf-8")).hexdigest()[:10]
+    suffix = f"_{run_token}_{worker_token}"
+    available_base_length = POSTGRES_IDENTIFIER_LIMIT - len(suffix)
+    database_name = f"{base_database_name[:available_base_length]}{suffix}"
+    database_url = _render_url(parsed.set(database=database_name))
+    return TestDatabaseTarget(
+        base_database_name=base_database_name,
+        database_name=database_name,
+        database_url=database_url,
+        run_id=selected_run_id,
+        worker_id=selected_worker_id,
+    )
+
+
+def _admin_connection_kwargs(database_url: str) -> dict[str, object]:
+    parsed = make_url(database_url)
+    kwargs: dict[str, object] = {
+        "dbname": "postgres",
+        "connect_timeout": 10,
+        "autocommit": True,
+    }
+    for key, value in (
+        ("user", parsed.username),
+        ("password", parsed.password),
+        ("host", parsed.host),
+        ("port", parsed.port),
+    ):
+        if value is not None:
+            kwargs[key] = value
+    return kwargs
+
+
+def _assert_safe_target(target: TestDatabaseTarget) -> None:
+    if target.database_name == target.base_database_name:
+        raise ValueError("The isolated database must differ from the base database")
+    if not _has_test_marker(target.database_name):
+        raise ValueError("Refusing to manage a database without a test marker")
+    if len(target.database_name) > POSTGRES_IDENTIFIER_LIMIT:
+        raise ValueError("The isolated database name exceeds the PostgreSQL limit")
+
+
+def drop_test_database(target: TestDatabaseTarget) -> None:
+    _assert_safe_target(target)
+    with psycopg.connect(**_admin_connection_kwargs(target.database_url)) as connection:
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                SELECT pg_terminate_backend(pid)
+                FROM pg_stat_activity
+                WHERE datname = %s
+                  AND pid <> pg_backend_pid()
+                """,
+                (target.database_name,),
+            )
+            cursor.execute(
+                sql.SQL("DROP DATABASE IF EXISTS {}").format(
+                    sql.Identifier(target.database_name)
+                )
+            )
+
+
+def create_test_database(target: TestDatabaseTarget) -> None:
+    _assert_safe_target(target)
+    drop_test_database(target)
+    with psycopg.connect(**_admin_connection_kwargs(target.database_url)) as connection:
+        with connection.cursor() as cursor:
+            cursor.execute(
+                sql.SQL("CREATE DATABASE {} TEMPLATE template0").format(
+                    sql.Identifier(target.database_name)
+                )
+            )

--- a/tests/unit/test_ci_migration_workflow.py
+++ b/tests/unit/test_ci_migration_workflow.py
@@ -70,6 +70,9 @@ def test_ci_keeps_full_coverage_with_compact_diagnostic_output():
     assert "suite: [unit, integration]" in workflow
     assert 'pytest -q --tb=short --durations=25 --durations-min=1.0' in workflow
     assert '"tests/${PYTEST_SUITE}"' in workflow
+    assert "EXPECT_XDIST_DATABASE_ISOLATION=1" in workflow
+    assert "pytest -q -n 2 --dist load" in workflow
+    assert "test_postgres_worker_database_isolation.py" in workflow
     assert "--junitxml=/test-results/results.xml" in workflow
     assert "pytest_status=$?" in workflow
     assert "chmod 0644 /test-results/results.xml" in workflow

--- a/tests/unit/test_postgres_test_support.py
+++ b/tests/unit/test_postgres_test_support.py
@@ -1,0 +1,115 @@
+from sqlalchemy.engine import make_url
+
+from postgres_test_support import (
+    POSTGRES_IDENTIFIER_LIMIT,
+    build_test_database_target,
+    resolve_base_test_database_url,
+)
+
+
+BASE_URL = (
+    "postgresql+asyncpg://postgres:postgres@localhost:5433/"
+    "air_conditioners_test"
+)
+
+
+def test_worker_database_names_are_distinct_and_keep_the_test_marker():
+    first = build_test_database_target(
+        BASE_URL,
+        run_id="same-test-run",
+        worker_id="gw0",
+    )
+    second = build_test_database_target(
+        BASE_URL,
+        run_id="same-test-run",
+        worker_id="gw1",
+    )
+
+    assert first.database_name != second.database_name
+    assert first.database_name.endswith("_gw0")
+    assert second.database_name.endswith("_gw1")
+    assert "test" in first.database_name
+    assert make_url(first.database_url).database == first.database_name
+
+
+def test_worker_database_name_is_sanitized_and_within_postgres_limit():
+    target = build_test_database_target(
+        BASE_URL.replace("air_conditioners_test", "very_long_test_" + "x" * 80),
+        run_id="run with unsafe / separators",
+        worker_id="GW 17/unsafe",
+    )
+
+    assert len(target.database_name) <= POSTGRES_IDENTIFIER_LIMIT
+    assert target.database_name.endswith("_gw_17_unsafe")
+    assert "/" not in target.database_name
+    assert " " not in target.database_name
+
+
+def test_non_test_database_is_never_accepted_even_when_password_contains_test():
+    unsafe_url = (
+        "postgresql+asyncpg://postgres:test-password@localhost:5432/air_conditioners"
+    )
+
+    try:
+        build_test_database_target(unsafe_url, run_id="run", worker_id="master")
+    except ValueError as exc:
+        assert "non-test database" in str(exc)
+    else:
+        raise AssertionError("A production-shaped database URL was accepted")
+
+
+def test_database_name_requires_a_test_token_not_a_substring():
+    unsafe_url = (
+        "postgresql+asyncpg://postgres:postgres@localhost:5432/contest_production"
+    )
+
+    try:
+        build_test_database_target(unsafe_url, run_id="run", worker_id="master")
+    except ValueError as exc:
+        assert "non-test database" in str(exc)
+    else:
+        raise AssertionError("A database without an explicit test token was accepted")
+
+
+def test_base_url_resolution_ignores_non_test_database(monkeypatch):
+    monkeypatch.delenv("PYTEST_BASE_DATABASE_URL", raising=False)
+    monkeypatch.delenv("TEST_DATABASE_URL", raising=False)
+    monkeypatch.setenv(
+        "DATABASE_URL",
+        "postgresql+asyncpg://postgres:test-password@localhost:5432/air_conditioners",
+    )
+    monkeypatch.setenv("POSTGRES_USER", "postgres")
+    monkeypatch.setenv("POSTGRES_PASSWORD", "postgres")
+    monkeypatch.setenv("TEST_POSTGRES_DB", "air_conditioners_test")
+
+    resolved = resolve_base_test_database_url(running_inside_docker=False)
+
+    assert make_url(resolved).database == "air_conditioners_test"
+    assert make_url(resolved).port == 5433
+
+
+def test_explicit_base_database_override_fails_closed(monkeypatch):
+    monkeypatch.setenv(
+        "PYTEST_BASE_DATABASE_URL",
+        "postgresql+asyncpg://postgres:postgres@localhost:5432/air_conditioners",
+    )
+
+    try:
+        resolve_base_test_database_url(running_inside_docker=False)
+    except ValueError as exc:
+        assert "PYTEST_BASE_DATABASE_URL" in str(exc)
+    else:
+        raise AssertionError("An unsafe explicit base database was ignored")
+
+
+def test_fallback_url_encodes_password_characters(monkeypatch):
+    monkeypatch.delenv("PYTEST_BASE_DATABASE_URL", raising=False)
+    monkeypatch.delenv("TEST_DATABASE_URL", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setenv("POSTGRES_USER", "postgres")
+    monkeypatch.setenv("POSTGRES_PASSWORD", "p@ss/word")
+    monkeypatch.setenv("TEST_POSTGRES_DB", "air_conditioners_test")
+
+    resolved = resolve_base_test_database_url(running_inside_docker=False)
+
+    assert make_url(resolved).password == "p@ss/word"

--- a/tests/unit/test_postgres_test_support.py
+++ b/tests/unit/test_postgres_test_support.py
@@ -74,6 +74,9 @@ def test_database_name_requires_a_test_token_not_a_substring():
 def test_base_url_resolution_ignores_non_test_database(monkeypatch):
     monkeypatch.delenv("PYTEST_BASE_DATABASE_URL", raising=False)
     monkeypatch.delenv("TEST_DATABASE_URL", raising=False)
+    monkeypatch.delenv("TEST_DB_HOST", raising=False)
+    monkeypatch.delenv("TEST_DB_PORT", raising=False)
+    monkeypatch.delenv("POSTGRES_PORT", raising=False)
     monkeypatch.setenv(
         "DATABASE_URL",
         "postgresql+asyncpg://postgres:test-password@localhost:5432/air_conditioners",


### PR DESCRIPTION
## Что изменено\n\n- pytest создаёт отдельную физическую PostgreSQL-БД для каждого процесса и xdist-worker;\n- тестовая конфигурация приложения и fixtures используют один и тот же URL;\n- схема создаётся один раз на worker, между тестами данные очищаются через TRUNCATE;\n- исторический expand-phase временно ослабляет только нужные ограничения и гарантированно восстанавливает их;\n- PostgreSQL fixtures со своими схемами привязаны к worker-БД;\n- в CI добавлен короткий canary на двух xdist-worker, но полные unit/integration suites пока остаются последовательными;\n- добавлены fail-closed проверки, запрещающие использовать production-shaped database name.\n\n## Зачем\n\nПрежний function-scoped drop_all/create_all занимал большую часть времени DB-тестов и не позволял безопасно запускать pytest параллельно. Кроме того, TEST_DATABASE_URL и глобальный DATABASE_URL могли указывать на разные БД.\n\n## Проверка\n\nЛокально:\n\n- full unit: 3022 passed, 4 skipped — 7:05;\n- full integration: 336 passed — 5:01;\n- все 146 тестов, напрямую использующих db_engine: passed;\n- два независимых pytest-процесса одновременно использовали разные физические БД;\n- после завершения временных БД не осталось;\n- test_lead_service: 31.06s → 13.08s wall time;\n- expand-phase + contracted follow-up: 65.76s → 28.84s wall time;\n- actionlint, py_compile и git diff --check: clean.\n\nGitHub Actions, green run 31303581664:\n\n- xdist isolation canary: 4 passed на 2 workers за 5.85s;\n- integration: 336 passed за 5:43, job 7:47;\n- unit: 3027 passed, 2 skipped за 8:31, job 10:13;\n- backend contracts: 2:55;\n- обязательный aggregate check: success;\n- полный wall time: 11:13.\n\n## Граница этого PR\n\nШирокий pytest-xdist пока не включён. Этот PR создаёт и проверяет безопасную инфраструктуру; выбор suites и числа workers будет отдельным измеряемым изменением после CI.