### PR TITLE
Make HA Telegram alerts explain what actually happened

### DIFF
--- a/.github/actions/notify-ha-failure/action.yml
+++ b/.github/actions/notify-ha-failure/action.yml
@@ -21,6 +21,10 @@ inputs:
     description: Optional one-line context, usually the uploaded artifact name.
     required: false
     default: ""
+  message-file:
+    description: Optional UTF-8 file containing the complete owner-facing message.
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -33,6 +37,7 @@ runs:
         THREAD_ID: ${{ inputs.thread-id }}
         TITLE: ${{ inputs.title }}
         DETAILS: ${{ inputs.details }}
+        MESSAGE_FILE: ${{ inputs.message-file }}
       run: |
         set -euo pipefail
         if [ -z "${BOT_TOKEN}" ] || [ -z "${CHAT_ID}" ]; then
@@ -50,15 +55,23 @@ runs:
             f"{os.environ.get('GITHUB_REPOSITORY', '')}/actions/runs/"
             f"{os.environ.get('GITHUB_RUN_ID', '')}"
         )
-        lines = [
-            os.environ.get("TITLE", "MVN HA monitor failed"),
-            f"Workflow: {os.environ.get('GITHUB_WORKFLOW', '')}",
-            f"Branch: {os.environ.get('GITHUB_REF_NAME', '')}",
-            f"Run: {run_url}",
-        ]
-        details = os.environ.get("DETAILS", "").strip()
-        if details:
-            lines.append(details)
+        message_file = os.environ.get("MESSAGE_FILE", "").strip()
+        if message_file:
+            with open(message_file, encoding="utf-8") as source:
+                message = source.read().strip()
+            if not message or len(message) > 3500:
+                raise SystemExit("owner-facing HA message must contain 1..3500 characters")
+            lines = [message, "", f"Технические подробности: {run_url}"]
+        else:
+            lines = [
+                os.environ.get("TITLE", "MVN HA monitor failed"),
+                f"Workflow: {os.environ.get('GITHUB_WORKFLOW', '')}",
+                f"Branch: {os.environ.get('GITHUB_REF_NAME', '')}",
+                f"Run: {run_url}",
+            ]
+            details = os.environ.get("DETAILS", "").strip()
+            if details:
+                lines.append(details)
 
         payload = {
             "chat_id": os.environ["CHAT_ID"],

--- a/.github/workflows/api-restore-drill.yml
+++ b/.github/workflows/api-restore-drill.yml
@@ -71,5 +71,5 @@ jobs:
           bot-token: ${{ secrets.HA_ALERT_TELEGRAM_BOT_TOKEN }}
           chat-id: ${{ secrets.HA_ALERT_TELEGRAM_CHAT_ID }}
           thread-id: ${{ secrets.HA_ALERT_TELEGRAM_THREAD_ID }}
-          title: "MVN API restore drill failed"
-          details: "Artifact: api-restore-drill-log-${{ github.run_id }}"
+          title: "🟡 Не удалось проверить восстановление API из резервной копии"
+          details: "Работа сайта не обязательно нарушена: завершилась ошибкой учебная проверка восстановления."

--- a/.github/workflows/check-api-ha-invariants.yml
+++ b/.github/workflows/check-api-ha-invariants.yml
@@ -96,5 +96,5 @@ jobs:
           bot-token: ${{ secrets.HA_ALERT_TELEGRAM_BOT_TOKEN }}
           chat-id: ${{ secrets.HA_ALERT_TELEGRAM_CHAT_ID }}
           thread-id: ${{ secrets.HA_ALERT_TELEGRAM_THREAD_ID }}
-          title: "MVN API HA invariant check failed"
-          details: "Artifact: api-ha-invariant-log-${{ github.run_id }}"
+          title: "🔴 Не подтверждена безопасная схема основного и резервного API"
+          details: "Мониторинг не смог подтвердить, что один API активен, а второй корректно отключён от трафика."

--- a/.github/workflows/check-api-ha-readiness.yml
+++ b/.github/workflows/check-api-ha-readiness.yml
@@ -143,5 +143,5 @@ jobs:
           bot-token: ${{ secrets.HA_ALERT_TELEGRAM_BOT_TOKEN }}
           chat-id: ${{ secrets.HA_ALERT_TELEGRAM_CHAT_ID }}
           thread-id: ${{ secrets.HA_ALERT_TELEGRAM_THREAD_ID }}
-          title: "MVN API HA readiness audit failed"
-          details: "Artifact: api-ha-readiness-log-${{ github.run_id }}"
+          title: "🟠 HA-контур API требует проверки"
+          details: "Одна из обязательных проверок готовности, репликации или маршрутизации не прошла."

--- a/.github/workflows/check-api-vps-health.yml
+++ b/.github/workflows/check-api-vps-health.yml
@@ -184,5 +184,5 @@ jobs:
           bot-token: ${{ secrets.HA_ALERT_TELEGRAM_BOT_TOKEN }}
           chat-id: ${{ secrets.HA_ALERT_TELEGRAM_CHAT_ID }}
           thread-id: ${{ secrets.HA_ALERT_TELEGRAM_THREAD_ID }}
-          title: "MVN API VPS health check failed"
-          details: "Artifact: api-vps-health-log-${{ github.run_id }}"
+          title: "🟠 Один из API-серверов требует проверки"
+          details: "Мониторинг обнаружил проблему доступности или ресурсов сервера; состояние публичного API проверяется отдельно."

--- a/.github/workflows/check-cloudflare-lb-config.yml
+++ b/.github/workflows/check-cloudflare-lb-config.yml
@@ -94,5 +94,5 @@ jobs:
           bot-token: ${{ secrets.HA_ALERT_TELEGRAM_BOT_TOKEN }}
           chat-id: ${{ secrets.HA_ALERT_TELEGRAM_CHAT_ID }}
           thread-id: ${{ secrets.HA_ALERT_TELEGRAM_THREAD_ID }}
-          title: "MVN Cloudflare LB config check failed"
-          details: "Artifact: cloudflare-lb-config-log-${{ github.run_id }}"
+          title: "🟡 Маршрутизация Cloudflare требует проверки"
+          details: "Конфигурация переключения трафика между API-серверами отличается от проверенной."

--- a/.github/workflows/check-media-cdn.yml
+++ b/.github/workflows/check-media-cdn.yml
@@ -143,5 +143,5 @@ jobs:
           bot-token: ${{ secrets.HA_ALERT_TELEGRAM_BOT_TOKEN }}
           chat-id: ${{ secrets.HA_ALERT_TELEGRAM_CHAT_ID }}
           thread-id: ${{ secrets.HA_ALERT_TELEGRAM_THREAD_ID }}
-          title: "MVN media CDN check failed"
-          details: "Artifact: media-cdn-check-log-${{ github.run_id }}"
+          title: "🟡 Проверка изображений и CDN не прошла"
+          details: "Часть файлов может быть временно недоступна; основной API проверяется отдельно."

--- a/.github/workflows/check-postgres-pitr.yml
+++ b/.github/workflows/check-postgres-pitr.yml
@@ -107,5 +107,5 @@ jobs:
           bot-token: ${{ secrets.HA_ALERT_TELEGRAM_BOT_TOKEN }}
           chat-id: ${{ secrets.HA_ALERT_TELEGRAM_CHAT_ID }}
           thread-id: ${{ secrets.HA_ALERT_TELEGRAM_THREAD_ID }}
-          title: "MVN PostgreSQL PITR check failed"
-          details: "Artifact: postgres-pitr-check-log-${{ github.run_id }}"
+          title: "🟠 Резервные копии PostgreSQL требуют проверки"
+          details: "Автоматическая проверка WAL или свежести базовой копии завершилась ошибкой; работа основной базы проверяется отдельно."

--- a/.github/workflows/check-postgres-replication.yml
+++ b/.github/workflows/check-postgres-replication.yml
@@ -14,11 +14,16 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
+concurrency:
+  group: postgres-replication-monitor
+  cancel-in-progress: false
+
 jobs:
   check:
     runs-on: ubuntu-latest
     timeout-minutes: 8
     permissions:
+      actions: read
       contents: read
 
     steps:
@@ -96,7 +101,9 @@ jobs:
               export RESERVE_NODE_COMPOSE_FILE=docker-compose.patroni.yml
               export API_NODE_WG_IP="${EXPECTED_PRIMARY_WG_IP}"
               export RESERVE_NODE_WG_IP="${EXPECTED_STANDBY_WG_IP}"
-              python3 scripts/ha/check_patroni_production.py | tee -a postgres-replication-check.log
+              python3 scripts/ha/check_patroni_production.py \
+                --snapshot-output postgres-ha-snapshot.json \
+                | tee -a postgres-replication-check.log
               ;;
             physical)
               export PRIMARY_SSH="${SSH_USER_API}@${SSH_HOST_API}"
@@ -108,6 +115,49 @@ jobs:
               exit 1
               ;;
           esac
+
+      - name: Restore previous HA notification state
+        id: previous-state
+        if: ${{ always() && (vars.API_DB_HA_MODE || 'physical') == 'patroni' && steps.maintenance.outputs.active != 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          previous_dir="${RUNNER_TEMP}/ha-notification-previous"
+          mkdir -p "${previous_dir}"
+          restored=false
+          while IFS= read -r previous_run_id; do
+            if gh run download "${previous_run_id}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --name "ha-notification-state-${previous_run_id}" \
+              --dir "${previous_dir}" 2>/dev/null; then
+              restored=true
+              break
+            fi
+          done < <(
+            gh run list \
+              --repo "${GITHUB_REPOSITORY}" \
+              --workflow check-postgres-replication.yml \
+              --branch main \
+              --status completed \
+              --limit 10 \
+              --json databaseId \
+              --jq '.[].databaseId'
+          )
+          echo "restored=${restored}" >> "${GITHUB_OUTPUT}"
+
+      - name: Classify owner-facing HA event
+        id: ha-event
+        if: ${{ always() && (vars.API_DB_HA_MODE || 'physical') == 'patroni' && steps.maintenance.outputs.active != 'true' }}
+        run: |
+          set -euo pipefail
+          python3 scripts/ha/ha_telegram_events.py \
+            --snapshot postgres-ha-snapshot.json \
+            --previous-state "${RUNNER_TEMP}/ha-notification-previous/ha-notification-state.json" \
+            --fallback-log postgres-replication-check.log \
+            --state-output ha-notification-state.json \
+            --message-output ha-owner-message.txt \
+            --github-output "${GITHUB_OUTPUT}"
 
       - name: Write Summary
         if: always()
@@ -133,12 +183,21 @@ jobs:
           path: postgres-replication-check.log
           if-no-files-found: warn
 
-      - name: Notify HA failure
-        if: failure()
+      - name: Upload HA notification state
+        if: ${{ always() && steps.ha-event.outcome == 'success' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: ha-notification-state-${{ github.run_id }}
+          path: ha-notification-state.json
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Notify owner about HA event
+        if: ${{ always() && github.ref == 'refs/heads/main' && steps.ha-event.outputs.notify == 'true' }}
         uses: ./.github/actions/notify-ha-failure
         with:
           bot-token: ${{ secrets.HA_ALERT_TELEGRAM_BOT_TOKEN }}
           chat-id: ${{ secrets.HA_ALERT_TELEGRAM_CHAT_ID }}
           thread-id: ${{ secrets.HA_ALERT_TELEGRAM_THREAD_ID }}
-          title: "MVN PostgreSQL replication check failed"
-          details: "Artifact: postgres-replication-check-log-${{ github.run_id }}"
+          title: "Событие PostgreSQL HA"
+          message-file: ha-owner-message.txt

--- a/.github/workflows/postgres-pitr-restore-drill.yml
+++ b/.github/workflows/postgres-pitr-restore-drill.yml
@@ -140,5 +140,5 @@ jobs:
           bot-token: ${{ secrets.HA_ALERT_TELEGRAM_BOT_TOKEN }}
           chat-id: ${{ secrets.HA_ALERT_TELEGRAM_CHAT_ID }}
           thread-id: ${{ secrets.HA_ALERT_TELEGRAM_THREAD_ID }}
-          title: "MVN PostgreSQL PITR restore drill failed"
-          details: "Artifact: postgres-pitr-restore-drill-log-${{ github.run_id }}"
+          title: "🟡 Не удалось проверить восстановление PostgreSQL"
+          details: "Работа основной базы не обязательно нарушена: завершилась ошибкой изолированная учебная проверка восстановления."

--- a/.github/workflows/report-ha-status.yml
+++ b/.github/workflows/report-ha-status.yml
@@ -126,13 +126,3 @@ jobs:
           name: ha-status-report-log-${{ github.run_id }}
           path: ha-status-report.log
           if-no-files-found: warn
-
-      - name: Notify HA failure
-        if: failure()
-        uses: ./.github/actions/notify-ha-failure
-        with:
-          bot-token: ${{ secrets.HA_ALERT_TELEGRAM_BOT_TOKEN }}
-          chat-id: ${{ secrets.HA_ALERT_TELEGRAM_CHAT_ID }}
-          thread-id: ${{ secrets.HA_ALERT_TELEGRAM_THREAD_ID }}
-          title: "MVN API HA status report failed"
-          details: "Artifact: ha-status-report-log-${{ github.run_id }}"

--- a/docs/api-ha-runbook.md
+++ b/docs/api-ha-runbook.md
@@ -228,9 +228,26 @@ Scheduled monitors:
 
 Owner-visible alerting:
 
-All HA monitor workflows call `.github/actions/notify-ha-failure` on failure
-after the log artifact upload step. Without the secrets below, the notifier
-prints a skip message and does not fail the workflow:
+The replication monitor is the authoritative source for PostgreSQL topology
+events. It stores a secret-free state artifact after each run and compares the
+new observation with the latest retained state. Telegram receives an event only
+for a confirmed transition:
+
+- `primary_changed`: names the old and new primary with country labels;
+- `degraded`: the primary remains writable but synchronous standby protection
+  is not confirmed;
+- `critical`: no safe writable primary or another unsafe topology was proven;
+- `monitoring_error`: two consecutive checks could not observe the cluster;
+- `recovered` / `monitoring_recovered`: the corresponding incident closed.
+
+A single SSH timeout is retained in the diagnostic artifact but does not page
+the owner. Repeated identical observations are deduplicated. The rollup status
+report does not send a second Telegram alert for failures already owned by a
+source monitor. Other HA workflows still send a concise Russian failure message
+after their diagnostic artifact is uploaded.
+
+Without the secrets below, the notifier prints a skip message and does not fail
+the workflow:
 
 ```bash
 gh secret set HA_ALERT_TELEGRAM_BOT_TOKEN --repo mvnby/air-api

--- a/docs/postgres-quorum-runbook.md
+++ b/docs/postgres-quorum-runbook.md
@@ -553,8 +553,11 @@ role-aware instead of treating the API VPS as a permanent primary:
   `scripts/ha/check_patroni_production.py`;
 - `PostgreSQL PITR Check` probes both Patroni REST APIs and executes the local
   archive/timer/R2 freshness check on whichever node is currently primary;
-- both workflows retain the existing Telegram failure action and diagnostic
-  artifacts.
+- the replication workflow persists a secret-free observation state and sends
+  deduplicated owner events for primary changes, degraded protection, critical
+  topology, repeated monitoring failure, and recovery;
+- the PITR workflow retains a separate human-readable backup warning and
+  diagnostic artifact, so a backup problem is not mislabeled as a failover.
 
 Scheduled HA checks recognize an official maintenance window only after
 `scripts/ha/check_patroni_maintenance.py` proves the marker independently on

--- a/scripts/ha/check_patroni_production.py
+++ b/scripts/ha/check_patroni_production.py
@@ -9,12 +9,10 @@ three-member etcd quorum without reading database or infrastructure secrets.
 
 from __future__ import annotations
 
-import argparse
 import json
 import os
 import shlex
 import subprocess
-import sys
 from dataclasses import dataclass, field
 from typing import Any, Mapping, Sequence
 
@@ -677,70 +675,10 @@ def _check_runtime(
         )
 
 
-def perform_checks(config: CheckerConfig, runner: SshRunner) -> Report:
-    report = Report()
-    payloads = probe_nodes(config, runner)
-    primary, standby = select_primary(config.nodes, payloads)
-    report.pass_check(
-        f"exactly one Patroni primary: {primary.label} ({primary.patroni_name})"
-    )
-
-    _check_cluster_views(config, runner, primary, standby, report)
-    _check_postgres(config, runner, primary, standby, report)
-    _check_runtime(config, runner, primary, standby, report)
-
-    etcd = runner.run(config.api, config.etcd_check_command, check=False)
-    if etcd.returncode == 0 and "etcd_quorum_status=passed members=3" in etcd.stdout:
-        report.pass_check("etcd quorum has three healthy members")
-    else:
-        detail = (etcd.stderr or etcd.stdout or "check failed").strip().replace("\n", " ")
-        report.fail(f"etcd quorum check failed: {detail}")
-    return report
-
-
-def _print_report(report: Report) -> None:
-    for message in report.ok:
-        print(f"[patroni-production][ok] {message}")
-    for message in report.failures:
-        print(f"[patroni-production][fail] {message}")
-    status = "failed" if report.failures else "passed"
-    print(
-        f"[patroni-production][summary] status={status} "
-        f"ok={len(report.ok)} failures={len(report.failures)}"
-    )
-
-
-def parse_args(argv: Sequence[str]) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        "--resolve-primary",
-        action="store_true",
-        help="Print only api or reserve after validating the two Patroni roles.",
-    )
-    return parser.parse_args(argv)
-
-
-def main(argv: Sequence[str] | None = None) -> int:
-    args = parse_args(argv or sys.argv[1:])
-    try:
-        config = load_config()
-        runner = SshRunner(config.ssh_options)
-        if args.resolve_primary:
-            primary, _ = select_primary(config.nodes, probe_nodes(config, runner))
-            print(primary.label)
-            return 0
-        report = perform_checks(config, runner)
-    except (RuntimeError, ValueError) as exc:
-        if args.resolve_primary:
-            print(f"could not resolve Patroni primary: {exc}", file=sys.stderr)
-        else:
-            print(f"[patroni-production][fail] {exc}")
-            print("[patroni-production][summary] status=failed ok=0 failures=1")
-        return 2
-
-    _print_report(report)
-    return 1 if report.failures else 0
-
-
 if __name__ == "__main__":
+    try:
+        from scripts.ha.patroni_production_command import main
+    except ModuleNotFoundError:
+        from patroni_production_command import main
+
     raise SystemExit(main())

--- a/scripts/ha/ha_telegram_events.py
+++ b/scripts/ha/ha_telegram_events.py
@@ -1,0 +1,444 @@
+#!/usr/bin/env python3
+"""Turn Patroni observations into deduplicated, owner-readable Telegram events."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+
+STATE_VERSION = 1
+SNAPSHOT_STATES = {"healthy", "degraded", "critical", "monitoring_error"}
+NODE_LABELS = {
+    "mvn-api": "🇳🇱 Нидерланды — mvn-api",
+    "zakup": "🇧🇾 Беларусь — zakup",
+}
+
+
+@dataclass(frozen=True)
+class Decision:
+    kind: str | None
+    message: str
+    state: dict[str, Any]
+
+
+def _load_object(path: Path) -> dict[str, Any] | None:
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid JSON in {path}") from exc
+    if not isinstance(value, dict):
+        raise ValueError(f"JSON root in {path} must be an object")
+    return value
+
+
+def _snapshot(value: Mapping[str, Any]) -> dict[str, Any]:
+    status = str(value.get("status") or "").strip()
+    if status not in SNAPSHOT_STATES:
+        raise ValueError(f"unsupported HA snapshot status: {status or '<empty>'}")
+    failures = value.get("failures") or []
+    if not isinstance(failures, list) or not all(isinstance(item, str) for item in failures):
+        raise ValueError("HA snapshot failures must be a string list")
+    return {
+        "status": status,
+        "observed_at": str(value.get("observed_at") or "").strip(),
+        "primary": str(value.get("primary") or "").strip(),
+        "standby": str(value.get("standby") or "").strip(),
+        "timeline": value.get("timeline"),
+        "lag_bytes": value.get("lag_bytes"),
+        "primary_ready": value.get("primary_ready"),
+        "standby_fenced": value.get("standby_fenced"),
+        "replication_state": str(value.get("replication_state") or "").strip(),
+        "sync_state": str(value.get("sync_state") or "").strip(),
+        "failures": failures[:6],
+        "detail": str(value.get("detail") or "").strip()[:500],
+    }
+
+
+def _state(value: Mapping[str, Any] | None) -> dict[str, Any]:
+    if not value or value.get("version") != STATE_VERSION:
+        return {
+            "version": STATE_VERSION,
+            "last_confirmed": None,
+            "last_observation": None,
+            "monitoring_error_streak": 0,
+            "monitoring_alert_open": False,
+        }
+    confirmed = value.get("last_confirmed")
+    observation = value.get("last_observation")
+    return {
+        "version": STATE_VERSION,
+        "last_confirmed": _snapshot(confirmed) if isinstance(confirmed, Mapping) else None,
+        "last_observation": _snapshot(observation) if isinstance(observation, Mapping) else None,
+        "monitoring_error_streak": max(0, int(value.get("monitoring_error_streak") or 0)),
+        "monitoring_alert_open": bool(value.get("monitoring_alert_open", False)),
+    }
+
+
+def _node(alias: str) -> str:
+    return NODE_LABELS.get(alias, alias or "не определён")
+
+
+def _service_line(snapshot: Mapping[str, Any]) -> str:
+    if snapshot.get("primary_ready") is True:
+        return "Сайт и API: работают"
+    return "Сайт и API: требуют проверки"
+
+
+def _replication_line(snapshot: Mapping[str, Any]) -> str:
+    lag = snapshot.get("lag_bytes")
+    if snapshot.get("status") == "healthy":
+        lag_bytes = lag if isinstance(lag, int) else 0
+        return f"Репликация: синхронная, отставание WAL {lag_bytes} байт"
+    if isinstance(lag, int):
+        return f"WAL lag: {lag} байт"
+    return "Репликация: резервный узел не подтверждён"
+
+
+def _humanize_problem(problem: str) -> str:
+    lowered = problem.lower()
+    mappings = (
+        (
+            ("unsafe patroni topology", "primary count="),
+            "не подтверждён единственный безопасный primary",
+        ),
+        (
+            ("/sync endpoint", "sync_state="),
+            "резервный сервер не подтверждён как синхронная реплика",
+        ),
+        (
+            ("replica lag", "replay lag", "wal receiver lag"),
+            "реплика отстаёт по журналу изменений",
+        ),
+        (
+            ("not writable primary",),
+            "основной сервер не подтверждён как доступный для записи",
+        ),
+        (
+            ("not in recovery",),
+            "резервный сервер не подтверждён в безопасном режиме standby",
+        ),
+        (
+            ("replication state=", "wal receiver status="),
+            "репликация не находится в рабочем состоянии streaming",
+        ),
+        (
+            ("no replication slot", "replication slot"),
+            "не подтверждён защищающий репликацию WAL-слот",
+        ),
+        (
+            ("pending_restart",),
+            "один из серверов ожидает обязательного перезапуска PostgreSQL",
+        ),
+        (
+            ("members disagree on timeline", "timeline mismatch"),
+            "серверы расходятся по истории WAL",
+        ),
+        (
+            ("system identifier",),
+            "серверы сообщили разные идентификаторы кластера PostgreSQL",
+        ),
+        (
+            ("etcd quorum",),
+            "не подтверждён кворум координаторов автоматического переключения",
+        ),
+        (
+            ("readiness", "no api app service"),
+            "служебная проверка API не подтвердила безопасную готовность серверов",
+        ),
+        (
+            ("role agent", "scheduler_runtime"),
+            "служба автоматического назначения ролей работает некорректно",
+        ),
+        (
+            ("failsafe mode", "cluster is paused", "no leader lock"),
+            "Patroni не подтвердил безопасное автоматическое управление кластером",
+        ),
+    )
+    for markers, message in mappings:
+        if any(marker in lowered for marker in markers):
+            return message
+    return "одна из проверок безопасной репликации не прошла"
+
+
+def _humanize_monitoring_error(detail: str) -> str:
+    lowered = detail.lower()
+    location = "HA-серверами"
+    if lowered.startswith("api:"):
+        location = NODE_LABELS["mvn-api"]
+    elif lowered.startswith("reserve:"):
+        location = NODE_LABELS["zakup"]
+    if any(
+        marker in lowered
+        for marker in (
+            "connection closed",
+            "connection refused",
+            "no route to host",
+            "operation timed out",
+            "timed out",
+            "timeout",
+        )
+    ):
+        return f"нет ответа от {location} по служебному каналу"
+    if "invalid patroni json" in lowered or "unexpected patroni payload" in lowered:
+        return f"ответ от {location} получен, но состояние Patroni не удалось прочитать"
+    if "is required" in lowered:
+        return "проверка запущена с неполной служебной конфигурацией"
+    return "служебная проверка не смогла получить состояние HA-серверов"
+
+
+def _switch_message(previous: Mapping[str, Any], current: Mapping[str, Any]) -> str:
+    lines = [
+        "🟠 PostgreSQL: переключение primary",
+        "",
+        f"Было: {_node(str(previous.get('primary') or ''))}",
+        f"Стало: {_node(str(current.get('primary') or ''))}",
+        "",
+        _service_line(current),
+        _replication_line(current),
+    ]
+    if current.get("status") == "healthy":
+        lines.extend(["", "Кластер снова защищён синхронной репликой."])
+    else:
+        lines.extend(
+            [
+                "",
+                "Новый primary работает, но полноценное резервирование "
+                "ещё не подтверждено.",
+            ]
+        )
+    lines.extend(
+        [
+            "Причина переключения пока не подтверждена.",
+            "Действия от вас сейчас не требуются.",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _degraded_message(current: Mapping[str, Any]) -> str:
+    failure = next(iter(current.get("failures") or []), "standby не прошёл проверку")
+    return "\n".join(
+        [
+            "🟠 PostgreSQL работает без полноценного резерва",
+            "",
+            f"Primary: {_node(str(current.get('primary') or ''))}",
+            f"Standby: {_node(str(current.get('standby') or ''))}",
+            _service_line(current),
+            _replication_line(current),
+            "",
+            f"Что обнаружено: {_humanize_problem(failure)}.",
+            "Запись данных продолжается, но отказоустойчивость снижена.",
+        ]
+    )
+
+
+def _critical_message(current: Mapping[str, Any]) -> str:
+    failure = next(
+        iter(current.get("failures") or []),
+        current.get("detail") or "primary не подтверждён",
+    )
+    return "\n".join(
+        [
+            "🔴 Критическая проблема PostgreSQL HA",
+            "",
+            _service_line(current),
+            f"Primary: {_node(str(current.get('primary') or ''))}",
+            f"Что обнаружено: {_humanize_problem(str(failure))}.",
+            "",
+            "Требуется срочная техническая проверка. Автоматически роли не меняйте.",
+        ]
+    )
+
+
+def _recovered_message(current: Mapping[str, Any]) -> str:
+    return "\n".join(
+        [
+            "🟢 Резервирование PostgreSQL восстановлено",
+            "",
+            f"Primary: {_node(str(current.get('primary') or ''))}",
+            f"Standby: {_node(str(current.get('standby') or ''))}",
+            _service_line(current),
+            _replication_line(current),
+            "",
+            "Кластер снова защищён от отказа одного сервера.",
+        ]
+    )
+
+
+def _monitoring_error_message(
+    last_confirmed: Mapping[str, Any] | None,
+    current: Mapping[str, Any],
+) -> str:
+    detail = current.get("detail") or next(
+        iter(current.get("failures") or []),
+        "неизвестная ошибка соединения",
+    )
+    lines = [
+        "🟡 Не удалось проверить HA-серверы",
+        "",
+        "Две проверки подряд не смогли подтвердить состояние кластера.",
+        "Это не означает, что PostgreSQL остановлен.",
+    ]
+    if last_confirmed:
+        lines.extend(
+            [
+                "",
+                "Последняя подтверждённая топология:",
+                f"Primary: {_node(str(last_confirmed.get('primary') or ''))}",
+                f"Standby: {_node(str(last_confirmed.get('standby') or ''))}",
+            ]
+        )
+    lines.extend(
+        [
+            "",
+            f"Что произошло: {_humanize_monitoring_error(str(detail))}.",
+            "Повторная проверка выполнится автоматически.",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _monitoring_recovered_message(current: Mapping[str, Any]) -> str:
+    return "\n".join(
+        [
+            "🟢 Мониторинг HA снова работает",
+            "",
+            f"Primary: {_node(str(current.get('primary') or ''))}",
+            f"Standby: {_node(str(current.get('standby') or ''))}",
+            _service_line(current),
+            _replication_line(current),
+            "",
+            "Предыдущая ошибка была связана с проверкой соединения, "
+            "а не с подтверждённой остановкой PostgreSQL.",
+        ]
+    )
+
+
+def decide(previous_raw: Mapping[str, Any] | None, current_raw: Mapping[str, Any]) -> Decision:
+    previous = _state(previous_raw)
+    current = _snapshot(current_raw)
+    last_confirmed = previous["last_confirmed"]
+    next_state = dict(previous)
+    next_state["last_observation"] = current
+
+    if current["status"] == "monitoring_error":
+        streak = previous["monitoring_error_streak"] + 1
+        next_state["monitoring_error_streak"] = streak
+        if streak >= 2 and not previous["monitoring_alert_open"]:
+            next_state["monitoring_alert_open"] = True
+            return Decision(
+                "monitoring_error",
+                _monitoring_error_message(last_confirmed, current),
+                next_state,
+            )
+        return Decision(None, "", next_state)
+
+    next_state["monitoring_error_streak"] = 0
+    monitoring_was_open = previous["monitoring_alert_open"]
+    next_state["monitoring_alert_open"] = False
+    next_state["last_confirmed"] = current
+
+    if last_confirmed is None and current["status"] == "healthy":
+        return Decision(None, "", next_state)
+    if last_confirmed is None and current["status"] == "critical":
+        return Decision("critical", _critical_message(current), next_state)
+    if last_confirmed is None and current["status"] == "degraded":
+        return Decision("degraded", _degraded_message(current), next_state)
+    if current["primary"] and current["primary"] != last_confirmed["primary"]:
+        return Decision("primary_changed", _switch_message(last_confirmed, current), next_state)
+    if current["status"] == "critical" and last_confirmed["status"] != "critical":
+        return Decision("critical", _critical_message(current), next_state)
+    if current["status"] == "degraded" and last_confirmed["status"] == "healthy":
+        return Decision("degraded", _degraded_message(current), next_state)
+    if current["status"] == "healthy" and last_confirmed["status"] in {"degraded", "critical"}:
+        return Decision("recovered", _recovered_message(current), next_state)
+    if monitoring_was_open:
+        return Decision("monitoring_recovered", _monitoring_recovered_message(current), next_state)
+    return Decision(None, "", next_state)
+
+
+def _fallback_snapshot(log_path: Path) -> dict[str, Any]:
+    detail = "проверка завершилась до получения топологии"
+    try:
+        lines = log_path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except FileNotFoundError:
+        lines = []
+    for line in reversed(lines):
+        lowered = line.lower()
+        if any(
+            marker in lowered
+            for marker in (
+                "connection closed",
+                "timed out",
+                "timeout",
+                "connection refused",
+            )
+        ):
+            detail = line.strip()[-300:]
+            break
+    return {
+        "status": "monitoring_error",
+        "observed_at": "",
+        "failures": [],
+        "detail": detail,
+    }
+
+
+def _write_json(path: Path, value: Mapping[str, Any]) -> None:
+    path.write_text(json.dumps(value, ensure_ascii=False, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _write_github_output(path: Path | None, *, notify: bool, kind: str | None) -> None:
+    if path is None:
+        return
+    with path.open("a", encoding="utf-8") as output:
+        output.write(f"notify={'true' if notify else 'false'}\n")
+        output.write(f"event_kind={kind or 'none'}\n")
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--snapshot", type=Path, required=True)
+    parser.add_argument("--previous-state", type=Path, required=True)
+    parser.add_argument("--fallback-log", type=Path, required=True)
+    parser.add_argument("--state-output", type=Path, required=True)
+    parser.add_argument("--message-output", type=Path, required=True)
+    parser.add_argument("--github-output", type=Path)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv or os.sys.argv[1:])
+    current = _load_object(args.snapshot) or _fallback_snapshot(args.fallback_log)
+    previous = _load_object(args.previous_state)
+    decision = decide(previous, current)
+    _write_json(args.state_output, decision.state)
+    args.message_output.write_text(decision.message, encoding="utf-8")
+    _write_github_output(
+        args.github_output
+        or (
+            Path(os.environ["GITHUB_OUTPUT"])
+            if os.getenv("GITHUB_OUTPUT")
+            else None
+        ),
+        notify=decision.kind is not None,
+        kind=decision.kind,
+    )
+    print(
+        f"ha_telegram_event status=classified event={decision.kind or 'none'} "
+        f"snapshot={current.get('status', 'unknown')}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ha/patroni_notification_snapshot.py
+++ b/scripts/ha/patroni_notification_snapshot.py
@@ -1,0 +1,117 @@
+"""Build secret-free owner-notification snapshots from a proven Patroni check."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+
+ClusterLoader = Callable[[Any, Any, str], Mapping[str, Any]]
+ReadyLoader = Callable[[Any, Any, str], tuple[int, Mapping[str, Any]]]
+
+
+def build_notification_snapshot(
+    config: Any,
+    runner: Any,
+    report: Any,
+    primary: Any,
+    standby: Any,
+    *,
+    cluster_loader: ClusterLoader,
+    ready_loader: ReadyLoader,
+) -> dict[str, object]:
+    cluster = cluster_loader(runner, primary, "cluster")
+    members = cluster.get("members")
+    if not isinstance(members, list):
+        raise RuntimeError("Patroni /cluster has no member list")
+    replica = next(
+        (
+            item
+            for item in members
+            if isinstance(item, Mapping) and item.get("name") == standby.patroni_name
+        ),
+        None,
+    )
+    if not isinstance(replica, Mapping):
+        raise RuntimeError("Patroni /cluster has no standby member")
+    lag_raw = replica.get("lag", 0)
+    if type(lag_raw) is not int:
+        raise RuntimeError("Patroni /cluster lag is not an integer")
+
+    primary_code, primary_body = ready_loader(runner, primary, config.ready_url)
+    standby_code, standby_body = ready_loader(runner, standby, config.ready_url)
+    primary_ready = (
+        primary_code == 200
+        and primary_body.get("api") == "ready"
+        and primary_body.get("traffic") == "enabled"
+    )
+    standby_fenced = (
+        standby_code == 503
+        and standby_body.get("api") == "not_ready"
+        and standby_body.get("traffic") == "disabled"
+    )
+
+    if not primary_ready:
+        status = "critical"
+    elif report.failures:
+        status = "degraded"
+    else:
+        status = "healthy"
+    return {
+        "status": status,
+        "observed_at": datetime.now(timezone.utc).isoformat(),
+        "primary": primary.patroni_name,
+        "standby": standby.patroni_name,
+        "timeline": next(
+            (
+                item.get("timeline")
+                for item in members
+                if isinstance(item, Mapping) and item.get("name") == primary.patroni_name
+            ),
+            None,
+        ),
+        "lag_bytes": lag_raw,
+        "primary_ready": primary_ready,
+        "standby_fenced": standby_fenced,
+        "replication_state": str(replica.get("state") or ""),
+        "sync_state": str(replica.get("role") or ""),
+        "failures": list(report.failures),
+        "detail": "",
+    }
+
+
+def failure_snapshot(error: Exception) -> dict[str, object]:
+    detail = str(error).strip().replace("\n", " ")[:500]
+    unsafe_topology = any(
+        marker in detail.lower()
+        for marker in (
+            "unsafe patroni topology",
+            "failsafe mode is active",
+            "pending_restart",
+        )
+    )
+    return {
+        "status": "critical" if unsafe_topology else "monitoring_error",
+        "observed_at": datetime.now(timezone.utc).isoformat(),
+        "primary": "",
+        "standby": "",
+        "timeline": None,
+        "lag_bytes": None,
+        "primary_ready": None,
+        "standby_fenced": None,
+        "replication_state": "",
+        "sync_state": "",
+        "failures": [detail] if unsafe_topology else [],
+        "detail": detail,
+    }
+
+
+def write_snapshot(path: Path | None, snapshot: Mapping[str, object]) -> None:
+    if path is None:
+        return
+    path.write_text(
+        json.dumps(snapshot, ensure_ascii=False, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )

--- a/scripts/ha/patroni_production_command.py
+++ b/scripts/ha/patroni_production_command.py
@@ -1,0 +1,117 @@
+"""CLI orchestration for the production Patroni checker."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Sequence
+
+try:
+    from scripts.ha import check_patroni_production as checks
+    from scripts.ha.patroni_notification_snapshot import (
+        build_notification_snapshot,
+        failure_snapshot,
+        write_snapshot,
+    )
+except ModuleNotFoundError:
+    import check_patroni_production as checks  # type: ignore[no-redef]
+    from patroni_notification_snapshot import (  # type: ignore[no-redef]
+        build_notification_snapshot,
+        failure_snapshot,
+        write_snapshot,
+    )
+
+
+def perform_checks_with_topology(
+    config: checks.CheckerConfig, runner: checks.SshRunner
+) -> tuple[checks.Report, checks.NodeConfig, checks.NodeConfig]:
+    report = checks.Report()
+    payloads = checks.probe_nodes(config, runner)
+    primary, standby = checks.select_primary(config.nodes, payloads)
+    report.pass_check(
+        f"exactly one Patroni primary: {primary.label} ({primary.patroni_name})"
+    )
+
+    checks._check_cluster_views(config, runner, primary, standby, report)
+    checks._check_postgres(config, runner, primary, standby, report)
+    checks._check_runtime(config, runner, primary, standby, report)
+
+    etcd = runner.run(config.api, config.etcd_check_command, check=False)
+    if etcd.returncode == 0 and "etcd_quorum_status=passed members=3" in etcd.stdout:
+        report.pass_check("etcd quorum has three healthy members")
+    else:
+        detail = (etcd.stderr or etcd.stdout or "check failed").strip().replace("\n", " ")
+        report.fail(f"etcd quorum check failed: {detail}")
+    return report, primary, standby
+
+
+def perform_checks(
+    config: checks.CheckerConfig, runner: checks.SshRunner
+) -> checks.Report:
+    report, _, _ = perform_checks_with_topology(config, runner)
+    return report
+
+
+def _print_report(report: checks.Report) -> None:
+    for message in report.ok:
+        print(f"[patroni-production][ok] {message}")
+    for message in report.failures:
+        print(f"[patroni-production][fail] {message}")
+    status = "failed" if report.failures else "passed"
+    print(
+        f"[patroni-production][summary] status={status} "
+        f"ok={len(report.ok)} failures={len(report.failures)}"
+    )
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=checks.__doc__)
+    parser.add_argument(
+        "--resolve-primary",
+        action="store_true",
+        help="Print only api or reserve after validating the two Patroni roles.",
+    )
+    parser.add_argument(
+        "--snapshot-output",
+        type=Path,
+        help="Write a secret-free JSON observation for owner-facing HA notifications.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    try:
+        config = checks.load_config()
+        runner = checks.SshRunner(config.ssh_options)
+        if args.resolve_primary:
+            primary, _ = checks.select_primary(
+                config.nodes, checks.probe_nodes(config, runner)
+            )
+            print(primary.label)
+            return 0
+        report, primary, standby = perform_checks_with_topology(config, runner)
+        write_snapshot(
+            args.snapshot_output,
+            build_notification_snapshot(
+                config,
+                runner,
+                report,
+                primary,
+                standby,
+                cluster_loader=checks._json_remote,
+                ready_loader=checks._ready_response,
+            ),
+        )
+    except (RuntimeError, ValueError) as exc:
+        write_snapshot(args.snapshot_output, failure_snapshot(exc))
+        if args.resolve_primary:
+            print(f"could not resolve Patroni primary: {exc}", file=sys.stderr)
+        else:
+            print(f"[patroni-production][fail] {exc}")
+            print("[patroni-production][summary] status=failed ok=0 failures=1")
+        return 2
+
+    _print_report(report)
+    return 1 if report.failures else 0

--- a/tests/unit/test_ha_alert_workflows.py
+++ b/tests/unit/test_ha_alert_workflows.py
@@ -17,9 +17,7 @@ ALERTED_WORKFLOWS = [
     (".github/workflows/check-cloudflare-lb-config.yml", "check"),
     (".github/workflows/check-media-cdn.yml", "check"),
     (".github/workflows/check-postgres-pitr.yml", "check"),
-    (".github/workflows/check-postgres-replication.yml", "check"),
     (".github/workflows/postgres-pitr-restore-drill.yml", "pitr-restore-drill"),
-    (".github/workflows/report-ha-status.yml", "report"),
 ]
 
 
@@ -41,6 +39,8 @@ def test_notify_ha_failure_action_skips_when_telegram_secrets_are_absent():
     assert "https://api.telegram.org/bot${BOT_TOKEN}/sendMessage" in run
     assert "GITHUB_RUN_ID" in run
     assert "disable_web_page_preview" in run
+    assert "message_file" in run
+    assert "Технические подробности" in run
 
 
 def test_ha_monitor_workflows_notify_on_failure_after_artifact_upload():
@@ -69,7 +69,34 @@ def test_ha_monitor_workflows_notify_on_failure_after_artifact_upload():
         assert "HA_ALERT_TELEGRAM_BOT_TOKEN" in notify_step["with"]["bot-token"]
         assert "HA_ALERT_TELEGRAM_CHAT_ID" in notify_step["with"]["chat-id"]
         assert "HA_ALERT_TELEGRAM_THREAD_ID" in notify_step["with"]["thread-id"]
-        assert "Artifact:" in notify_step["with"]["details"]
+        assert notify_step["with"]["title"][0] in {"🟡", "🟠", "🔴"}
+        assert len(notify_step["with"]["details"]) >= 40
+
+
+def test_replication_workflow_sends_stateful_owner_events_without_rollup_duplicates():
+    replication = _yaml(REPO_ROOT / ".github/workflows/check-postgres-replication.yml")
+    steps = replication["jobs"]["check"]["steps"]
+    classify = _step(replication, "check", "Classify owner-facing HA event")
+    notify = _step(replication, "check", "Notify owner about HA event")
+
+    assert replication["concurrency"] == {
+        "group": "postgres-replication-monitor",
+        "cancel-in-progress": "false",
+    }
+    assert replication["jobs"]["check"]["permissions"]["actions"] == "read"
+    assert "--snapshot-output postgres-ha-snapshot.json" in _step(
+        replication, "check", "Run PostgreSQL replication check"
+    )["run"]
+    assert "ha_telegram_events.py" in classify["run"]
+    assert steps.index(notify) > steps.index(
+        _step(replication, "check", "Upload HA notification state")
+    )
+    assert "steps.ha-event.outputs.notify == 'true'" in notify["if"]
+    assert notify["with"]["message-file"] == "ha-owner-message.txt"
+
+    report = _yaml(REPO_ROOT / ".github/workflows/report-ha-status.yml")
+    report_steps = report["jobs"]["report"]["steps"]
+    assert all(step.get("name") != "Notify HA failure" for step in report_steps)
 
 
 def test_restore_drill_checks_out_repo_before_local_alert_action():

--- a/tests/unit/test_ha_telegram_events.py
+++ b/tests/unit/test_ha_telegram_events.py
@@ -1,0 +1,175 @@
+import json
+
+from scripts.ha.ha_telegram_events import decide, main
+
+
+def _snapshot(
+    status: str = "healthy",
+    *,
+    primary: str = "mvn-api",
+    standby: str = "zakup",
+    lag_bytes: int | None = 0,
+    failures: list[str] | None = None,
+    detail: str = "",
+):
+    return {
+        "status": status,
+        "observed_at": "2026-08-14T00:00:00+00:00",
+        "primary": primary,
+        "standby": standby,
+        "timeline": 20,
+        "lag_bytes": lag_bytes,
+        "primary_ready": status != "critical",
+        "standby_fenced": True,
+        "replication_state": "streaming",
+        "sync_state": "sync_standby",
+        "failures": failures or [],
+        "detail": detail,
+    }
+
+
+def _baseline(snapshot=None):
+    first = decide(None, snapshot or _snapshot())
+    assert first.kind is None
+    return first.state
+
+
+def test_primary_change_is_immediate_and_names_both_locations():
+    previous = _baseline()
+
+    decision = decide(
+        previous,
+        _snapshot(primary="zakup", standby="mvn-api"),
+    )
+
+    assert decision.kind == "primary_changed"
+    assert "Было: 🇳🇱 Нидерланды — mvn-api" in decision.message
+    assert "Стало: 🇧🇾 Беларусь — zakup" in decision.message
+    assert "Причина переключения пока не подтверждена" in decision.message
+    assert "отставание WAL 0 байт" in decision.message
+
+
+def test_degraded_and_recovered_events_are_deduplicated():
+    previous = _baseline()
+    degraded = _snapshot(
+        "degraded",
+        failures=["reserve: Patroni /sync endpoint is not healthy"],
+    )
+
+    opened = decide(previous, degraded)
+    repeated = decide(opened.state, degraded)
+    recovered = decide(repeated.state, _snapshot())
+
+    assert opened.kind == "degraded"
+    assert "без полноценного резерва" in opened.message
+    assert repeated.kind is None
+    assert recovered.kind == "recovered"
+    assert "Резервирование PostgreSQL восстановлено" in recovered.message
+
+
+def test_first_confirmed_problem_is_not_silenced_without_previous_state():
+    degraded = decide(
+        None,
+        _snapshot(
+            "degraded",
+            failures=["reserve: Patroni /sync endpoint is not healthy"],
+        ),
+    )
+    critical = decide(
+        None,
+        _snapshot(
+            "critical",
+            primary="",
+            standby="",
+            lag_bytes=None,
+            failures=["unsafe Patroni topology: primary count=2 standby count=0"],
+        ),
+    )
+
+    assert degraded.kind == "degraded"
+    assert "синхронная реплика" in degraded.message
+    assert "/sync endpoint" not in degraded.message
+    assert critical.kind == "critical"
+    assert "единственный безопасный primary" in critical.message
+    assert "primary count=" not in critical.message
+
+
+def test_monitoring_error_alerts_only_after_two_failures_then_recovers():
+    previous = _baseline()
+    unavailable = _snapshot(
+        "monitoring_error",
+        primary="",
+        standby="",
+        lag_bytes=None,
+        detail="reserve: Connection closed by host port 22",
+    )
+
+    first = decide(previous, unavailable)
+    second = decide(first.state, unavailable)
+    repeated = decide(second.state, unavailable)
+    recovered = decide(repeated.state, _snapshot())
+
+    assert first.kind is None
+    assert second.kind == "monitoring_error"
+    assert "Это не означает, что PostgreSQL остановлен" in second.message
+    assert "Primary: 🇳🇱 Нидерланды — mvn-api" in second.message
+    assert "нет ответа от 🇧🇾 Беларусь — zakup" in second.message
+    assert "Connection closed" not in second.message
+    assert repeated.kind is None
+    assert recovered.kind == "monitoring_recovered"
+    assert "ошибка была связана с проверкой соединения" in recovered.message
+
+
+def test_critical_topology_alert_is_immediate():
+    previous = _baseline()
+
+    decision = decide(
+        previous,
+        _snapshot(
+            "critical",
+            primary="",
+            standby="",
+            lag_bytes=None,
+            failures=["unsafe Patroni topology: primary count=2 standby count=0"],
+        ),
+    )
+
+    assert decision.kind == "critical"
+    assert "Критическая проблема PostgreSQL HA" in decision.message
+    assert "Автоматически роли не меняйте" in decision.message
+
+
+def test_cli_uses_connection_log_as_monitoring_fallback(tmp_path):
+    previous_path = tmp_path / "previous.json"
+    previous_path.write_text(json.dumps(_baseline()), encoding="utf-8")
+    log_path = tmp_path / "check.log"
+    log_path.write_text(
+        "[patroni-maintenance][error] reserve: Connection closed by host port 22\n",
+        encoding="utf-8",
+    )
+    state_path = tmp_path / "state.json"
+    message_path = tmp_path / "message.txt"
+    output_path = tmp_path / "github-output.txt"
+
+    assert (
+        main(
+            [
+                "--snapshot",
+                str(tmp_path / "missing-snapshot.json"),
+                "--previous-state",
+                str(previous_path),
+                "--fallback-log",
+                str(log_path),
+                "--state-output",
+                str(state_path),
+                "--message-output",
+                str(message_path),
+                "--github-output",
+                str(output_path),
+            ]
+        )
+        == 0
+    )
+    assert json.loads(state_path.read_text())["monitoring_error_streak"] == 1
+    assert message_path.read_text() == ""
+    assert "notify=false" in output_path.read_text()

--- a/tests/unit/test_patroni_notification_snapshot.py
+++ b/tests/unit/test_patroni_notification_snapshot.py
@@ -1,0 +1,76 @@
+from types import SimpleNamespace
+
+from scripts.ha.patroni_notification_snapshot import (
+    build_notification_snapshot,
+    failure_snapshot,
+)
+
+
+def _build(*, failures=None, primary_code=200, lag=0):
+    config = SimpleNamespace(ready_url="http://127.0.0.1:18080/api/ready")
+    report = SimpleNamespace(failures=failures or [])
+    primary = SimpleNamespace(patroni_name="zakup")
+    standby = SimpleNamespace(patroni_name="mvn-api")
+
+    def cluster_loader(_runner, _node, _path):
+        return {
+            "members": [
+                {
+                    "name": "zakup",
+                    "role": "leader",
+                    "state": "running",
+                    "timeline": 20,
+                },
+                {
+                    "name": "mvn-api",
+                    "role": "sync_standby",
+                    "state": "streaming",
+                    "timeline": 20,
+                    "lag": lag,
+                },
+            ]
+        }
+
+    def ready_loader(_runner, node, _url):
+        if node is primary:
+            return primary_code, {
+                "api": "ready" if primary_code == 200 else "not_ready",
+                "traffic": "enabled" if primary_code == 200 else "disabled",
+            }
+        return 503, {"api": "not_ready", "traffic": "disabled"}
+
+    return build_notification_snapshot(
+        config,
+        object(),
+        report,
+        primary,
+        standby,
+        cluster_loader=cluster_loader,
+        ready_loader=ready_loader,
+    )
+
+
+def test_snapshot_distinguishes_healthy_degraded_and_critical():
+    healthy = _build()
+    degraded = _build(failures=["replay lag exceeds limit"], lag=2_000_000)
+    critical = _build(primary_code=503)
+
+    assert healthy["status"] == "healthy"
+    assert healthy["lag_bytes"] == 0
+    assert healthy["standby_fenced"] is True
+    assert degraded["status"] == "degraded"
+    assert degraded["lag_bytes"] == 2_000_000
+    assert critical["status"] == "critical"
+    assert critical["primary_ready"] is False
+
+
+def test_failure_snapshot_does_not_call_transport_failure_a_database_outage():
+    transport = failure_snapshot(RuntimeError("reserve: Connection closed by host port 22"))
+    split_brain = failure_snapshot(
+        ValueError("unsafe Patroni topology: primary count=2 standby count=0")
+    )
+
+    assert transport["status"] == "monitoring_error"
+    assert transport["failures"] == []
+    assert split_brain["status"] == "critical"
+    assert split_brain["failures"]


### PR DESCRIPTION
## Что меняется

- PostgreSQL replication check хранит безопасный снимок состояния и сообщает именно о переходах: смена primary, потеря резерва, критическая топология, восстановление
- сообщения называют Нидерланды и Беларусь, показывают «было → стало», состояние API и отставание WAL
- одиночная ошибка SSH остаётся в диагностике; уведомление приходит только после двух ошибок мониторинга подряд
- одинаковые состояния дедуплицируются, а сводный HA Status Report больше не присылает повторную общую ошибку
- остальные HA-уведомления получили понятные русские заголовки

## Проверки

- 43 focused HA unit tests
- Python syntax compilation
- actionlint for changed workflows
- YAML parsing for all workflows and composite action
- live read-only Patroni check: primary `zakup`, standby `mvn-api`, synchronous streaming, WAL lag 0, three healthy etcd members

## Локальное ограничение

Полный unit-набор запускался: 3001 тест прошёл, 4 пропущено, 87 setup errors возникли только потому, что локальный Docker Desktop не отдаёт тестовую PostgreSQL на `127.0.0.1:5433`. GitHub CI поднимет отдельную PostgreSQL и выполнит полный прогон.
