### PR TITLE
Improve nameplate serial recognition safety

### DIFF
--- a/services/bot_repair_nameplate_service.py
+++ b/services/bot_repair_nameplate_service.py
@@ -26,6 +26,7 @@ from services.deepseek_provider_service import (
     request_deepseek_completion,
 )
 from services.order_service import OrderService
+from services.nameplate_serial_resolver import resolve_serial_number
 from services.private_attachment_storage_service import sha256_bytes
 from services.service_attachment_service import ServiceAttachmentService
 from services.staff_user_service import StaffUserService
@@ -82,139 +83,9 @@ class BotRepairNameplateService:
         text = re.sub(r"\n{3,}", "\n\n", text)
         return text[:max_length].strip() or None
 
-    @classmethod
-    def _clean_serial_candidate(cls, value: Any) -> Optional[str]:
-        text = cls._clean_text(value, max_length=240)
-        if not text:
-            return None
-        text = text.upper().strip(" .,:;")
-        text = re.sub(r"\s+", " ", text)
-        comparable = re.sub(r"[^A-Z0-9]", "", text)
-        if len(comparable) < 5:
-            return None
-        if "/" in text:
-            return None
-        return text
-
-    @classmethod
-    def _serial_candidate_tokens(cls, value: Any) -> list[str]:
-        text = cls._clean_text(value, max_length=4000)
-        if not text:
-            return []
-        candidates = []
-        if "\n" not in text and len(text) <= 80 and not re.search(
-            r"\b(MODEL|МОДЕЛЬ|REFRIGERANT|CAPACITY|МОЩНОСТЬ)\b",
-            text,
-            flags=re.IGNORECASE,
-        ):
-            candidates.append(text)
-        candidates.extend(re.findall(r"\b[A-Z0-9][A-Z0-9/-]{5,}[A-Z0-9]\b", text, flags=re.IGNORECASE))
-        cleaned: list[str] = []
-        for candidate in candidates:
-            normalized = cls._clean_serial_candidate(candidate)
-            if normalized:
-                cleaned.append(normalized)
-        return cleaned
-
     @staticmethod
     def _serial_identity(value: str) -> str:
         return re.sub(r"[^A-Z0-9]", "", value.upper())
-
-    @classmethod
-    def _collect_serial_candidates(
-        cls,
-        raw: dict[str, Any],
-        raw_text: str,
-        *,
-        equipment_model: str | None,
-    ) -> list[str]:
-        values: list[Any] = []
-        for key in (
-            "equipment_serial_number",
-            "serial_number",
-            "serial",
-            "sn",
-            "s_n",
-            "barcode_text",
-            "barcode_value",
-            "barcode",
-        ):
-            values.append(raw.get(key))
-
-        for key in (
-            "serial_candidates",
-            "serial_number_candidates",
-            "serials",
-            "barcode_values",
-            "barcodes",
-            "raw_markings",
-        ):
-            value = raw.get(key)
-            if isinstance(value, list):
-                values.extend(value)
-            elif isinstance(value, dict):
-                values.extend(value.values())
-            else:
-                values.append(value)
-        values.append(raw_text)
-
-        model_identity = cls._serial_identity(equipment_model or "")
-        seen: set[str] = set()
-        result: list[str] = []
-        for value in values:
-            for candidate in cls._serial_candidate_tokens(value):
-                identity = cls._serial_identity(candidate)
-                if (
-                    not identity
-                    or identity == model_identity
-                    or bool(model_identity and identity in model_identity)
-                    or identity in seen
-                ):
-                    continue
-                seen.add(identity)
-                result.append(candidate)
-        return result
-
-    @classmethod
-    def _serial_candidate_score(cls, candidate: str, *, brand: str | None, model: str | None) -> int:
-        identity = cls._serial_identity(candidate)
-        score = min(len(identity), 30)
-        has_letters = bool(re.search(r"[A-Z]", identity))
-        has_digits = bool(re.search(r"\d", identity))
-        if has_letters and has_digits:
-            score += 25
-        if len(identity) >= 18:
-            score += 35
-        elif len(identity) >= 14:
-            score += 20
-        elif len(identity) <= 10 and identity.isdigit():
-            score -= 20
-
-        brand_text = (brand or "").upper()
-        model_text = (model or "").upper()
-        looks_like_tcl = "TCL" in brand_text or model_text.startswith("TAC-")
-        if looks_like_tcl:
-            if has_letters and has_digits and len(identity) >= 18:
-                score += 60
-            if re.fullmatch(r"MO\d+", identity):
-                score -= 60
-            if identity.isdigit() and len(identity) <= 12:
-                score -= 35
-        elif re.fullmatch(r"MO\d+", identity):
-            score -= 25
-        return score
-
-    @classmethod
-    def _select_serial_candidate(
-        cls,
-        candidates: list[str],
-        *,
-        brand: str | None,
-        model: str | None,
-    ) -> Optional[str]:
-        if not candidates:
-            return None
-        return max(candidates, key=lambda candidate: cls._serial_candidate_score(candidate, brand=brand, model=model))
 
     @classmethod
     def _decode_tcl_year(cls, value: str) -> Optional[int]:
@@ -468,8 +339,10 @@ class BotRepairNameplateService:
             "Правила:\n"
             "- equipment_name: человекочитаемо, например 'Кондиционер, наружный блок' или 'Кондиционер'.\n"
             "- equipment_model: модель блока ровно как на шильдике.\n"
-            "- equipment_serial_number: серийный номер/SN/Serial No, только если он явно виден.\n"
+            "- equipment_serial_number: серийный номер/SN/Serial No, только если он явно виден. "
+            "Сначала ищи значение рядом с Serial, Serial No, S/N, SN (OCR иногда пишет CEREAL), затем под штрих-кодом.\n"
             "- serial_candidates: если на наклейке несколько похожих номеров, верни массив всех вариантов.\n"
+            "- Дата производства/Manufactured Date, модель, напряжение, мощность, ток, хладагент, заправка и значения с kg/W/V/Hz/MPa — не серийные номера.\n"
             "- Для TCL/TAC часто серийный номер — длинный буквенно-цифровой код под штрихкодом; короткие MO/даты/партии не выбирай серийником, если есть длинный код.\n"
             "- Для TCL factory SN формата 20 символов учитывай сегменты: 1 + 4 + W/N/Z + год/месяц заказа + batch + S/Z + год/месяц/день производства + 5 цифр серийного номера.\n"
             "- equipment_power: полезная холодопроизводительность/мощность, как на шильдике; не путай с потребляемой мощностью.\n"
@@ -516,25 +389,20 @@ class BotRepairNameplateService:
                 raw.get("equipment_inventory_number") or raw.get("inventory_number"),
                 max_length=160,
             ),
-            "equipment_commissioning_date": cls._clean_text(
-                raw.get("equipment_commissioning_date") or raw.get("manufactured_year"),
-                max_length=80,
-            ),
+            "equipment_commissioning_date": cls._clean_text(raw.get("equipment_commissioning_date"), max_length=80),
             "refrigerant_type": cls._normalize_refrigerant_type(raw.get("refrigerant_type") or raw.get("refrigerant")),
             "refrigerant_amount": cls._normalize_refrigerant_amount(
                 raw.get("refrigerant_amount") or raw.get("refrigerant_charge")
             ),
         }
-        serial_candidates = cls._collect_serial_candidates(
+        serial_resolution = resolve_serial_number(
             raw,
             raw_text,
             equipment_model=data.get("equipment_model"),
-        )
-        selected_serial = cls._select_serial_candidate(
-            serial_candidates,
             brand=data.get("equipment_brand"),
-            model=data.get("equipment_model"),
         )
+        serial_candidates = serial_resolution["candidates"]
+        selected_serial = serial_resolution["selected"]
         if selected_serial:
             data["equipment_serial_number"] = selected_serial
         data = {key: value for key, value in data.items() if value}
@@ -555,9 +423,13 @@ class BotRepairNameplateService:
             warnings["equipment_model"] = "Модель не распознана уверенно"
         if not data.get("equipment_serial_number"):
             warnings["equipment_serial_number"] = "Серийный номер не найден на шильдике"
+        elif serial_resolution["selection_required"]:
+            warnings["serial_candidates"] = (
+                "Серийный номер определен неоднозначно; сотрудник должен выбрать вариант перед записью"
+            )
         elif len(serial_candidates) > 1:
             warnings["serial_candidates"] = (
-                "Нашел несколько похожих номеров; выбрал наиболее вероятный серийник, проверьте перед записью"
+                "Нашел несколько похожих номеров; выбран вариант с явными признаками серийного номера"
             )
         if not data.get("refrigerant_type"):
             warnings["refrigerant_type"] = "Хладагент не распознан"
@@ -567,15 +439,6 @@ class BotRepairNameplateService:
             confidence_value = float(confidence) if confidence is not None else None
         except (TypeError, ValueError):
             confidence_value = None
-        serial_candidates = sorted(
-            serial_candidates,
-            key=lambda candidate: cls._serial_candidate_score(
-                candidate,
-                brand=data.get("equipment_brand"),
-                model=data.get("equipment_model"),
-            ),
-            reverse=True,
-        )
         flags = {
             "warnings": warnings,
             "confidence": confidence_value,
@@ -584,6 +447,11 @@ class BotRepairNameplateService:
         }
         if serial_candidates:
             flags["serial_candidates"] = serial_candidates[:8]
+            flags["serial_candidate_details"] = serial_resolution["details"][:8]
+            flags["serial_selection_required"] = bool(serial_resolution["selection_required"])
+            flags["serial_selection"] = serial_resolution["selection"]
+        if serial_resolution["rejected"]:
+            flags["serial_rejected_candidates"] = serial_resolution["rejected"][:8]
         serial_details = cls._decode_tcl_factory_serial(data.get("equipment_serial_number"))
         if serial_details:
             flags["serial_details"] = serial_details
@@ -673,6 +541,8 @@ class BotRepairNameplateService:
         file_content: bytes | None = None,
         tenant_scope: TenantScope,
     ) -> dict[str, Any] | None:
+        if isinstance(validation_flags, dict) and validation_flags.get("serial_selection_required"):
+            raise ValueError("Серийный номер нужно явно выбрать перед записью")
         allowed = await cls.can_use_order(
             session,
             order_id,

--- a/services/bot_warranty_nameplate_service.py
+++ b/services/bot_warranty_nameplate_service.py
@@ -440,6 +440,8 @@ class BotWarrantyNameplateService:
     ) -> dict[str, Any] | None:
         if unit_type not in cls.UNIT_TYPES:
             raise ValueError("Неизвестный тип блока")
+        if isinstance(validation_flags, dict) and validation_flags.get("serial_selection_required"):
+            raise ValueError("Серийный номер нужно явно выбрать перед записью")
         allowed = await cls.can_use_order(
             session,
             order_id,
@@ -569,7 +571,18 @@ class BotWarrantyNameplateService:
                 "raw_text": raw_text[:4000],
             }
         )
-        history.append(entry)
+        existing_index = next(
+            (
+                index
+                for index, item in enumerate(history)
+                if isinstance(item, dict) and item.get("file_id") == file_id
+            ),
+            None,
+        )
+        if existing_index is None:
+            history.append(entry)
+        else:
+            history[existing_index] = entry
         meta[cls.HISTORY_META_KEY] = history[-20:]
         BotOrderAttachmentService.upsert_telegram_attachment(meta, entry)
         order.technical_meta = meta

--- a/services/nameplate_serial_resolver.py
+++ b/services/nameplate_serial_resolver.py
@@ -1,0 +1,190 @@
+"""Deterministic, safety-first serial-number resolution for HVAC nameplates."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+
+SERIAL_LABEL_RE = re.compile(r"\b(?:SERIAL(?:\s*(?:NO|NUMBER|NUM))?|S\s*/?\s*N|CEREAL)\b", re.I)
+BARCODE_LABEL_RE = re.compile(r"\b(?:BAR\s*CODE|BARCODE|ШТРИХ\s*-?\s*КОД)\b", re.I)
+REJECT_CONTEXT_RE = re.compile(
+    r"\b(?:MANUFACTURED|MANUFACTURE|MFG|DATE|VOLTAGE|CURRENT|POWER|CAPACITY|"
+    r"REFRIGERANT|REFRI|CHARGE|PRESSURE|FREQUENCY|WEIGHT|MODEL|"
+    r"ИЗГОТОВЛ|ДАТА|НАПРЯЖ|ТОК|МОЩНОСТ|ХЛАДАГЕНТ|ДАВЛЕН)\b",
+    re.I,
+)
+UNIT_RE = re.compile(r"(?:\d)\s*(?:KG|КГ|W|KW|КВТ|V|В|A|А|HZ|ГЦ|MPA|KPA|PA|BTU|TONNES?)\b", re.I)
+DATE_RE = re.compile(r"^(?:19|20)\d{2}[.\-/](?:0?[1-9]|1[0-2])(?:[.\-/](?:0?[1-9]|[12]\d|3[01]))?$")
+TOKEN_RE = re.compile(r"\b[A-Z0-9][A-Z0-9._-]{4,}[A-Z0-9]\b", re.I)
+
+
+def _identity(value: str) -> str:
+    return re.sub(r"[^A-Z0-9]", "", value.upper())
+
+
+def _clean(value: Any) -> str | None:
+    text = re.sub(r"\s+", " ", str(value or "").upper()).strip(" .,:;")
+    identity = _identity(text)
+    if len(identity) < 5 or len(identity) > 64 or not re.search(r"\d", identity):
+        return None
+    return text
+
+
+def _reject_reason(value: str, *, context: str = "") -> str | None:
+    identity = _identity(value)
+    combined = f"{context} {value}"
+    if DATE_RE.fullmatch(value.replace(" ", "")):
+        return "date"
+    if UNIT_RE.search(combined):
+        return "measurement"
+    if REJECT_CONTEXT_RE.search(value):
+        return "technical_label"
+    if re.fullmatch(r"R\d{2,4}A?", identity):
+        return "refrigerant"
+    if context and REJECT_CONTEXT_RE.search(context) and not SERIAL_LABEL_RE.search(context):
+        return "technical_context"
+    if re.fullmatch(r"(?:19|20)\d{4,6}", identity):
+        return "date_like"
+    return None
+
+
+def _brand_specific_bonus(candidate: str, brand: str | None, model: str | None) -> int:
+    identity = _identity(candidate)
+    looks_like_tcl = "TCL" in (brand or "").upper() or (model or "").upper().startswith("TAC-")
+    if not looks_like_tcl:
+        return -25 if re.fullmatch(r"MO\d+", identity) else 0
+    score = 0
+    if re.search(r"[A-Z]", identity) and re.search(r"\d", identity) and len(identity) >= 18:
+        score += 95
+    if re.fullmatch(r"MO\d+", identity):
+        score -= 60
+    if identity.isdigit() and len(identity) <= 12:
+        score -= 35
+    return score
+
+
+def resolve_serial_number(
+    raw: dict[str, Any],
+    raw_text: str,
+    *,
+    equipment_model: str | None,
+    brand: str | None,
+) -> dict[str, Any]:
+    """Return ranked candidates and whether a person must make the choice."""
+    records: dict[str, dict[str, Any]] = {}
+    rejected: list[dict[str, str]] = []
+    model_identity = _identity(equipment_model or "")
+
+    def add(value: Any, *, source: str, context: str = "", bonus: int = 0) -> None:
+        cleaned = _clean(value)
+        if not cleaned:
+            return
+        identity = _identity(cleaned)
+        if identity == model_identity or (model_identity and identity in model_identity):
+            return
+        reason = _reject_reason(cleaned, context=context)
+        if reason:
+            if len(rejected) < 12:
+                rejected.append({"value": cleaned, "reason": reason})
+            return
+        record = records.setdefault(
+            identity,
+            {"value": cleaned, "score": min(len(identity), 24), "sources": [], "evidence": []},
+        )
+        if source not in record["sources"]:
+            record["sources"].append(source)
+            record["score"] += bonus
+        if context and context not in record["evidence"] and len(record["evidence"]) < 3:
+            record["evidence"].append(context[:160])
+
+    direct_keys = (
+        "equipment_serial_number",
+        "serial_number",
+        "serial",
+        "sn",
+        "s_n",
+        "barcode_text",
+        "barcode_value",
+        "barcode",
+    )
+    for key in direct_keys:
+        value = raw.get(key)
+        if value:
+            add(
+                value,
+                source=f"field:{key}",
+                bonus=55 if "serial" in key or key in {"sn", "s_n"} else 35,
+            )
+            for token in TOKEN_RE.findall(str(value)):
+                add(token, source=f"field:{key}", bonus=55 if "serial" in key or key in {"sn", "s_n"} else 35)
+
+    list_keys = (
+        "serial_candidates",
+        "serial_number_candidates",
+        "serials",
+        "barcode_values",
+        "barcodes",
+    )
+    for key in list_keys:
+        value = raw.get(key)
+        values = value if isinstance(value, list) else list(value.values()) if isinstance(value, dict) else [value]
+        for item in values:
+            add(item, source=f"field:{key}", bonus=25)
+            for token in TOKEN_RE.findall(str(item or "")):
+                add(token, source=f"field:{key}", bonus=25)
+
+    lines = [re.sub(r"\s+", " ", line).strip() for line in str(raw_text or "").splitlines()]
+    for index, line in enumerate(lines):
+        serial_label = bool(SERIAL_LABEL_RE.search(line))
+        barcode_label = bool(BARCODE_LABEL_RE.search(line))
+        for distance in range(0, 3 if serial_label or barcode_label else 1):
+            if index + distance >= len(lines):
+                break
+            candidate_line = lines[index + distance]
+            context = " | ".join(lines[index : min(len(lines), index + distance + 1)])
+            for token in TOKEN_RE.findall(candidate_line):
+                bonus = 0
+                source = "ocr"
+                if serial_label:
+                    bonus = 85 - distance * 22
+                    source = "serial_label"
+                elif barcode_label:
+                    bonus = 55 - distance * 15
+                    source = "barcode_label"
+                add(token, source=source, context=context, bonus=bonus)
+
+    for record in records.values():
+        identity = _identity(record["value"])
+        if identity.isdigit() and 11 <= len(identity) <= 14:
+            record["score"] += 38
+            record["sources"].append("numeric_barcode_shape")
+        if re.search(r"[A-Z]", identity) and re.search(r"\d", identity):
+            record["score"] += 18
+        record["score"] += _brand_specific_bonus(record["value"], brand, equipment_model)
+
+    ranked = sorted(records.values(), key=lambda item: (-int(item["score"]), str(item["value"])))[:8]
+    if not ranked:
+        return {"candidates": [], "details": [], "selected": None, "selection_required": False, "rejected": rejected}
+
+    top = ranked[0]
+    runner_up_score = int(ranked[1]["score"]) if len(ranked) > 1 else -999
+    has_strong_evidence = bool(
+        {"serial_label", "barcode_label", "numeric_barcode_shape"}.intersection(top["sources"])
+        or any(str(source).startswith("field:serial") or source in {"field:sn", "field:s_n"} for source in top["sources"])
+    )
+    selection_required = not (has_strong_evidence and int(top["score"]) - runner_up_score >= 18)
+    selected = str(top["value"])
+    return {
+        "candidates": [str(item["value"]) for item in ranked],
+        "details": ranked,
+        "selected": selected,
+        "selection_required": selection_required,
+        "selection": {
+            "source": "auto",
+            "value": selected,
+            "evidence": list(top["sources"]),
+            "score": int(top["score"]),
+        },
+        "rejected": rejected,
+    }

--- a/tests/unit/test_bot_repair_nameplate_service.py
+++ b/tests/unit/test_bot_repair_nameplate_service.py
@@ -128,6 +128,105 @@ def test_nameplate_normalization_prefers_tcl_barcode_serial_candidate():
     assert "несколько похожих номеров" in flags["warnings"]["serial_candidates"]
 
 
+def test_nameplate_normalization_rejects_manufacture_date_and_prefers_reported_aeronik_serial():
+    extracted, flags = BotRepairNameplateService.normalize_extracted(
+        {
+            "brand": "Aeronik",
+            "model": "AMV-450WM/B-X",
+            "serial_number": "MANUFACTURED DATE: 2018.06",
+            "serial_candidates": [
+                "MANUFACTURED DATE: 2018.06",
+                "REFRI. CHARGE: 10.30KG",
+                "5064TONNES",
+                "380-415V",
+                "600008000357",
+            ],
+            "manufactured_year": "2018.06",
+        },
+        "\n".join(
+            [
+                "AERONIK AIR CONDITIONER OUTDOOR UNIT",
+                "MODEL AMV-450WM/B-X",
+                "REFRIGERANT R410A",
+                "REFRI. CHARGE 10.30KG",
+                "MANUFACTURED DATE 2018.06",
+                "CEREAL",
+                "63229991431",
+                "600008000357",
+            ]
+        ),
+    )
+
+    assert extracted["equipment_serial_number"] == "600008000357"
+    assert "equipment_commissioning_date" not in extracted
+    assert flags["serial_candidates"][0] == "600008000357"
+    assert "MANUFACTURED DATE: 2018.06" not in flags["serial_candidates"]
+    assert flags["serial_selection_required"] is True
+    assert flags["serial_selection"]["source"] == "auto"
+
+
+def test_nameplate_normalization_requires_choice_when_candidates_are_ambiguous():
+    extracted, flags = BotRepairNameplateService.normalize_extracted(
+        {
+            "brand": "Generic",
+            "model": "AC-12",
+            "serial_candidates": ["12345678901", "12345678902"],
+        },
+        "12345678901\n12345678902",
+    )
+
+    assert extracted["equipment_serial_number"] in {"12345678901", "12345678902"}
+    assert flags["serial_selection_required"] is True
+    assert "должен выбрать" in flags["warnings"]["serial_candidates"]
+
+
+@pytest.mark.parametrize(
+    ("label", "serial"),
+    [
+        ("SERIAL NO", "ABC1234567"),
+        ("S/N", "SN99887766"),
+        ("BARCODE", "AB1234567890"),
+        ("CEREAL", "600008000357"),
+    ],
+)
+def test_nameplate_normalization_uses_serial_and_barcode_labels(label, serial):
+    extracted, flags = BotRepairNameplateService.normalize_extracted(
+        {"brand": "Generic", "model": "AC-12"},
+        f"MODEL AC-12\n{label}\n{serial}\nMANUFACTURED DATE 2020.06",
+    )
+
+    assert extracted["equipment_serial_number"] == serial
+    assert flags["serial_selection_required"] is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("flow", ["repair", "warranty"])
+async def test_nameplate_apply_rejects_unconfirmed_ambiguous_serial(
+    sqlite_repair_nameplate_session, flow
+):
+    kwargs = {
+        "extracted": {"equipment_serial_number": "12345678901"},
+        "raw_text": "12345678901\n12345678902",
+        "validation_flags": {"serial_selection_required": True},
+        "file_id": "photo",
+        "filename": "plate.jpg",
+        "mime_type": "image/jpeg",
+        "telegram_user_id": 777,
+        "telegram_chat_id": 100,
+        "telegram_message_id": 55,
+        "can_attach_any": True,
+        "tenant_scope": TEST_TENANT_SCOPE,
+    }
+    if flow == "warranty":
+        kwargs["unit_type"] = "outdoor_unit"
+        service = BotWarrantyNameplateService
+    else:
+        service = BotRepairNameplateService
+
+    with pytest.raises(ValueError, match="явно выбрать"):
+        await service.apply_to_order(sqlite_repair_nameplate_session, 999, **kwargs)
+
+
 def test_nameplate_normalization_decodes_tcl_factory_serial_details():
     extracted, flags = BotRepairNameplateService.normalize_extracted(
         {
@@ -787,3 +886,29 @@ async def test_warranty_nameplate_creates_order_equipment_and_updates_selected_c
     assert component.model == "AS25S2SF1FA"
     assert component.serial == "SN-IN-001"
     assert order.technical_meta["warranty_nameplate_recognitions"][0]["purpose"] == "warranty_nameplate"
+
+    repeated = await BotWarrantyNameplateService.apply_to_order(
+        sqlite_repair_nameplate_session,
+        int(order.id),
+        unit_type="indoor_unit",
+        extracted={
+            "equipment_brand": "Haier",
+            "equipment_model": "AS25S2SF1FA",
+            "equipment_serial_number": "SN-IN-001",
+            "refrigerant_type": "R32",
+        },
+        raw_text="MODEL AS25S2SF1FA SERIAL SN-IN-001",
+        validation_flags={"warnings": {}, "is_valid": True},
+        file_id="photo-file",
+        filename="nameplate.jpg",
+        mime_type="image/jpeg",
+        telegram_user_id=777,
+        telegram_chat_id=100,
+        telegram_message_id=55,
+        can_attach_any=True,
+        tenant_scope=TEST_TENANT_SCOPE,
+    )
+
+    assert repeated is not None
+    await sqlite_repair_nameplate_session.refresh(order)
+    assert len(order.technical_meta["warranty_nameplate_recognitions"]) == 1


### PR DESCRIPTION
## Что изменено

- выделен отдельный safety-first resolver серийных номеров с приоритетом `Serial` / `S/N` / OCR-варианта `CEREAL` и расположения у штрихкода;
- даты изготовления, модель, напряжение, ток, мощность, хладагент, заправка и единицы измерения исключаются из кандидатов;
- числовые штрихкоды 11–14 цифр больше не проигрывают техническим значениям;
- неоднозначный результат помечается `serial_selection_required`, и API запрещает запись без явного выбора сотрудника;
- `manufactured_year` больше не записывается как дата ввода оборудования;
- гарантийная история идемпотентно обновляется по Telegram `file_id`;
- добавлена регрессия по фактическому Aeronik-кейсу заказа #194 и фикстуры `SERIAL NO`, `S/N`, `BARCODE`, `CEREAL`.

## Проверки

- `27 passed` — полный файл unit-тестов nameplate service;
- `33 passed` — nameplate service + internal bot admin router;
- полный unit-прогон: `2993 passed, 4 skipped`; 87 setup errors относятся только к недоступному локальному PostgreSQL `localhost:5433`;
- `git diff --check` — чисто.

## Audit follow-up

Версионный серверный draft/idempotency key, блокировки warranty target и полностью типизированный OpenAPI-контракт остаются отдельным архитектурным слоем: они требуют миграции и не включены в этот safety-релиз.
