### PR TITLE
Parallelize PostgreSQL pytest suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,7 +290,10 @@ jobs:
                     tests/integration/test_postgres_worker_database_isolation.py
               fi
               set +e
-              pytest -q --tb=short --durations=25 --durations-min=1.0 --junitxml=/test-results/results.xml "tests/${PYTEST_SUITE}"
+              pytest -q -n 2 --dist loadscope \
+                --tb=short --durations=25 --durations-min=1.0 \
+                --junitxml=/test-results/results.xml \
+                "tests/${PYTEST_SUITE}"
               pytest_status=$?
               chmod 0644 /test-results/results.xml 2>/dev/null || true
               exit "${pytest_status}"

--- a/tests/unit/test_ci_migration_workflow.py
+++ b/tests/unit/test_ci_migration_workflow.py
@@ -68,10 +68,11 @@ def test_ci_keeps_full_coverage_with_compact_diagnostic_output():
     workflow = CI_WORKFLOW.read_text(encoding="utf-8")
 
     assert "suite: [unit, integration]" in workflow
-    assert 'pytest -q --tb=short --durations=25 --durations-min=1.0' in workflow
+    assert "pytest -q -n 2 --dist loadscope" in workflow
+    assert "--tb=short --durations=25 --durations-min=1.0" in workflow
     assert '"tests/${PYTEST_SUITE}"' in workflow
     assert "EXPECT_XDIST_DATABASE_ISOLATION=1" in workflow
-    assert "pytest -q -n 2 --dist load" in workflow
+    assert "pytest -q -n 2 --dist load \\" in workflow
     assert "test_postgres_worker_database_isolation.py" in workflow
     assert "--junitxml=/test-results/results.xml" in workflow
     assert "pytest_status=$?" in workflow

--- a/tests/unit/test_postgres_pitr_runtime_contract.py
+++ b/tests/unit/test_postgres_pitr_runtime_contract.py
@@ -593,6 +593,8 @@ def test_scheduled_runner_reports_lock_collision_as_intentional_skip(
     monkeypatch,
     capsys,
 ):
+    umask_calls = []
+    monkeypatch.setattr(scheduled.os, "umask", umask_calls.append)
     monkeypatch.setattr(
         scheduled,
         "run_scheduled",
@@ -611,4 +613,5 @@ def test_scheduled_runner_reports_lock_collision_as_intentional_skip(
     )
 
     assert result == 75
+    assert umask_calls == [0o077]
     assert "busy" in capsys.readouterr().err


### PR DESCRIPTION
## Summary
- run the complete unit and integration suites with two `loadscope` pytest workers
- retain the dedicated integration canary that proves xdist worker/database isolation
- isolate the PITR scheduled-runner test's intentional `umask(077)` call so it cannot leak process state into later tests

## Why
PR #907 gave every pytest process and xdist worker its own physical PostgreSQL database. This change enables the bounded parallel configuration only after both complete suites passed locally. Two workers are explicit to keep database and runner load predictable.

## Validation
- `pytest -q -n 2 --dist loadscope tests/unit`: 3025 passed, 4 skipped in 320.78s
- `pytest -q -n 2 --dist loadscope tests/integration`: 336 passed in 259.20s
- `pytest -q tests/unit/test_postgres_pitr_runtime_contract.py`: 23 passed
- `actionlint .github/workflows/ci.yml`
- `git diff --check`
