### PR TITLE
Fix parallel CI initialization and reruns

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,11 @@ jobs:
       - name: Upload Manager Frontend Build
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: manager-dist-${{ github.run_id }}-${{ github.run_attempt }}
+          name: manager-dist-${{ github.run_id }}
           path: manager_frontend/dist
           if-no-files-found: error
           retention-days: 1
+          overwrite: true
 
   manager:
     runs-on: ubuntu-latest
@@ -77,7 +78,7 @@ jobs:
       - name: Download Manager Frontend Build
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: manager-dist-${{ github.run_id }}-${{ github.run_attempt }}
+          name: manager-dist-${{ github.run_id }}
           path: manager_frontend/dist
 
       - name: Setup Node.js
@@ -212,7 +213,7 @@ jobs:
       - name: Download Manager Frontend Build
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: manager-dist-${{ github.run_id }}-${{ github.run_attempt }}
+          name: manager-dist-${{ github.run_id }}
           path: manager_frontend/dist
 
       - name: Create Dummy Env

--- a/services/backup_service.py
+++ b/services/backup_service.py
@@ -39,8 +39,7 @@ class BackupService:
         self.backup_folder_id = os.getenv("BACKUP_FOLDER_ID")
         self.media_dir = "media"
 
-        if not os.path.exists(BACKUP_DIR):
-            os.makedirs(BACKUP_DIR)
+        os.makedirs(BACKUP_DIR, exist_ok=True)
 
     @staticmethod
     def _parse_created_at(raw_value: Optional[str]) -> datetime:

--- a/tests/unit/test_backup_service.py
+++ b/tests/unit/test_backup_service.py
@@ -1,10 +1,35 @@
-import pytest
-import tarfile
 import io
+import os
+import tarfile
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
+import pytest
+
+from services import backup_service
 from services.backup_service import BackupConfigurationError, BackupService
 from services.google_oauth_credentials import GoogleTokenRefreshError
+
+
+def test_concurrent_initialization_creates_backup_directory_once(monkeypatch, tmp_path: Path):
+    backup_dir = tmp_path / "backups"
+    workers = 8
+    barrier = threading.Barrier(workers)
+    real_makedirs = os.makedirs
+
+    def synchronized_makedirs(path, mode=0o777, exist_ok=False):
+        barrier.wait(timeout=5)
+        return real_makedirs(path, mode=mode, exist_ok=exist_ok)
+
+    monkeypatch.setattr(backup_service, "BACKUP_DIR", str(backup_dir))
+    monkeypatch.setattr(backup_service.os, "makedirs", synchronized_makedirs)
+
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        services = list(executor.map(lambda _: BackupService(), range(workers)))
+
+    assert len(services) == workers
+    assert backup_dir.is_dir()
 
 
 def test_list_backups_classifies_and_sorts(monkeypatch):

--- a/tests/unit/test_ci_migration_workflow.py
+++ b/tests/unit/test_ci_migration_workflow.py
@@ -89,7 +89,8 @@ def test_ci_uses_dependency_cache_and_isolated_compose_cleanup():
     assert workflow.count("cache-dependency-path: manager_frontend/package-lock.json") == 3
     assert workflow.count("npm run build") == 1
     assert workflow.count("actions/download-artifact@") == 2
-    assert "manager-dist-${{ github.run_id }}-${{ github.run_attempt }}" in workflow
+    assert workflow.count("manager-dist-${{ github.run_id }}") == 3
+    assert "github.run_attempt" not in workflow
     assert workflow.count("docker/setup-buildx-action@") == 2
     assert workflow.count("docker/build-push-action@") == 2
     assert (
@@ -120,6 +121,7 @@ def test_ci_uses_dependency_cache_and_isolated_compose_cleanup():
     )
     assert manager_upload["with"]["retention-days"] == 1
     assert manager_upload["with"]["if-no-files-found"] == "error"
+    assert manager_upload["with"]["overwrite"] is True
     manager_steps = "\n".join(
         str(step.get("run", "")) for step in jobs["manager"]["steps"]
     )


### PR DESCRIPTION
## Summary

- make BackupService directory initialization safe across concurrent pytest workers
- keep the manager build artifact name stable across workflow rerun attempts
- allow a full rerun to replace that artifact before dependent jobs start
- add regression coverage for concurrent initialization and artifact contract

## Failure evidence

Post-merge run 31328600937 first failed with FileExistsError while two integration workers imported BackupService. Rerun-failed-jobs then searched for a run-attempt-2 artifact although manager-dist had succeeded only in attempt 1.

## Verification

- 348 integration tests passed with two workers and loadscope distribution
- exact previously failing integration test passed with two workers
- 16 changed-area unit tests passed with two workers
- 25 backup-focused unit tests passed
- compileall and git diff --check passed
- independent concurrency and workflow audit found no blockers