### PR TITLE
feat: attach bot reports to work stages

### DIFF
--- a/api_contracts/bot.py
+++ b/api_contracts/bot.py
@@ -142,6 +142,12 @@ class BotTaskReportSaveResponse(BaseModel):
     changed: bool
 
 
+class BotTaskAttachmentResponse(BaseModel):
+    stage_id: int = Field(ge=1)
+    order_id: int = Field(ge=1)
+    already_attached: bool = False
+
+
 BotQuickOrderServiceType = Literal[
     "turnkey",
     "install_only",

--- a/manager_frontend/src/client/index.ts
+++ b/manager_frontend/src/client/index.ts
@@ -24,6 +24,7 @@ export type { BankStatementImportResponse } from './models/BankStatementImportRe
 export type { Body_apply_internal_bot_repair_nameplate_v1 } from './models/Body_apply_internal_bot_repair_nameplate_v1';
 export type { Body_apply_internal_bot_warranty_nameplate_v1 } from './models/Body_apply_internal_bot_warranty_nameplate_v1';
 export type { Body_attach_internal_bot_order_file_v1 } from './models/Body_attach_internal_bot_order_file_v1';
+export type { Body_attach_internal_bot_task_stage_file_v1 } from './models/Body_attach_internal_bot_task_stage_file_v1';
 export type { Body_attach_manager_doc_file } from './models/Body_attach_manager_doc_file';
 export type { Body_bulk_upload_local_images } from './models/Body_bulk_upload_local_images';
 export type { Body_complete_media_worker_job } from './models/Body_complete_media_worker_job';
@@ -90,6 +91,7 @@ export type { BotStaffNotificationMutationResponse } from './models/BotStaffNoti
 export type { BotStaffNotificationNackRequest } from './models/BotStaffNotificationNackRequest';
 export type { BotStaffNotificationPayload } from './models/BotStaffNotificationPayload';
 export type { BotStaffNotificationRenewRequest } from './models/BotStaffNotificationRenewRequest';
+export type { BotTaskAttachmentResponse } from './models/BotTaskAttachmentResponse';
 export type { BotTaskListRequest } from './models/BotTaskListRequest';
 export type { BotTaskListResponse } from './models/BotTaskListResponse';
 export type { BotTaskReportSaveRequest } from './models/BotTaskReportSaveRequest';

--- a/manager_frontend/src/client/models/Body_attach_internal_bot_task_stage_file_v1.ts
+++ b/manager_frontend/src/client/models/Body_attach_internal_bot_task_stage_file_v1.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type Body_attach_internal_bot_task_stage_file_v1 = {
+    telegram_id: number;
+    file_id: string;
+    telegram_chat_id?: (number | null);
+    telegram_message_id?: (number | null);
+    file: Blob;
+};
+

--- a/manager_frontend/src/client/models/BotTaskAttachmentResponse.ts
+++ b/manager_frontend/src/client/models/BotTaskAttachmentResponse.ts
@@ -1,0 +1,10 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type BotTaskAttachmentResponse = {
+    stage_id: number;
+    order_id: number;
+    already_attached?: boolean;
+};
+

--- a/manager_frontend/src/client/services/InternalBotV1Service.ts
+++ b/manager_frontend/src/client/services/InternalBotV1Service.ts
@@ -2,6 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { Body_attach_internal_bot_task_stage_file_v1 } from '../models/Body_attach_internal_bot_task_stage_file_v1';
 import type { Body_recognize_internal_bot_customer_requisites_file_v1 } from '../models/Body_recognize_internal_bot_customer_requisites_file_v1';
 import type { BotApiHealthResponse } from '../models/BotApiHealthResponse';
 import type { BotCatalogProductLookupResponse } from '../models/BotCatalogProductLookupResponse';
@@ -16,6 +17,7 @@ import type { BotQuickOrderCreateResponse } from '../models/BotQuickOrderCreateR
 import type { BotQuickOrderParseRequest } from '../models/BotQuickOrderParseRequest';
 import type { BotQuickOrderParseResponse } from '../models/BotQuickOrderParseResponse';
 import type { BotStaffContextResponse } from '../models/BotStaffContextResponse';
+import type { BotTaskAttachmentResponse } from '../models/BotTaskAttachmentResponse';
 import type { BotTaskListRequest } from '../models/BotTaskListRequest';
 import type { BotTaskListResponse } from '../models/BotTaskListResponse';
 import type { BotTaskReportSaveRequest } from '../models/BotTaskReportSaveRequest';
@@ -163,6 +165,30 @@ export class InternalBotV1Service {
             },
             body: requestBody,
             mediaType: 'application/json',
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Attach Internal Bot Task Stage File
+     * @param stageId
+     * @param formData
+     * @returns BotTaskAttachmentResponse Successful Response
+     * @throws ApiError
+     */
+    public static attachInternalBotTaskStageFileV1(
+        stageId: number,
+        formData: Body_attach_internal_bot_task_stage_file_v1,
+    ): CancelablePromise<BotTaskAttachmentResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/internal/bot/v1/tasks/stages/{stage_id}/attachments',
+            path: {
+                'stage_id': stageId,
+            },
+            formData: formData,
+            mediaType: 'multipart/form-data',
             errors: {
                 422: `Validation Error`,
             },

--- a/openapi.json
+++ b/openapi.json
@@ -428,6 +428,64 @@
         }
       }
     },
+    "/api/internal/bot/v1/tasks/stages/{stage_id}/attachments": {
+      "post": {
+        "tags": [
+          "internal bot v1"
+        ],
+        "summary": "Attach Internal Bot Task Stage File",
+        "operationId": "attach_internal_bot_task_stage_file_v1",
+        "security": [
+          {
+            "BotServiceBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "stage_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "title": "Stage Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_attach_internal_bot_task_stage_file_v1"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BotTaskAttachmentResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/internal/bot/v1/quick-orders/parse": {
       "post": {
         "tags": [
@@ -22857,6 +22915,55 @@
         ],
         "title": "Body_attach_internal_bot_order_file_v1"
       },
+      "Body_attach_internal_bot_task_stage_file_v1": {
+        "properties": {
+          "telegram_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Telegram Id"
+          },
+          "file_id": {
+            "type": "string",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "File Id"
+          },
+          "telegram_chat_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Telegram Chat Id"
+          },
+          "telegram_message_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Telegram Message Id"
+          },
+          "file": {
+            "type": "string",
+            "format": "binary",
+            "title": "File"
+          }
+        },
+        "type": "object",
+        "required": [
+          "telegram_id",
+          "file_id",
+          "file"
+        ],
+        "title": "Body_attach_internal_bot_task_stage_file_v1"
+      },
       "Body_attach_manager_doc_file": {
         "properties": {
           "file": {
@@ -25395,6 +25502,31 @@
           "lease_token"
         ],
         "title": "BotStaffNotificationRenewRequest"
+      },
+      "BotTaskAttachmentResponse": {
+        "properties": {
+          "stage_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Stage Id"
+          },
+          "order_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Order Id"
+          },
+          "already_attached": {
+            "type": "boolean",
+            "title": "Already Attached",
+            "default": false
+          }
+        },
+        "type": "object",
+        "required": [
+          "stage_id",
+          "order_id"
+        ],
+        "title": "BotTaskAttachmentResponse"
       },
       "BotTaskListRequest": {
         "properties": {

--- a/routers/internal_bot.py
+++ b/routers/internal_bot.py
@@ -19,6 +19,7 @@ from api_contracts.bot import (
     BotQuickOrderParseRequest,
     BotQuickOrderParseResponse,
     BotStaffContextResponse,
+    BotTaskAttachmentResponse,
     BotTaskListRequest,
     BotTaskListResponse,
     BotTaskReportSaveRequest,
@@ -32,6 +33,7 @@ from core.database import get_session
 from core.tenant_scope import get_system_tenant_scope
 from models import OrderStageStatus
 from models.tenancy import TenantScope
+from routers.internal_bot_common import read_bot_upload
 from services.bot_access_service import BotAccessService
 from services.bot_catalog_service import BotCatalogAccessDeniedError, BotCatalogService
 from services.bot_customer_requisites_api_service import (
@@ -218,6 +220,49 @@ async def save_internal_bot_task_report(
     return BotTaskReportSaveResponse(
         stage_id=result.stage_id,
         changed=result.changed,
+    )
+
+
+@router.post(
+    "/tasks/stages/{stage_id}/attachments",
+    response_model=BotTaskAttachmentResponse,
+    operation_id="attach_internal_bot_task_stage_file_v1",
+)
+async def attach_internal_bot_task_stage_file(
+    stage_id: int = Path(ge=1),
+    telegram_id: int = Form(ge=1),
+    file_id: str = Form(min_length=1, max_length=255),
+    telegram_chat_id: int | None = Form(default=None),
+    telegram_message_id: int | None = Form(default=None),
+    file: UploadFile = File(),
+    session: AsyncSession = Depends(get_session),
+    tenant_scope: TenantScope = Depends(get_system_tenant_scope),
+) -> BotTaskAttachmentResponse:
+    content, filename, mime_type = await read_bot_upload(file)
+    try:
+        result = await BotTaskMutationService.attach_stage_attachment(
+            session,
+            telegram_id=telegram_id,
+            stage_id=stage_id,
+            file_id=file_id,
+            filename=filename,
+            mime_type=mime_type,
+            content=content,
+            telegram_chat_id=telegram_chat_id,
+            telegram_message_id=telegram_message_id,
+            tenant_scope=tenant_scope,
+        )
+    except BotTaskMutationAccessDeniedError as exc:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=str(exc),
+        ) from exc
+    return BotTaskAttachmentResponse(
+        stage_id=result.stage_id,
+        order_id=result.order_id,
+        already_attached=result.already_attached,
     )
 
 

--- a/services/bot_task_mutation_service.py
+++ b/services/bot_task_mutation_service.py
@@ -2,12 +2,21 @@
 
 import logging
 from dataclasses import dataclass
+from datetime import datetime
 
 from sqlalchemy.ext.asyncio import AsyncSession
-from models import OrderStageStatus, OrderWorkStage
+from sqlmodel import select
+
+from models import (
+    OrderAttachmentLink,
+    OrderStageStatus,
+    OrderWorkStage,
+    ServiceAttachment,
+)
 from models.tenancy import TenantScope
 from services.bot_access_service import BotAccessService
 from services.notification_service import NotificationService
+from services.service_attachment_service import ServiceAttachmentService
 from services.tenant_entity_access_service import TenantEntityAccessService
 
 logger = logging.getLogger(__name__)
@@ -32,6 +41,13 @@ class BotTaskStatusMutationResult:
 class BotTaskReportMutationResult:
     stage_id: int
     changed: bool
+
+
+@dataclass(frozen=True)
+class BotTaskAttachmentMutationResult:
+    stage_id: int
+    order_id: int
+    already_attached: bool
 
 
 class BotTaskMutationService:
@@ -136,3 +152,99 @@ class BotTaskMutationService:
         session.add(stage)
         await session.commit()
         return BotTaskReportMutationResult(stage_id=stage_id, changed=True)
+
+    @staticmethod
+    async def _stage_attachment_exists(
+        session: AsyncSession,
+        *,
+        stage_id: int,
+        order_id: int,
+        file_id: str,
+        telegram_chat_id: int | None,
+        telegram_message_id: int | None,
+    ) -> bool:
+        filters = [
+            OrderAttachmentLink.order_id == order_id,
+            OrderAttachmentLink.work_stage_id == stage_id,
+            OrderAttachmentLink.archived_at.is_(None),
+            ServiceAttachment.archived_at.is_(None),
+        ]
+        if telegram_chat_id is not None and telegram_message_id is not None:
+            filters.extend(
+                [
+                    ServiceAttachment.telegram_chat_id == telegram_chat_id,
+                    ServiceAttachment.telegram_message_id == telegram_message_id,
+                ]
+            )
+        else:
+            filters.append(ServiceAttachment.telegram_file_id == file_id)
+        statement = (
+            select(OrderAttachmentLink.id)
+            .join(
+                ServiceAttachment,
+                ServiceAttachment.id == OrderAttachmentLink.attachment_id,
+            )
+            .where(*filters)
+            .limit(1)
+        )
+        return await session.scalar(statement) is not None
+
+    @classmethod
+    async def attach_stage_attachment(
+        cls,
+        session: AsyncSession,
+        *,
+        telegram_id: int,
+        stage_id: int,
+        file_id: str,
+        filename: str,
+        mime_type: str | None,
+        content: bytes,
+        telegram_chat_id: int | None,
+        telegram_message_id: int | None,
+        tenant_scope: TenantScope,
+    ) -> BotTaskAttachmentMutationResult:
+        stage = await cls._authorized_stage_for_update(
+            session,
+            telegram_id=telegram_id,
+            stage_id=stage_id,
+            tenant_scope=tenant_scope,
+        )
+        order_id = int(stage.order_id)
+        # The authorized stage is locked through the attachment service commit,
+        # so concurrent retries serialize before this idempotency check.
+        already_attached = await cls._stage_attachment_exists(
+            session,
+            stage_id=stage_id,
+            order_id=order_id,
+            file_id=file_id,
+            telegram_chat_id=telegram_chat_id,
+            telegram_message_id=telegram_message_id,
+        )
+        await ServiceAttachmentService.create_and_link_order_attachment(
+            session,
+            order_id=order_id,
+            content=content,
+            filename=filename,
+            mime_type=mime_type,
+            category="service",
+            source="telegram_bot",
+            work_stage_id=stage_id,
+            captured_at=datetime.now(),
+            telegram_meta={
+                "file_id": file_id,
+                "user_id": telegram_id,
+                "chat_id": telegram_chat_id,
+                "message_id": telegram_message_id,
+            },
+            source_meta={
+                "purpose": "task_stage_report",
+                "stage_id": stage_id,
+            },
+            tenant_scope=tenant_scope,
+        )
+        return BotTaskAttachmentMutationResult(
+            stage_id=stage_id,
+            order_id=order_id,
+            already_attached=already_attached,
+        )

--- a/services/service_attachment_service.py
+++ b/services/service_attachment_service.py
@@ -164,6 +164,10 @@ class ServiceAttachmentService:
                 OrderAttachmentLink.archived_at.is_(None),
                 ServiceAttachment.archived_at.is_(None),
             ]
+            if work_stage_id is not None:
+                occurrence_filters.append(
+                    OrderAttachmentLink.work_stage_id == work_stage_id
+                )
             if telegram_chat_id is not None and telegram_message_id is not None:
                 occurrence_filters.extend(
                     [

--- a/tests/integration/test_bot_task_attachment.py
+++ b/tests/integration/test_bot_task_attachment.py
@@ -1,0 +1,228 @@
+import asyncio
+import base64
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import select
+
+from models import (
+    Installer,
+    Order,
+    OrderAttachmentLink,
+    OrderStatus,
+    OrderWorkStage,
+    ServiceAttachment,
+    StaffUser,
+    Storefront,
+    Tenant,
+    TenantMembership,
+)
+from services.bot_task_mutation_service import (
+    BotTaskMutationAccessDeniedError,
+    BotTaskMutationService,
+)
+from services.private_attachment_storage_service import StoredPrivateObject
+from services.tenant_scope_service import SystemTenantScopeResolver
+
+
+PNG_CONTENT = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+)
+
+
+class _FakePrivateStorage:
+    provider_name = "test_private"
+    inventory_id = "test_private"
+
+    def __init__(self) -> None:
+        self.objects: dict[str, bytes] = {}
+
+    async def save(self, **kwargs) -> StoredPrivateObject:
+        key = f"private/{kwargs['content_hash']}/{kwargs['variant']}.{kwargs['extension']}"
+        self.objects.setdefault(key, kwargs["content"])
+        return StoredPrivateObject(
+            provider=self.provider_name,
+            storage_key=key,
+            content_hash=kwargs["content_hash"],
+            size_bytes=len(kwargs["content"]),
+        )
+
+    async def exists(self, storage_key: str) -> bool:
+        return storage_key in self.objects
+
+
+@pytest.mark.asyncio
+async def test_stage_attachment_is_authorized_tenant_scoped_and_race_idempotent(
+    db_engine,
+    monkeypatch,
+):
+    assert db_engine.dialect.name == "postgresql"
+    storage = _FakePrivateStorage()
+    monkeypatch.setattr(
+        "services.service_attachment_service.get_private_attachment_storage",
+        lambda: storage,
+    )
+    session_factory = sessionmaker(
+        bind=db_engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+
+    async with session_factory() as setup_session:
+        tenant_scope = await SystemTenantScopeResolver.resolve(setup_session)
+        assigned_installer = Installer(name="Assigned stage attachment installer")
+        other_installer = Installer(name="Other stage attachment installer")
+        setup_session.add_all([assigned_installer, other_installer])
+        await setup_session.flush()
+        staff = StaffUser(
+            display_name="Stage attachment staff",
+            status="active",
+            roles=["installer"],
+            telegram_id=987654322,
+            legacy_installer_id=int(assigned_installer.id),
+        )
+        setup_session.add(staff)
+        await setup_session.flush()
+        setup_session.add(
+            TenantMembership(
+                tenant_id=tenant_scope.tenant_id,
+                staff_user_id=int(staff.id),
+                role="installer",
+                status="active",
+            )
+        )
+        order = Order(
+            tenant_id=tenant_scope.tenant_id,
+            storefront_id=tenant_scope.storefront_id,
+            status=OrderStatus.EXECUTION,
+            title="Stage attachment order",
+        )
+        setup_session.add(order)
+        await setup_session.flush()
+        assigned_stage = OrderWorkStage(
+            order_id=int(order.id),
+            name="Assigned stage",
+            installer_id=int(assigned_installer.id),
+        )
+        other_stage = OrderWorkStage(
+            order_id=int(order.id),
+            name="Other stage",
+            installer_id=int(other_installer.id),
+        )
+        setup_session.add_all([assigned_stage, other_stage])
+
+        foreign_tenant = Tenant(
+            id=2,
+            slug="stage-attachment-foreign",
+            display_name="Stage attachment foreign tenant",
+            status="active",
+        )
+        setup_session.add(foreign_tenant)
+        await setup_session.flush()
+        foreign_storefront = Storefront(
+            id=2,
+            tenant_id=2,
+            slug="main",
+            display_name="Foreign main",
+            status="active",
+            is_default=True,
+        )
+        setup_session.add(foreign_storefront)
+        await setup_session.flush()
+        foreign_order = Order(
+            tenant_id=2,
+            storefront_id=2,
+            status=OrderStatus.EXECUTION,
+            title="Foreign tenant order",
+        )
+        setup_session.add(foreign_order)
+        await setup_session.flush()
+        foreign_stage = OrderWorkStage(
+            order_id=int(foreign_order.id),
+            name="Foreign tenant stage",
+            installer_id=int(assigned_installer.id),
+        )
+        setup_session.add(foreign_stage)
+        await setup_session.commit()
+
+        assigned_stage_id = int(assigned_stage.id)
+        other_stage_id = int(other_stage.id)
+        foreign_stage_id = int(foreign_stage.id)
+        order_id = int(order.id)
+
+    barrier = asyncio.Barrier(8)
+
+    async def attach_once():
+        async with session_factory() as session:
+            await barrier.wait()
+            return await BotTaskMutationService.attach_stage_attachment(
+                session,
+                telegram_id=987654322,
+                stage_id=assigned_stage_id,
+                file_id="telegram-stage-photo",
+                filename="report.png",
+                mime_type="image/png",
+                content=PNG_CONTENT,
+                telegram_chat_id=-100,
+                telegram_message_id=77,
+                tenant_scope=tenant_scope,
+            )
+
+    results = await asyncio.gather(*(attach_once() for _ in range(8)))
+    assert sum(not result.already_attached for result in results) == 1
+    assert {result.order_id for result in results} == {order_id}
+
+    async with session_factory() as verification_session:
+        attachments = list(
+            (await verification_session.execute(select(ServiceAttachment)))
+            .scalars()
+            .all()
+        )
+        links = list(
+            (await verification_session.execute(select(OrderAttachmentLink)))
+            .scalars()
+            .all()
+        )
+        assert len(attachments) == 1
+        assert len(links) == 1
+        assert links[0].work_stage_id == assigned_stage_id
+        assert links[0].order_id == order_id
+        assert links[0].category == "service"
+        assert attachments[0].source == "telegram_bot"
+        assert attachments[0].telegram_file_id == "telegram-stage-photo"
+        assert attachments[0].telegram_chat_id == -100
+        assert attachments[0].telegram_message_id == 77
+        assert attachments[0].telegram_user_id == 987654322
+        assert attachments[0].source_meta == {
+            "purpose": "task_stage_report",
+            "stage_id": assigned_stage_id,
+        }
+
+    async with session_factory() as denied_session:
+        with pytest.raises(BotTaskMutationAccessDeniedError):
+            await BotTaskMutationService.attach_stage_attachment(
+                denied_session,
+                telegram_id=987654322,
+                stage_id=other_stage_id,
+                file_id="other-stage-photo",
+                filename="other.png",
+                mime_type="image/png",
+                content=PNG_CONTENT,
+                telegram_chat_id=None,
+                telegram_message_id=None,
+                tenant_scope=tenant_scope,
+            )
+        with pytest.raises(BotTaskMutationAccessDeniedError):
+            await BotTaskMutationService.attach_stage_attachment(
+                denied_session,
+                telegram_id=987654322,
+                stage_id=foreign_stage_id,
+                file_id="foreign-stage-photo",
+                filename="foreign.png",
+                mime_type="image/png",
+                content=PNG_CONTENT,
+                telegram_chat_id=None,
+                telegram_message_id=None,
+                tenant_scope=tenant_scope,
+            )

--- a/tests/unit/test_bot_task_mutation_service.py
+++ b/tests/unit/test_bot_task_mutation_service.py
@@ -157,3 +157,69 @@ async def test_task_report_mutation_is_normalized_and_idempotent(monkeypatch):
     assert repeated.changed is False
     assert stage.installer_report == "Монтаж завершен"
     assert session.commit_count == 1
+
+
+@pytest.mark.asyncio
+async def test_task_attachment_uses_stage_order_and_service_provenance(monkeypatch):
+    stage = SimpleNamespace(id=10, order_id=42, installer_id=7)
+    session = object()
+    authorize = AsyncMock(return_value=stage)
+    exists = AsyncMock(return_value=False)
+    create = AsyncMock(return_value={"id": 99})
+    monkeypatch.setattr(
+        BotTaskMutationService,
+        "_authorized_stage_for_update",
+        authorize,
+    )
+    monkeypatch.setattr(BotTaskMutationService, "_stage_attachment_exists", exists)
+    monkeypatch.setattr(
+        "services.bot_task_mutation_service."
+        "ServiceAttachmentService.create_and_link_order_attachment",
+        create,
+    )
+
+    result = await BotTaskMutationService.attach_stage_attachment(
+        session,
+        telegram_id=777,
+        stage_id=10,
+        file_id="telegram-file-10",
+        filename="report.jpg",
+        mime_type="image/jpeg",
+        content=b"photo",
+        telegram_chat_id=-100,
+        telegram_message_id=55,
+        tenant_scope=TEST_TENANT_SCOPE,
+    )
+
+    assert result.stage_id == 10
+    assert result.order_id == 42
+    assert result.already_attached is False
+    authorize.assert_awaited_once_with(
+        session,
+        telegram_id=777,
+        stage_id=10,
+        tenant_scope=TEST_TENANT_SCOPE,
+    )
+    exists.assert_awaited_once_with(
+        session,
+        stage_id=10,
+        order_id=42,
+        file_id="telegram-file-10",
+        telegram_chat_id=-100,
+        telegram_message_id=55,
+    )
+    kwargs = create.await_args.kwargs
+    assert kwargs["order_id"] == 42
+    assert kwargs["work_stage_id"] == 10
+    assert kwargs["category"] == "service"
+    assert kwargs["source"] == "telegram_bot"
+    assert kwargs["telegram_meta"] == {
+        "file_id": "telegram-file-10",
+        "user_id": 777,
+        "chat_id": -100,
+        "message_id": 55,
+    }
+    assert kwargs["source_meta"] == {
+        "purpose": "task_stage_report",
+        "stage_id": 10,
+    }

--- a/tests/unit/test_internal_bot_api.py
+++ b/tests/unit/test_internal_bot_api.py
@@ -20,6 +20,7 @@ from services.bot_quick_order_api_service import (
 )
 from services.bot_task_read_service import BotTaskAccessDeniedError, BotTaskReadService
 from services.bot_task_mutation_service import (
+    BotTaskAttachmentMutationResult,
     BotTaskMutationAccessDeniedError,
     BotTaskMutationConflictError,
     BotTaskMutationService,
@@ -118,6 +119,9 @@ def test_internal_bot_api_openapi_contract_is_versioned_and_secured():
     task_list = schema["paths"]["/api/internal/bot/v1/tasks/my"]["post"]
     task_status = schema["paths"]["/api/internal/bot/v1/tasks/stages/{stage_id}/status"]["post"]
     task_report = schema["paths"]["/api/internal/bot/v1/tasks/stages/{stage_id}/report"]["post"]
+    task_attachment = schema["paths"][
+        "/api/internal/bot/v1/tasks/stages/{stage_id}/attachments"
+    ]["post"]
     quick_order_parse = schema["paths"]["/api/internal/bot/v1/quick-orders/parse"]["post"]
     quick_order_create = schema["paths"]["/api/internal/bot/v1/quick-orders"]["post"]
     requisites_text = schema["paths"]["/api/internal/bot/v1/customers/requisites/recognize-text"]["post"]
@@ -140,6 +144,7 @@ def test_internal_bot_api_openapi_contract_is_versioned_and_secured():
     assert task_list["operationId"] == "list_internal_bot_my_tasks_v1"
     assert task_status["operationId"] == "update_internal_bot_task_status_v1"
     assert task_report["operationId"] == "save_internal_bot_task_report_v1"
+    assert task_attachment["operationId"] == "attach_internal_bot_task_stage_file_v1"
     assert quick_order_parse["operationId"] == "parse_internal_bot_quick_order_v1"
     assert quick_order_create["operationId"] == "create_internal_bot_quick_order_v1"
     assert requisites_text["operationId"] == "recognize_internal_bot_customer_requisites_text_v1"
@@ -148,6 +153,8 @@ def test_internal_bot_api_openapi_contract_is_versioned_and_secured():
     assert health["security"] == [{"BotServiceBearer": []}]
     assert staff_context["security"] == [{"BotServiceBearer": []}]
     assert catalog_search["security"] == [{"BotServiceBearer": []}]
+    assert task_attachment["security"] == [{"BotServiceBearer": []}]
+    assert "multipart/form-data" in task_attachment["requestBody"]["content"]
     assert catalog_product["security"] == [{"BotServiceBearer": []}]
     assert task_list["security"] == [{"BotServiceBearer": []}]
     assert task_status["security"] == [{"BotServiceBearer": []}]
@@ -659,6 +666,88 @@ async def test_internal_bot_task_report_normalizes_and_saves(monkeypatch):
 
     assert response.status_code == 200
     assert response.json() == {"stage_id": 7, "changed": False}
+
+
+async def test_internal_bot_task_attachment_uses_typed_authorized_service(monkeypatch):
+    monkeypatch.setattr(settings, "BOT_API_TOKEN", "expected-token")
+
+    async def fake_attach(_session, **kwargs):
+        assert kwargs == {
+            "telegram_id": 123456,
+            "stage_id": 7,
+            "file_id": "telegram-file-7",
+            "filename": "report.jpg",
+            "mime_type": "image/jpeg",
+            "content": b"photo-content",
+            "telegram_chat_id": -100,
+            "telegram_message_id": 55,
+            "tenant_scope": TEST_TENANT_SCOPE,
+        }
+        return BotTaskAttachmentMutationResult(
+            stage_id=7,
+            order_id=42,
+            already_attached=False,
+        )
+
+    async def fake_session():
+        yield object()
+
+    monkeypatch.setattr(BotTaskMutationService, "attach_stage_attachment", fake_attach)
+    app.dependency_overrides[get_session] = fake_session
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            response = await client.post(
+                "/api/internal/bot/v1/tasks/stages/7/attachments",
+                headers={"Authorization": "Bearer expected-token"},
+                data={
+                    "telegram_id": "123456",
+                    "file_id": "telegram-file-7",
+                    "telegram_chat_id": "-100",
+                    "telegram_message_id": "55",
+                },
+                files={"file": ("report.jpg", b"photo-content", "image/jpeg")},
+            )
+    finally:
+        app.dependency_overrides.pop(get_session, None)
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "stage_id": 7,
+        "order_id": 42,
+        "already_attached": False,
+    }
+
+
+async def test_internal_bot_task_attachment_maps_stage_access_denial(monkeypatch):
+    monkeypatch.setattr(settings, "BOT_API_TOKEN", "expected-token")
+
+    async def deny(*_args, **_kwargs):
+        raise BotTaskMutationAccessDeniedError("not assigned")
+
+    async def fake_session():
+        yield object()
+
+    monkeypatch.setattr(BotTaskMutationService, "attach_stage_attachment", deny)
+    app.dependency_overrides[get_session] = fake_session
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            response = await client.post(
+                "/api/internal/bot/v1/tasks/stages/7/attachments",
+                headers={"Authorization": "Bearer expected-token"},
+                data={"telegram_id": "123456", "file_id": "telegram-file-7"},
+                files={"file": ("report.jpg", b"photo-content", "image/jpeg")},
+            )
+    finally:
+        app.dependency_overrides.pop(get_session, None)
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "not assigned"}
 
 
 async def test_internal_bot_quick_order_parse_and_create_use_stable_contract(monkeypatch):


### PR DESCRIPTION
## Что изменено
- добавлен typed multipart endpoint для вложений отчёта этапа
- сохранение идёт в приватные ServiceAttachment с привязкой к order и work_stage
- сохранены tenant scope, назначение исполнителя и Telegram provenance
- повтор одного события идемпотентен; конкурентные повторы сериализуются stage lock
- обновлены OpenAPI и Manager client

## Проверки
- 3068 unit passed, 4 skipped
- 45 scoped unit/integration passed
- PostgreSQL race test: 8 конкурентных повторов создают одно вложение
- OpenAPI generation и git diff check