### PR TITLE
Use ephemeral package token for Patroni deployments

### DIFF
--- a/.github/workflows/deploy-api-patroni.yml
+++ b/.github/workflows/deploy-api-patroni.yml
@@ -188,7 +188,7 @@ jobs:
           API_NODE_COMPOSE_SOURCE: deploy/ha/mvn-api/docker-compose.patroni.yml
           API_NODE_PROXY_MODE: host_nginx
           SSH_PRIVATE_KEY: ${{ secrets.SSH_KEY }}
-          GHCR_PAT: ${{ secrets.GHCR_PAT }}
+          GHCR_PAT: ${{ github.token }}
           BOT_VOICE_TRANSCRIPTION_API_KEY: ${{ secrets.BOT_VOICE_TRANSCRIPTION_API_KEY }}
           BACKEND_IMAGE: ${{ needs.build-backend.outputs.backend_image }}
         run: bash scripts/ha/run_patroni_node_remote.sh migrate
@@ -218,7 +218,7 @@ jobs:
           API_NODE_COMPOSE_SOURCE: deploy/ha/zakup/docker-compose.patroni.yml
           API_NODE_PROXY_MODE: container_nginx
           SSH_PRIVATE_KEY: ${{ secrets.SSH_KEY }}
-          GHCR_PAT: ${{ secrets.GHCR_PAT }}
+          GHCR_PAT: ${{ github.token }}
           BOT_VOICE_TRANSCRIPTION_API_KEY: ${{ secrets.BOT_VOICE_TRANSCRIPTION_API_KEY }}
           BACKEND_IMAGE: ${{ needs.build-backend.outputs.backend_image }}
         run: bash scripts/ha/run_patroni_node_remote.sh migrate
@@ -249,7 +249,7 @@ jobs:
           API_NODE_PROXY_MODE: container_nginx
           API_EXPECTED_PATRONI_ROLE: standby
           SSH_PRIVATE_KEY: ${{ secrets.SSH_KEY }}
-          GHCR_PAT: ${{ secrets.GHCR_PAT }}
+          GHCR_PAT: ${{ github.token }}
           BOT_VOICE_TRANSCRIPTION_API_KEY: ${{ secrets.BOT_VOICE_TRANSCRIPTION_API_KEY }}
           BACKEND_IMAGE: ${{ needs.build-backend.outputs.backend_image }}
         run: bash scripts/ha/run_patroni_node_remote.sh deploy && bash scripts/ha/run_patroni_node_remote.sh verify
@@ -280,7 +280,7 @@ jobs:
           API_NODE_PROXY_MODE: host_nginx
           API_EXPECTED_PATRONI_ROLE: standby
           SSH_PRIVATE_KEY: ${{ secrets.SSH_KEY }}
-          GHCR_PAT: ${{ secrets.GHCR_PAT }}
+          GHCR_PAT: ${{ github.token }}
           BOT_VOICE_TRANSCRIPTION_API_KEY: ${{ secrets.BOT_VOICE_TRANSCRIPTION_API_KEY }}
           BACKEND_IMAGE: ${{ needs.build-backend.outputs.backend_image }}
         run: bash scripts/ha/run_patroni_node_remote.sh deploy && bash scripts/ha/run_patroni_node_remote.sh verify
@@ -312,7 +312,7 @@ jobs:
           API_NODE_PROXY_MODE: host_nginx
           API_EXPECTED_PATRONI_ROLE: primary
           SSH_PRIVATE_KEY: ${{ secrets.SSH_KEY }}
-          GHCR_PAT: ${{ secrets.GHCR_PAT }}
+          GHCR_PAT: ${{ github.token }}
           BOT_VOICE_TRANSCRIPTION_API_KEY: ${{ secrets.BOT_VOICE_TRANSCRIPTION_API_KEY }}
           BACKEND_IMAGE: ${{ needs.build-backend.outputs.backend_image }}
         run: bash scripts/ha/run_patroni_node_remote.sh deploy && bash scripts/ha/run_patroni_node_remote.sh verify
@@ -344,7 +344,7 @@ jobs:
           API_NODE_PROXY_MODE: container_nginx
           API_EXPECTED_PATRONI_ROLE: primary
           SSH_PRIVATE_KEY: ${{ secrets.SSH_KEY }}
-          GHCR_PAT: ${{ secrets.GHCR_PAT }}
+          GHCR_PAT: ${{ github.token }}
           BOT_VOICE_TRANSCRIPTION_API_KEY: ${{ secrets.BOT_VOICE_TRANSCRIPTION_API_KEY }}
           BACKEND_IMAGE: ${{ needs.build-backend.outputs.backend_image }}
         run: bash scripts/ha/run_patroni_node_remote.sh deploy && bash scripts/ha/run_patroni_node_remote.sh verify

--- a/tests/unit/test_patroni_deploy_workflow.py
+++ b/tests/unit/test_patroni_deploy_workflow.py
@@ -69,11 +69,13 @@ def test_patroni_release_orders_migration_replica_then_primary():
         run = jobs[job_name]["steps"][-1]["run"]
         assert "scripts/ha/run_patroni_node_remote.sh" in run
         env = jobs[job_name]["steps"][-1]["env"]
+        assert env["GHCR_PAT"] == "${{ github.token }}"
         assert env["BOT_VOICE_TRANSCRIPTION_API_KEY"] == (
             "${{ secrets.BOT_VOICE_TRANSCRIPTION_API_KEY }}"
         )
 
     text = (REPO_ROOT / ".github/workflows/deploy-api-patroni.yml").read_text(encoding="utf-8")
+    assert "secrets.GHCR_PAT" not in text
     assert "up -d db" not in text
     assert "docker compose" not in text
 


### PR DESCRIPTION
## Причина

Два production rollout подряд безопасно остановились до миграций: постоянный `GHCR_PAT` больше не проходит вход в GHCR (`denied`). Кандидат каждый раз был очищен, приложение и PostgreSQL не изменялись.

## Исправление

- все Patroni migration/deploy jobs используют короткоживущий `${{ github.token }}`
- права job остаются `packages: read`; токен существует только во время конкретного job
- удаляется зависимость production deployment от вручную обновляемого постоянного package token

## Проверки

- 48 focused Patroni deploy/remote/communications tests
- actionlint для reusable Patroni deployment и production workflow
- regression assertion запрещает возврат `secrets.GHCR_PAT` в этот workflow
