### PR TITLE
Hotfix manager AI drafts and HA write fencing

### DIFF
--- a/bot_app/runtime_lease.py
+++ b/bot_app/runtime_lease.py
@@ -6,7 +6,7 @@ import os
 import socket
 import uuid
 
-from .api_gateway import BotApiError
+from .api_gateway import BotApiError, BotApiUnavailableError
 from .api_runtime import get_bot_api_gateway
 from .settings import settings
 
@@ -22,6 +22,24 @@ class BotRuntimeLease:
         self.reason = "lease not requested"
         self.lost_event = asyncio.Event()
         self._heartbeat_task: asyncio.Task | None = None
+        self._lease_deadline: float | None = None
+
+    def _record_lease_deadline(self) -> None:
+        self._lease_deadline = (
+            asyncio.get_running_loop().time() + settings.BOT_RUNTIME_LEASE_SECONDS
+        )
+
+    @staticmethod
+    def _next_retry_delay(delay: float) -> float:
+        return min(
+            max(float(settings.BOT_RUNTIME_RETRY_SECONDS), delay * 2),
+            min(60.0, float(settings.BOT_RUNTIME_LEASE_SECONDS)),
+        )
+
+    def _mark_lost(self, reason: str) -> None:
+        logger.error(reason)
+        self.acquired = False
+        self.lost_event.set()
 
     async def try_acquire(self) -> bool:
         result = await get_bot_api_gateway().acquire_runtime_lease(
@@ -32,33 +50,73 @@ class BotRuntimeLease:
         self.acquired = result.acquired
         self.reason = "runtime lease acquired" if result.acquired else "another bot owns runtime lease"
         if self.acquired and self._heartbeat_task is None:
+            self._record_lease_deadline()
             self._heartbeat_task = asyncio.create_task(self._heartbeat())
         return self.acquired
 
     async def wait_until_acquired(self) -> None:
-        while not await self.try_acquire():
+        retry_delay = float(settings.BOT_RUNTIME_RETRY_SECONDS)
+        while True:
+            try:
+                if await self.try_acquire():
+                    return
+            except BotApiUnavailableError as exc:
+                logger.warning(
+                    "Telegram polling lease API is unavailable; retrying in %.1fs: %s",
+                    retry_delay,
+                    exc,
+                )
+                await asyncio.sleep(retry_delay)
+                retry_delay = self._next_retry_delay(retry_delay)
+                continue
             logger.info("Telegram polling lease is busy; retrying")
-            await asyncio.sleep(settings.BOT_RUNTIME_RETRY_SECONDS)
+            retry_delay = float(settings.BOT_RUNTIME_RETRY_SECONDS)
+            await asyncio.sleep(retry_delay)
 
     async def _heartbeat(self) -> None:
         while self.acquired:
             await asyncio.sleep(settings.BOT_RUNTIME_RENEW_SECONDS)
-            try:
-                result = await get_bot_api_gateway().renew_runtime_lease(
-                    name=self.name,
-                    owner_id=self.owner_id,
-                    ttl_seconds=settings.BOT_RUNTIME_LEASE_SECONDS,
-                )
-            except BotApiError:
-                logger.exception("Telegram polling lease renewal failed")
-                self.acquired = False
-                self.lost_event.set()
-                return
-            if not result.acquired:
-                logger.error("Telegram polling lease ownership was lost")
-                self.acquired = False
-                self.lost_event.set()
-                return
+            retry_delay = float(settings.BOT_RUNTIME_RETRY_SECONDS)
+            while self.acquired:
+                try:
+                    result = await get_bot_api_gateway().renew_runtime_lease(
+                        name=self.name,
+                        owner_id=self.owner_id,
+                        ttl_seconds=settings.BOT_RUNTIME_LEASE_SECONDS,
+                    )
+                except BotApiUnavailableError as exc:
+                    loop_time = asyncio.get_running_loop().time()
+                    deadline = self._lease_deadline or loop_time
+                    safety_margin = min(
+                        5.0,
+                        max(1.0, float(settings.BOT_RUNTIME_RENEW_SECONDS)),
+                    )
+                    remaining = deadline - loop_time - safety_margin
+                    if remaining <= 0:
+                        self._mark_lost(
+                            "Telegram polling lease renewal deadline expired"
+                        )
+                        return
+                    delay = min(retry_delay, remaining)
+                    logger.warning(
+                        "Telegram polling lease renewal is unavailable; "
+                        "retrying in %.1fs: %s",
+                        delay,
+                        exc,
+                    )
+                    await asyncio.sleep(delay)
+                    retry_delay = self._next_retry_delay(retry_delay)
+                    continue
+                except BotApiError as exc:
+                    self._mark_lost(
+                        f"Telegram polling lease renewal failed: {exc}"
+                    )
+                    return
+                if not result.acquired:
+                    self._mark_lost("Telegram polling lease ownership was lost")
+                    return
+                self._record_lease_deadline()
+                break
 
     async def release(self) -> None:
         self.acquired = False

--- a/core/api_write_fence.py
+++ b/core/api_write_fence.py
@@ -1,0 +1,67 @@
+"""Fail closed for API mutations on a passive HA node."""
+
+import json
+
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+from core.config import settings
+from core.runtime_controls import ACTIVE_APP_ROLES, normalize_app_role
+
+
+_WRITE_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
+_RESPONSE_BODY = json.dumps(
+    {
+        "detail": {
+            "code": "api_write_fenced",
+            "message": (
+                "Сервер переключается на основной узел. "
+                "Повторите действие через несколько секунд."
+            ),
+            "retryable": True,
+        }
+    },
+    ensure_ascii=False,
+    separators=(",", ":"),
+).encode("utf-8")
+
+
+class ApiWriteFenceMiddleware:
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    @staticmethod
+    def _write_traffic_enabled() -> bool:
+        return (
+            normalize_app_role(settings.APP_ROLE) in ACTIVE_APP_ROLES
+            and settings.api_ready_control_decision.enabled
+        )
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if (
+            scope.get("type") == "http"
+            and str(scope.get("path") or "").startswith("/api/")
+            and str(scope.get("method") or "").upper() in _WRITE_METHODS
+            and not self._write_traffic_enabled()
+        ):
+            headers = [
+                (b"content-type", b"application/json"),
+                (b"content-length", str(len(_RESPONSE_BODY)).encode("ascii")),
+                (b"cache-control", b"no-store"),
+                (b"retry-after", b"3"),
+            ]
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 503,
+                    "headers": headers,
+                }
+            )
+            await send(
+                {
+                    "type": "http.response.body",
+                    "body": _RESPONSE_BODY,
+                    "more_body": False,
+                }
+            )
+            return
+        await self.app(scope, receive, send)

--- a/core/app_http.py
+++ b/core/app_http.py
@@ -8,6 +8,7 @@ from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 from core.app_constants import (
     INTERNAL_SERVER_ERROR_MESSAGE,
 )
+from core.api_write_fence import ApiWriteFenceMiddleware
 from core.config import settings
 from core.logger import logger
 from core.manager_error_codes import INTERNAL_ERROR, VALIDATION_ERROR, resolve_manager_error_message
@@ -155,6 +156,7 @@ def configure_http(app: FastAPI) -> None:
         StorefrontRequestGatewayMiddleware,
         max_body_bytes=settings.STOREFRONT_CONTEXT_MAX_BODY_BYTES,
     )
+    app.add_middleware(ApiWriteFenceMiddleware)
     # Added last so it is the outermost user middleware and also covers CORS
     # preflight/short-circuit responses.
     app.add_middleware(RequestContextMiddleware)

--- a/manager_frontend/src/components/brands/BrandShortDescriptionAiAction.vue
+++ b/manager_frontend/src/components/brands/BrandShortDescriptionAiAction.vue
@@ -18,26 +18,26 @@ const loading = ref(false);
 const error = ref("");
 
 const generate = async () => {
+  if (loading.value) return;
   const description = props.description.trim();
   if (!description) {
     error.value = "Сначала заполните полное описание бренда.";
     return;
   }
-  if (
-    props.hasExistingContent &&
-    !(await confirmDialog({
-      title: "Заменить короткое описание?",
-      description:
-        "AI подготовит новый черновик. Изменения останутся только в форме до сохранения.",
-      confirmText: "Заменить",
-      variant: "warning",
-    }))
-  )
-    return;
-
   loading.value = true;
   error.value = "";
   try {
+    if (
+      props.hasExistingContent &&
+      !(await confirmDialog({
+        title: "Заменить короткое описание?",
+        description:
+          "AI подготовит новый черновик. Изменения останутся только в форме до сохранения.",
+        confirmText: "Заменить",
+        variant: "warning",
+      }))
+    )
+      return;
     emit(
       "draft",
       await contentAiApi.brandShortDescriptionDraft({

--- a/manager_frontend/tests/brand-short-description-ai.spec.ts
+++ b/manager_frontend/tests/brand-short-description-ai.spec.ts
@@ -1,5 +1,5 @@
 import { mount, shallowMount } from "@vue/test-utils";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { brandShortDescriptionDraft, confirmDialog } = vi.hoisted(() => ({
   brandShortDescriptionDraft: vi.fn(),
@@ -13,6 +13,10 @@ vi.mock("../src/services/ui-feedback", () => ({ confirmDialog }));
 
 import BrandEditorModal from "../src/components/brands/BrandEditorModal.vue";
 import BrandShortDescriptionAiAction from "../src/components/brands/BrandShortDescriptionAiAction.vue";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
 
 describe("BrandShortDescriptionAiAction", () => {
   it("is unavailable until the full description is present", () => {
@@ -51,6 +55,34 @@ describe("BrandShortDescriptionAiAction", () => {
         prompt_version: "manager-brand-short-description-v1",
       },
     ]);
+  });
+
+  it("does not start duplicate requests while confirmation is open", async () => {
+    let resolveConfirmation: ((value: boolean) => void) | undefined;
+    confirmDialog.mockImplementation(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolveConfirmation = resolve;
+        }),
+    );
+    brandShortDescriptionDraft.mockResolvedValue({
+      short_description: "Короткий текст",
+      prompt_version: "manager-brand-short-description-v1",
+    });
+    const wrapper = mount(BrandShortDescriptionAiAction, {
+      props: {
+        title: "TCL",
+        description: "Полное описание",
+        hasExistingContent: true,
+      },
+    });
+
+    await wrapper.get("button").trigger("click");
+    await wrapper.get("button").trigger("click");
+
+    expect(confirmDialog).toHaveBeenCalledTimes(1);
+    resolveConfirmation?.(true);
+    await vi.waitFor(() => expect(brandShortDescriptionDraft).toHaveBeenCalledTimes(1));
   });
 });
 

--- a/services/deepseek_provider_service.py
+++ b/services/deepseek_provider_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from typing import Any
 
@@ -12,6 +13,7 @@ from core.config import settings
 
 MAX_DEEPSEEK_RESPONSE_BYTES = 512_000
 MAX_DEEPSEEK_OUTPUT_TOKENS = 4_096
+DEEPSEEK_REQUEST_DEADLINE_SECONDS = 50.0
 
 
 class DefectActAIProviderError(ValueError):
@@ -36,6 +38,7 @@ async def request_deepseek_completion(
     prompt: str,
     system_prompt: str,
     temperature: float,
+    thinking_enabled: bool | None = None,
 ) -> str:
     token = settings.DEEPSEEK_TOKEN.strip()
     if not token:
@@ -46,35 +49,42 @@ async def request_deepseek_completion(
             code="not_configured",
         )
 
+    request_payload: dict[str, Any] = {
+        "model": settings.DEEPSEEK_MODEL,
+        "temperature": temperature,
+        "max_tokens": MAX_DEEPSEEK_OUTPUT_TOKENS,
+        "response_format": {"type": "json_object"},
+        "messages": [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": prompt},
+        ],
+    }
+    if thinking_enabled is not None:
+        request_payload["thinking"] = {
+            "type": "enabled" if thinking_enabled else "disabled"
+        }
+
     response: httpx.Response | None = None
     try:
-        async with httpx.AsyncClient(timeout=45.0, trust_env=False) as client:
-            request = client.build_request(
-                "POST",
-                settings.DEEPSEEK_API_URL,
-                headers={
-                    "Authorization": f"Bearer {token}",
-                    "Content-Type": "application/json",
-                    "Accept": "application/json",
-                    "Accept-Encoding": "identity",
-                },
-                json={
-                    "model": settings.DEEPSEEK_MODEL,
-                    "temperature": temperature,
-                    "max_tokens": MAX_DEEPSEEK_OUTPUT_TOKENS,
-                    "response_format": {"type": "json_object"},
-                    "messages": [
-                        {"role": "system", "content": system_prompt},
-                        {"role": "user", "content": prompt},
-                    ],
-                },
-            )
-            response = await client.send(request, stream=True)
-            try:
-                raw_response = await _read_limited_response(response)
-            finally:
-                await response.aclose()
-    except httpx.TimeoutException as exc:
+        async with asyncio.timeout(DEEPSEEK_REQUEST_DEADLINE_SECONDS):
+            async with httpx.AsyncClient(timeout=45.0, trust_env=False) as client:
+                request = client.build_request(
+                    "POST",
+                    settings.DEEPSEEK_API_URL,
+                    headers={
+                        "Authorization": f"Bearer {token}",
+                        "Content-Type": "application/json",
+                        "Accept": "application/json",
+                        "Accept-Encoding": "identity",
+                    },
+                    json=request_payload,
+                )
+                response = await client.send(request, stream=True)
+                try:
+                    raw_response = await _read_limited_response(response)
+                finally:
+                    await response.aclose()
+    except (TimeoutError, httpx.TimeoutException) as exc:
         raise DefectActAIProviderError(
             "DeepSeek request timed out",
             status=None,

--- a/services/manager_content_ai_service.py
+++ b/services/manager_content_ai_service.py
@@ -94,6 +94,7 @@ class ManagerContentAIService:
             prompt=prompt,
             system_prompt=self._SYSTEM_PROMPT,
             temperature=0.1,
+            thinking_enabled=False,
         )
         parsed = self._parse_provider_json(content, _FeatureProviderDraft)
         try:
@@ -117,6 +118,7 @@ class ManagerContentAIService:
             prompt=prompt,
             system_prompt=self._SYSTEM_PROMPT,
             temperature=0.1,
+            thinking_enabled=False,
         )
         parsed = self._parse_provider_json(content, _BrandShortDescriptionProviderDraft)
         try:
@@ -143,6 +145,7 @@ class ManagerContentAIService:
             prompt=prompt,
             system_prompt=self._SYSTEM_PROMPT,
             temperature=0.1,
+            thinking_enabled=False,
         )
         parsed = self._parse_provider_json(content, _SeriesProviderDraft)
         try:
@@ -374,6 +377,13 @@ class ManagerContentAIService:
         if len(value) <= max_length:
             return value
         shortened = value[:max_length].rstrip()
+        sentence_boundary = max(
+            shortened.rfind("."),
+            shortened.rfind("!"),
+            shortened.rfind("?"),
+        )
+        if sentence_boundary >= max(40, max_length // 3):
+            return shortened[: sentence_boundary + 1].rstrip()
         boundary = max(shortened.rfind(" "), shortened.rfind("\n"))
         if boundary >= max_length // 2:
             shortened = shortened[:boundary].rstrip(" ,;:-")

--- a/tests/integration/test_api_readiness.py
+++ b/tests/integration/test_api_readiness.py
@@ -48,3 +48,35 @@ async def test_api_ready_returns_200_when_public_traffic_enabled(async_client, m
     assert payload["traffic"] == "enabled"
     assert payload["database"] == "online"
     assert payload["scheduler_runtime"] == scheduler_runtime
+
+
+@pytest.mark.asyncio
+async def test_standby_fences_api_mutations_before_auth_or_database(
+    async_client,
+    monkeypatch,
+):
+    monkeypatch.setattr(settings, "APP_ROLE", "standby", raising=False)
+    monkeypatch.setattr(settings, "API_READY_ENABLED", False, raising=False)
+
+    response = await async_client.post(
+        "/api/manager/content-ai/brands/short-description/draft",
+        json={"brand_name": "TCL", "full_description": "Описание"},
+    )
+
+    assert response.status_code == 503
+    assert response.headers["retry-after"] == "3"
+    assert response.headers["cache-control"] == "no-store"
+    assert response.json()["detail"]["code"] == "api_write_fenced"
+
+
+@pytest.mark.asyncio
+async def test_primary_does_not_apply_standby_write_fence(async_client, monkeypatch):
+    monkeypatch.setattr(settings, "APP_ROLE", "primary", raising=False)
+    monkeypatch.setattr(settings, "API_READY_ENABLED", True, raising=False)
+
+    response = await async_client.post(
+        "/api/manager/content-ai/brands/short-description/draft",
+        json={"brand_name": "TCL", "full_description": "Описание"},
+    )
+
+    assert response.status_code == 401

--- a/tests/unit/test_bot_runtime_lease.py
+++ b/tests/unit/test_bot_runtime_lease.py
@@ -1,0 +1,87 @@
+from types import SimpleNamespace
+
+import pytest
+
+from bot_app.api_gateway import BotApiUnavailableError
+from bot_app.runtime_lease import BotRuntimeLease
+
+
+@pytest.mark.asyncio
+async def test_runtime_lease_acquire_uses_bounded_backoff_on_api_outage(monkeypatch):
+    lease = BotRuntimeLease(name="test:bot")
+    attempts = 0
+    delays: list[float] = []
+
+    async def try_acquire():
+        nonlocal attempts
+        attempts += 1
+        if attempts < 4:
+            raise BotApiUnavailableError("offline")
+        return True
+
+    async def sleep(delay):
+        delays.append(float(delay))
+
+    monkeypatch.setattr(lease, "try_acquire", try_acquire)
+    monkeypatch.setattr("bot_app.runtime_lease.asyncio.sleep", sleep)
+    monkeypatch.setattr(
+        "bot_app.runtime_lease.settings.BOT_RUNTIME_RETRY_SECONDS", 5
+    )
+    monkeypatch.setattr(
+        "bot_app.runtime_lease.settings.BOT_RUNTIME_LEASE_SECONDS", 45
+    )
+
+    await lease.wait_until_acquired()
+
+    assert attempts == 4
+    assert delays == [5.0, 10.0, 20.0]
+
+
+@pytest.mark.asyncio
+async def test_runtime_lease_heartbeat_retries_transient_failure(monkeypatch):
+    lease = BotRuntimeLease(name="test:bot")
+    lease.acquired = True
+    lease._record_lease_deadline()
+    renew_calls = 0
+
+    class Gateway:
+        async def renew_runtime_lease(self, **_kwargs):
+            nonlocal renew_calls
+            renew_calls += 1
+            if renew_calls == 1:
+                raise BotApiUnavailableError("offline")
+            lease.acquired = False
+            return SimpleNamespace(acquired=True)
+
+    async def sleep(_delay):
+        return None
+
+    monkeypatch.setattr("bot_app.runtime_lease.get_bot_api_gateway", Gateway)
+    monkeypatch.setattr("bot_app.runtime_lease.asyncio.sleep", sleep)
+
+    await lease._heartbeat()
+
+    assert renew_calls == 2
+    assert not lease.lost_event.is_set()
+
+
+@pytest.mark.asyncio
+async def test_runtime_lease_heartbeat_stops_before_expiry(monkeypatch):
+    lease = BotRuntimeLease(name="test:bot")
+    lease.acquired = True
+    lease._lease_deadline = 0.0
+
+    class Gateway:
+        async def renew_runtime_lease(self, **_kwargs):
+            raise BotApiUnavailableError("offline")
+
+    async def sleep(_delay):
+        return None
+
+    monkeypatch.setattr("bot_app.runtime_lease.get_bot_api_gateway", Gateway)
+    monkeypatch.setattr("bot_app.runtime_lease.asyncio.sleep", sleep)
+
+    await lease._heartbeat()
+
+    assert lease.acquired is False
+    assert lease.lost_event.is_set()

--- a/tests/unit/test_deepseek_provider_service.py
+++ b/tests/unit/test_deepseek_provider_service.py
@@ -60,12 +60,14 @@ async def test_deepseek_transport_is_bounded_and_disables_environment_proxy(monk
         prompt="prompt",
         system_prompt="system",
         temperature=0.1,
+        thinking_enabled=False,
     )
 
     assert result == '{"ok":true}'
     assert _RecordingClient.init_kwargs["trust_env"] is False
     request_payload = json.loads(_RecordingClient.request.content)
     assert request_payload["max_tokens"] == 4096
+    assert request_payload["thinking"] == {"type": "disabled"}
     assert _RecordingClient.request.headers["accept-encoding"] == "identity"
 
 

--- a/tests/unit/test_manager_content_ai_service.py
+++ b/tests/unit/test_manager_content_ai_service.py
@@ -62,6 +62,7 @@ async def test_brand_short_description_draft_is_grounded_clean_and_capped():
     assert result.short_description == "Бытовые серии для разных сценариев"
     assert result.prompt_version == "manager-brand-short-description-v1"
     assert captured["temperature"] == 0.1
+    assert captured["thinking_enabled"] is False
     prompt = json.loads(captured["prompt"])
     assert prompt["entity"] == "brand"
     assert prompt["immutable_context"] == {"brand_name": "TCL"}
@@ -87,6 +88,36 @@ async def test_brand_short_description_draft_rejects_extra_provider_fields():
         )
 
     assert raised.value.code == "invalid_response"
+
+
+@pytest.mark.asyncio
+async def test_brand_short_description_prefers_complete_sentence_when_capped():
+    async def completion_request(**_kwargs):
+        return json.dumps(
+            {
+                "short_description": (
+                    "Бренд предлагает бытовые и коммерческие системы для квартир, "
+                    "домов, офисов и магазинов. "
+                    "Вторая фраза заведомо длинная и не должна остаться обрезанным "
+                    "фрагментом после достижения установленного лимита карточки. "
+                    "Дополнительный хвост делает ответ длиннее двухсот символов."
+                )
+            },
+            ensure_ascii=False,
+        )
+
+    service = ManagerContentAIService(completion_request=completion_request)
+    result = await service.generate_brand_short_description_draft(
+        BrandShortDescriptionDraftRequest(
+            brand_name="TCL",
+            full_description="Исходное описание бренда.",
+        )
+    )
+
+    assert result.short_description == (
+        "Бренд предлагает бытовые и коммерческие системы для квартир, домов, "
+        "офисов и магазинов."
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Что исправлено

- отключён DeepSeek thinking mode для manager content drafts: production-модель тратила весь лимит на reasoning_content, завершалась с finish_reason=length и возвращала пустой content
- добавлен жёсткий 50-секундный дедлайн внешнего AI-вызова, короче nginx timeout
- ограничение короткого описания сохраняет целое предложение
- passive/standby API теперь fail-closed отклоняет все изменяющие /api/* запросы до auth/DB с управляемым 503
- Telegram bot lease использует bounded exponential backoff при недоступности API и не создаёт restart/lock storm после единичной ошибки renewal
- AI-кнопка бренда блокирует повторный запрос уже во время confirmation

## Production evidence

- три brand AI запроса завершились 502 размером 114 байт
- DeepSeek во всех случаях ответил HTTP 200
- на реальных Energolux/Royal Clima ответ имел finish_reason=length, 4096 reasoning tokens и пустой message.content
- тот же production prompt с thinking.type=disabled завершился stop, без reasoning и с валидным JSON

## Проверки

- pytest integration: 350 passed
- расширенный unit-набор по AI/HA/bot: 70 passed
- целевой hotfix-набор: 21 passed
- manager components: 26 files / 73 passed
- manager build: passed
- git diff --check: passed